### PR TITLE
Support Rancher2 bootstrap behind corporate proxy

### DIFF
--- a/rancher2/util.go
+++ b/rancher2/util.go
@@ -117,6 +117,7 @@ func DoPost(url, data, cacert string, insecure bool, headers map[string]string) 
 
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	if cacert != "" {


### PR DESCRIPTION
In an environment with http proxy (and properly configured environment variables http_proxy and https_proxy), bootstrapping of the rancher server fails. 

The function DoPost misses the proxy settings in http.transport.

Tested on Windows 10.