### PR TITLE
Make AWS session token in EKS config sensitive

### DIFF
--- a/rancher2/schema_cluster_eks_config.go
+++ b/rancher2/schema_cluster_eks_config.go
@@ -123,6 +123,7 @@ func clusterEKSConfigFields() map[string]*schema.Schema {
 		"session_token": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			Sensitive:   true,
 			Description: "A session token to use with the client key and secret if applicable",
 		},
 		"user_data": {


### PR DESCRIPTION
The session token is a sensitive value and should not
be printed in the output, as the secret and key.