### PR TITLE
Updated certificate argument on rancher2_auth_config_openldap and rancher2_auth_config_freeipa resources

### DIFF
--- a/rancher2/structure_auth_config_freeipa_test.go
+++ b/rancher2/structure_auth_config_freeipa_test.go
@@ -51,7 +51,7 @@ func init() {
 		"servers":                            []interface{}{"server1", "server2"},
 		"service_account_distinguished_name": "service_account_distinguished_name",
 		"user_search_base":                   "user_search_base",
-		"certificate":                        "certificate",
+		"certificate":                        Base64Encode("certificate"),
 		"connection_timeout":                 10,
 		"group_dn_attribute":                 "group_dn_attribute",
 		"group_member_mapping_attribute":     "group_member_mapping_attribute",

--- a/rancher2/structure_auth_config_ldap.go
+++ b/rancher2/structure_auth_config_ldap.go
@@ -34,7 +34,7 @@ func flattenAuthConfigLdap(d *schema.ResourceData, in *managementClient.LdapConf
 
 	d.Set("service_account_distinguished_name", in.ServiceAccountDistinguishedName)
 	d.Set("user_search_base", in.UserSearchBase)
-	d.Set("certificate", in.Certificate)
+	d.Set("certificate", Base64Encode(in.Certificate))
 	d.Set("connection_timeout", int(in.ConnectionTimeout))
 	d.Set("group_dn_attribute", in.GroupDNAttribute)
 	d.Set("group_member_mapping_attribute", in.GroupMemberMappingAttribute)
@@ -106,7 +106,11 @@ func expandAuthConfigLdap(in *schema.ResourceData) (*managementClient.LdapConfig
 	}
 
 	if v, ok := in.Get("certificate").(string); ok && len(v) > 0 {
-		obj.Certificate = v
+		cert, err := Base64Decode(v)
+		if err != nil {
+			return nil, fmt.Errorf("expanding ldap Auth Config: certificate is not base64 encoded: %s", v)
+		}
+		obj.Certificate = cert
 	}
 
 	if v, ok := in.Get("connection_timeout").(int); ok && v > 0 {

--- a/rancher2/structure_auth_config_ldap_test.go
+++ b/rancher2/structure_auth_config_ldap_test.go
@@ -47,7 +47,7 @@ func init() {
 		"servers":                            []interface{}{"server1", "server2"},
 		"service_account_distinguished_name": "service_account_distinguished_name",
 		"user_search_base":                   "user_search_base",
-		"certificate":                        "certificate",
+		"certificate":                        Base64Encode("certificate"),
 		"connection_timeout":                 10,
 		"group_dn_attribute":                 "group_dn_attribute",
 		"group_member_mapping_attribute":     "group_member_mapping_attribute",

--- a/rancher2/structure_auth_config_openldap_test.go
+++ b/rancher2/structure_auth_config_openldap_test.go
@@ -51,7 +51,7 @@ func init() {
 		"servers":                            []interface{}{"server1", "server2"},
 		"service_account_distinguished_name": "service_account_distinguished_name",
 		"user_search_base":                   "user_search_base",
-		"certificate":                        "certificate",
+		"certificate":                        Base64Encode("certificate"),
 		"connection_timeout":                 10,
 		"group_dn_attribute":                 "group_dn_attribute",
 		"group_member_mapping_attribute":     "group_member_mapping_attribute",

--- a/rancher2/util.go
+++ b/rancher2/util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -24,6 +25,29 @@ const (
 	passDigits                = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
 	passDefaultLen            = 20
 )
+
+func Base64Encode(s string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	data := []byte(s)
+
+	return base64.StdEncoding.EncodeToString(data)
+}
+
+func Base64Decode(s string) (string, error) {
+	if len(s) == 0 {
+		return "", nil
+	}
+	data, err := base64.StdEncoding.DecodeString(s)
+
+	return string(data), err
+}
+
+func IsBase64(s string) bool {
+	_, err := base64.StdEncoding.DecodeString(s)
+	return err == nil
+}
 
 func GetRandomPass(n int) string {
 	rand.Seed(time.Now().Unix())

--- a/website/docs/r/authConfigFreeIpa.html.markdown
+++ b/website/docs/r/authConfigFreeIpa.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 * `user_search_base` - (Required) User search base DN (string)
 * `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted` (string)
 * `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `freeipa_user://<DN>`  `freeipa_group://<DN>` (list)
-* `certificate` - (Optional/Sensitive) CA certificate for TLS if selfsigned (string)
+* `certificate` - (Optional/Sensitive) Base64 encoded CA certificate for TLS if selfsigned. Use filebase64(<FILE>) for encoding file (string)
 * `connection_timeout` - (Optional) FreeIpa connection timeout. Default `5000` (int)
 * `enabled` - (Optional) Enable auth config provider. Default `true` (bool)
 * `group_dn_attribute` - (Optional/Computed) Group DN attribute. Default `entryDN` (string)

--- a/website/docs/r/authConfigOpenLdap.html.markdown
+++ b/website/docs/r/authConfigOpenLdap.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 * `user_search_base` - (Required) User search base DN (string)
 * `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted` (string)
 * `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `openldap_user://<DN>`  `openldap_group://<DN>` (list)
-* `certificate` - (Optional/Sensitive) CA certificate for TLS if selfsigned (string)
+* `certificate` - (Optional/Sensitive) Base64 encoded CA certificate for TLS if selfsigned. Use filebase64(<FILE>) for encoding file (string)
 * `connection_timeout` - (Optional) Openldap connection timeout. Default `5000` (int)
 * `enabled` - (Optional) Enable auth config provider. Default `true` (bool)
 * `group_dn_attribute` - (Optional/Computed) Group DN attribute. Default `entryDN` (string)


### PR DESCRIPTION
Updated `certificate` argument as base64 encoded string on `rancher2_auth_config_openldap` and `rancher2_auth_config_freeipa` resources.

Fix issue #24 