### PR TITLE
optional arguments eks_config argument on rancher2_cluster resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * Fix: `toArrayString` and `toMapString` functions to check `nil` values
+* Fix: Set `security_groups`, `service_role`, `subnets` and `virtual_network` arguments as optional to `eks_config` argument on `rancher2_cluster` resource
 
 ## 1.3.0 (June 26, 2019)
 

--- a/rancher2/schema_cluster_eks_config.go
+++ b/rancher2/schema_cluster_eks_config.go
@@ -47,32 +47,6 @@ func clusterEKSConfigFields() map[string]*schema.Schema {
 			Sensitive:   true,
 			Description: "The AWS Client Secret associated with the Client ID",
 		},
-		"security_groups": {
-			Type:        schema.TypeList,
-			Required:    true,
-			Description: "List of security groups to use for the cluster",
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-		},
-		"service_role": {
-			Type:        schema.TypeString,
-			Required:    true,
-			Description: "The service role to use to perform the cluster operations in AWS",
-		},
-		"subnets": {
-			Type:        schema.TypeList,
-			Required:    true,
-			Description: "List of subnets in the virtual network to use",
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-		},
-		"virtual_network": {
-			Type:        schema.TypeString,
-			Required:    true,
-			Description: "The name of the virtual network to use",
-		},
 		"ami": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -120,17 +94,43 @@ func clusterEKSConfigFields() map[string]*schema.Schema {
 			Default:     "us-west-2",
 			Description: "The AWS Region to create the EKS cluster in",
 		},
+		"security_groups": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "List of security groups to use for the cluster",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"service_role": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The service role to use to perform the cluster operations in AWS",
+		},
 		"session_token": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Sensitive:   true,
 			Description: "A session token to use with the client key and secret if applicable",
 		},
+		"subnets": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "List of subnets in the virtual network to use",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"user_data": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,
 			Description: "Pass user-data to the nodes to perform automated configuration tasks",
+		},
+		"virtual_network": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The name of the virtual network to use",
 		},
 	}
 

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -590,10 +590,6 @@ The following arguments are supported:
 
 * `access_key` - (Required/Sensitive) The AWS Client ID to use (string)
 * `secret_key` - (Required/Sensitive) The AWS Client Secret associated with the Client ID (string)
-* `security_groups` - (Required) List of security groups to use for the cluster (list)
-* `service_role` - (Required) The service role to use to perform the cluster operations in AWS (string)
-* `subnets` - (Required) List of subnets in the virtual network to use (list)
-* `virtual_network` - (Required) The name of the virtual network to use (string)
 * `ami` - (Optional) AMI ID to use for the worker nodes instead of the default (string)
 * `associate_worker_node_public_ip` - (Optional) Associate public ip EKS worker nodes. Default `true` (bool)
 * `instance_type` - (Optional) The type of machine to use for worker nodes. Default `t2.medium` (string)
@@ -602,8 +598,12 @@ The following arguments are supported:
 * `minimum_nodes` - (Optional) The minimum number of worker nodes. Default `1` (int)
 * `node_volume_size` - (Optional) The volume size for each node. Default `20` (int)
 * `region` - (Optional) The AWS Region to create the EKS cluster in. Default `us-west-2` (string)
+ `security_groups` - (Optional) List of security groups to use for the cluster. If it's not specified Rancher will create a new security group (list)
+* `service_role` - (Optional) The service role to use to perform the cluster operations in AWS. If it's not specified Rancher will create a new service role (string)
 * `session_token` - (Optional/Sensitive) A session token to use with the client key and secret if applicable (string)
+* `subnets` - (Optional) List of subnets in the virtual network to use. If it's not specified Rancher will create 3 news subnets (list)
 * `user_data` - (Optional/Computed) Pass user-data to the nodes to perform automated configuration tasks (string)
+* `virtual_network` - (Optional) The name of the virtual network to use. If it's not specified Rancher will create a new VPC (string)
 
 ### `gke_config`
 


### PR DESCRIPTION
This PR contains:
- Fix: Set `security_groups`, `service_role`, `subnets` and `virtual_network` arguments as optional to `eks_config` argument on `rancher2_cluster` resource.
- Updated CHANGELOG.md

Fix issue #43 