### PR TITLE
Feats and fixes on rancher2_cluster resource and docs

### DIFF
--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -140,11 +140,15 @@ func resourceRancher2ClusterUpdate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
+	enableNetworkPolicy := d.Get("enable_network_policy").(bool)
 	update := map[string]interface{}{
-		"name":        d.Get("name").(string),
-		"description": d.Get("description").(string),
-		"annotations": toMapString(d.Get("annotations").(map[string]interface{})),
-		"labels":      toMapString(d.Get("labels").(map[string]interface{})),
+		"name":                               d.Get("name").(string),
+		"description":                        d.Get("description").(string),
+		"defaultPodSecurityPolicyTemplateId": d.Get("default_pod_security_policy_template_id").(string),
+		"enableNetworkPolicy":                &enableNetworkPolicy,
+		"localClusterAuthEndpoint":           expandClusterAuthEndpoint(d.Get("cluster_auth_endpoint").([]interface{})),
+		"annotations":                        toMapString(d.Get("annotations").(map[string]interface{})),
+		"labels":                             toMapString(d.Get("labels").(map[string]interface{})),
 	}
 
 	switch driver := d.Get("driver").(string); driver {

--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -12,7 +12,8 @@ const (
 )
 
 var (
-	clusterDrivers = []string{clusterDriverImported, clusterDriverAKS, clusterDriverEKS, clusterDriverGKE, clusterDriverRKE}
+	clusterDrivers           = []string{clusterDriverImported, clusterDriverAKS, clusterDriverEKS, clusterDriverGKE, clusterDriverRKE}
+	clusterPodSecurityPolicy = []string{"restricted", "unrestricted"}
 )
 
 //Types
@@ -69,6 +70,26 @@ func clusterRegistationTokenFields() map[string]*schema.Schema {
 			Type:     schema.TypeMap,
 			Optional: true,
 			Computed: true,
+		},
+	}
+
+	return s
+}
+
+func clusterAuthEndpoint() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"ca_certs": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"enabled": &schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+		"fqdn": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 	}
 
@@ -139,6 +160,15 @@ func clusterFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"cluster_auth_endpoint": &schema.Schema{
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: clusterAuthEndpoint(),
+			},
+		},
 		"cluster_registration_token": &schema.Schema{
 			Type:     schema.TypeList,
 			MaxItems: 1,
@@ -146,6 +176,19 @@ func clusterFields() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: clusterRegistationTokenFields(),
 			},
+		},
+		"default_pod_security_policy_template_id": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.StringInSlice(clusterPodSecurityPolicy, true),
+			Description:  "Default pod security policy template id",
+		},
+		"enable_network_policy": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Enable project network isolation",
 		},
 		"annotations": &schema.Schema{
 			Type:     schema.TypeMap,

--- a/rancher2/schema_cluster_rke_config.go
+++ b/rancher2/schema_cluster_rke_config.go
@@ -83,7 +83,7 @@ func clusterRKEConfigFields() map[string]*schema.Schema {
 		"ignore_docker_version": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Computed:    true,
+			Default:     true,
 			Description: "Optional ignore docker version on nodes",
 		},
 		"ingress": {

--- a/rancher2/schema_cluster_rke_config_services.go
+++ b/rancher2/schema_cluster_rke_config_services.go
@@ -155,7 +155,7 @@ func clusterRKEConfigServicesKubeAPIFields() map[string]*schema.Schema {
 		"pod_security_policy": {
 			Type:     schema.TypeBool,
 			Optional: true,
-			Computed: true,
+			Default:  false,
 		},
 		"service_cluster_ip_range": {
 			Type:     schema.TypeString,

--- a/rancher2/structure_cluster_test.go
+++ b/rancher2/structure_cluster_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 var (
+	testLocalClusterAuthEndpointConf      *managementClient.LocalClusterAuthEndpoint
+	testLocalClusterAuthEndpointInterface []interface{}
 	testClusterRegistrationTokenConf      *managementClient.ClusterRegistrationToken
 	testClusterRegistrationToken2Conf     *managementClient.ClusterRegistrationToken
 	testClusterRegistrationTokenInterface []interface{}
@@ -24,6 +26,18 @@ var (
 )
 
 func init() {
+	testLocalClusterAuthEndpointConf = &managementClient.LocalClusterAuthEndpoint{
+		CACerts: "cacerts",
+		Enabled: true,
+		FQDN:    "fqdn",
+	}
+	testLocalClusterAuthEndpointInterface = []interface{}{
+		map[string]interface{}{
+			"ca_certs": "cacerts",
+			"enabled":  true,
+			"fqdn":     "fqdn",
+		},
+	}
 	testClusterRegistrationTokenConf = &managementClient.ClusterRegistrationToken{
 		ClusterID:          "cluster_test",
 		Name:               clusterRegistrationTokenName,
@@ -82,16 +96,22 @@ func init() {
 	testClusterConfAKS.Name = "test"
 	testClusterConfAKS.Description = "description"
 	testClusterConfAKS.Driver = clusterDriverAKS
+	testClusterConfAKS.DefaultPodSecurityPolicyTemplateID = "restricted"
+	testClusterConfAKS.EnableNetworkPolicy = newTrue()
+	testClusterConfAKS.LocalClusterAuthEndpoint = testLocalClusterAuthEndpointConf
 	testClusterInterfaceAKS = map[string]interface{}{
 		"id":                         "id",
 		"name":                       "test",
 		"default_project_id":         "default_project_id",
 		"description":                "description",
+		"cluster_auth_endpoint":      testLocalClusterAuthEndpointInterface,
 		"cluster_registration_token": testClusterRegistrationTokenInterface,
-		"kube_config":                "kube_config",
-		"driver":                     clusterDriverAKS,
-		"aks_config":                 testClusterAKSConfigInterface,
-		"system_project_id":          "system_project_id",
+		"default_pod_security_policy_template_id": "restricted",
+		"enable_network_policy":                   true,
+		"kube_config":                             "kube_config",
+		"driver":                                  clusterDriverAKS,
+		"aks_config":                              testClusterAKSConfigInterface,
+		"system_project_id":                       "system_project_id",
 	}
 	testClusterConfEKS = &Cluster{
 		AmazonElasticContainerServiceConfig: testClusterEKSConfigConf,
@@ -99,16 +119,22 @@ func init() {
 	testClusterConfEKS.Name = "test"
 	testClusterConfEKS.Description = "description"
 	testClusterConfEKS.Driver = clusterDriverEKS
+	testClusterConfEKS.DefaultPodSecurityPolicyTemplateID = "restricted"
+	testClusterConfEKS.EnableNetworkPolicy = newTrue()
+	testClusterConfEKS.LocalClusterAuthEndpoint = testLocalClusterAuthEndpointConf
 	testClusterInterfaceEKS = map[string]interface{}{
 		"id":                         "id",
 		"name":                       "test",
 		"default_project_id":         "default_project_id",
 		"description":                "description",
+		"cluster_auth_endpoint":      testLocalClusterAuthEndpointInterface,
 		"cluster_registration_token": testClusterRegistrationTokenInterface,
-		"kube_config":                "kube_config",
-		"driver":                     clusterDriverEKS,
-		"eks_config":                 testClusterEKSConfigInterface,
-		"system_project_id":          "system_project_id",
+		"default_pod_security_policy_template_id": "restricted",
+		"enable_network_policy":                   true,
+		"kube_config":                             "kube_config",
+		"driver":                                  clusterDriverEKS,
+		"eks_config":                              testClusterEKSConfigInterface,
+		"system_project_id":                       "system_project_id",
 	}
 	testClusterConfGKE = &Cluster{
 		GoogleKubernetesEngineConfig: testClusterGKEConfigConf,
@@ -116,32 +142,44 @@ func init() {
 	testClusterConfGKE.Name = "test"
 	testClusterConfGKE.Description = "description"
 	testClusterConfGKE.Driver = clusterDriverGKE
+	testClusterConfGKE.DefaultPodSecurityPolicyTemplateID = "restricted"
+	testClusterConfGKE.EnableNetworkPolicy = newTrue()
+	testClusterConfGKE.LocalClusterAuthEndpoint = testLocalClusterAuthEndpointConf
 	testClusterInterfaceGKE = map[string]interface{}{
 		"id":                         "id",
 		"name":                       "test",
 		"default_project_id":         "default_project_id",
 		"description":                "description",
+		"cluster_auth_endpoint":      testLocalClusterAuthEndpointInterface,
 		"cluster_registration_token": testClusterRegistrationTokenInterface,
-		"kube_config":                "kube_config",
-		"driver":                     clusterDriverGKE,
-		"gke_config":                 testClusterGKEConfigInterface,
-		"system_project_id":          "system_project_id",
+		"default_pod_security_policy_template_id": "restricted",
+		"enable_network_policy":                   true,
+		"kube_config":                             "kube_config",
+		"driver":                                  clusterDriverGKE,
+		"gke_config":                              testClusterGKEConfigInterface,
+		"system_project_id":                       "system_project_id",
 	}
 	testClusterConfRKE = &Cluster{}
 	testClusterConfRKE.Name = "test"
 	testClusterConfRKE.Description = "description"
 	testClusterConfRKE.RancherKubernetesEngineConfig = testClusterRKEConfigConf
 	testClusterConfRKE.Driver = clusterDriverRKE
+	testClusterConfRKE.DefaultPodSecurityPolicyTemplateID = "restricted"
+	testClusterConfRKE.EnableNetworkPolicy = newTrue()
+	testClusterConfRKE.LocalClusterAuthEndpoint = testLocalClusterAuthEndpointConf
 	testClusterInterfaceRKE = map[string]interface{}{
 		"id":                         "id",
 		"name":                       "test",
 		"default_project_id":         "default_project_id",
 		"description":                "description",
+		"cluster_auth_endpoint":      testLocalClusterAuthEndpointInterface,
 		"cluster_registration_token": testClusterRegistrationTokenInterface,
-		"kube_config":                "kube_config",
-		"driver":                     clusterDriverRKE,
-		"rke_config":                 testClusterRKEConfigInterface,
-		"system_project_id":          "system_project_id",
+		"default_pod_security_policy_template_id": "restricted",
+		"enable_network_policy":                   true,
+		"kube_config":                             "kube_config",
+		"driver":                                  clusterDriverRKE,
+		"rke_config":                              testClusterRKEConfigInterface,
+		"system_project_id":                       "system_project_id",
 	}
 }
 

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -88,6 +88,9 @@ The following arguments are supported:
 * `eks_config` - (Optional) The Amazon eks configuration for `eks` Clusters. Conflicts with `aks_config`, `gke_config` and `rke_config` (list maxitems:1)
 * `gke_config` - (Optional) The Google gke configuration for `gke` Clusters. Conflicts with `aks_config`, `eks_config` and `rke_config` (list maxitems:1)
 * `description` - (Optional) The description for Cluster (string)
+* `cluster_auth_endpoint` - (Optional/Computed) Enabling the [local cluster authorized endpoint](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#local-cluster-auth-endpoint) allows direct communication with the cluster, bypassing the Rancher API proxy. (list maxitems:1)
+* `default_pod_security_policy_template_id` - (Optional/Computed) [Default pod security policy template id](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#pod-security-policy-support). `restricted` and `unrestricted` are supported (string)
+* `enable_network_policy` - (Optional) Enable project network isolation. Default `false` (bool)
 * `annotations` - (Optional/Computed) Annotations for Node Pool object (map)
 * `labels` - (Optional/Computed) Labels for Node Pool object (map)
 
@@ -116,7 +119,7 @@ The following attributes are exported:
 * `bastion_host` - (Optional/Computed) RKE bastion host (list maxitems:1)
 * `cloud_provider` - (Optional/Computed) RKE cloud provider [rke-cloud-providers](https://rancher.com/docs/rke/v0.1.x/en/config-options/cloud-providers/) (list maxitems:1)
 * `dns` - (Optional/Computed) RKE dns add-on. Just for rancher v2.2.x (list maxitems:1)
-* `ignore_docker_version` - (Optional/Computed) Ignore docker version (bool)
+* `ignore_docker_version` - (Optional) Ignore docker version. Default `true` (bool)
 * `ingress` - (Optional/Computed) Kubernetes ingress configuration (list maxitems:1)
 * `kubernetes_version` - (Optional/Computed) Kubernetes version to deploy (string)
 * `monitoring` - (Optional/Computed) Kubernetes cluster monitoring (list maxitems:1)
@@ -488,7 +491,7 @@ The following attributes are exported:
 * `extra_binds` - (Optional) Extra binds for kube API service (list)
 * `extra_env` - (Optional) Extra environment for kube API service (list)
 * `image` - (Optional/Computed) Docker image for kube API service (string)
-* `pod_security_policy` - (Optional/Computed) Pod Security Policy option for kube API service (bool)
+* `pod_security_policy` - (Optional) Pod Security Policy option for kube API service. Default `false` (bool)
 * `service_cluster_ip_range` - (Optional/Computed) Service Cluster IP Range option for kube API service (string)
 * `service_node_port_range` - (Optional/Computed) Service Node Port Range option for kube API service (string)
 
@@ -649,6 +652,14 @@ The following arguments are supported:
 * `use_ip_aliases` - (Optional) Whether alias IPs will be used for pod IPs in the cluster. Default `false` (bool)
 * `taints` - (Required) List of kubernetes taints to be applied to each node (list)
 * `zone` - (Required) Zone GKE cluster (string)
+
+### `cluster_auth_endpoint`
+
+#### Arguments
+
+* `ca_certs` - (Optional) CA certs for the authorized cluster endpoint (string)
+* `enabled` - (Optional) Enable the authorized cluster endpoint. Default `true` (bool)
+* `fqdn` - (Optional) FQDN for the authorized cluster endpoint (string)
 
 ### `cluster_registration_token`
 

--- a/website/docs/r/nodeTemplate.html.markdown
+++ b/website/docs/r/nodeTemplate.html.markdown
@@ -214,7 +214,7 @@ The following attributes are exported:
 
 #### Arguments
 
-* `boot2dockerUrl` - (Optional) vSphere URL for boot2docker iso image. Default `https://releases.rancher.com/os/latest/rancheros-vmware.iso` (string)
+* `boot2docker_url` - (Optional) vSphere URL for boot2docker iso image. Default `https://releases.rancher.com/os/latest/rancheros-vmware.iso` (string)
 * `cfgparam` - (Optional) vSphere vm configuration parameters (used for guestinfo) (list)
 * `cloudinit` - (Optional) vSphere cloud-init file or url to set in the guestinfo (string)
 * `cpu_count` - (Optional) vSphere CPU number for docker VM. Default `2` (string)


### PR DESCRIPTION
This PR contains:
- Feat: new `cluster_auth_endpoint`, `default_pod_security_policy_template_id` and `enable_network_policy` arguments to `rancher2_cluster` resource
- Fix: set default value on `ignore_docker_version` and `pod_security_policy` on `rke_config` argument on `rancher2_cluster` resource
- Fix: typo on `boot2docker_url` on `vsphere_config` argument name on `rancher2_node_template` resource docs
- Updated CHANGELOG.md file

Fixes issues #23 , #25 and #26 