### PR TITLE
Move credential checking into client loading

### DIFF
--- a/rancher2/config.go
+++ b/rancher2/config.go
@@ -67,10 +67,26 @@ func (c *Config) UpdateToken(token string) error {
 	return nil
 }
 
+func (c *Config) checkCredentials() error {
+	// If no credentials, bail with an error
+	if c.TokenKey == "" && (c.AccessKey == "" || c.SecretKey == "") {
+		return fmt.Errorf("[ERROR] No token_key nor access_key and secret_key are provided")
+	}
+
+	// Credentials are set
+	return nil
+}
+
 // ManagementClient creates a Rancher client scoped to the management API
 func (c *Config) ManagementClient() (*managementClient.Client, error) {
 	if c.Client.Management != nil {
 		return c.Client.Management, nil
+	}
+
+	// Make sure the credentials have been provided
+	err := c.checkCredentials()
+	if err != nil {
+		return nil, err
 	}
 
 	options := c.CreateClientOpts()
@@ -95,6 +111,12 @@ func (c *Config) ClusterClient(id string) (*clusterClient.Client, error) {
 		return c.Client.Cluster, nil
 	}
 
+	// Make sure the credentials have been provided
+	err := c.checkCredentials()
+	if err != nil {
+		return nil, err
+	}
+
 	options := c.CreateClientOpts()
 	options.URL = options.URL + "/clusters/" + id
 
@@ -117,6 +139,12 @@ func (c *Config) ProjectClient(id string) (*projectClient.Client, error) {
 
 	if c.Client.Project != nil && id == c.ProjectID {
 		return c.Client.Project, nil
+	}
+
+	// Make sure the credentials have been provided
+	err := c.checkCredentials()
+	if err != nil {
+		return nil, err
 	}
 
 	options := c.CreateClientOpts()

--- a/rancher2/provider.go
+++ b/rancher2/provider.go
@@ -168,16 +168,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		if config.TokenKey != "" || config.AccessKey != "" || config.SecretKey != "" {
 			return &Config{}, fmt.Errorf("[ERROR] Bootsrap mode activated. Token_key or access_key and secret_key can not be provided")
 		}
-	} else {
-		// Else token or access key and secret key should be provided
-		if config.TokenKey == "" && (config.AccessKey == "" || config.SecretKey == "") {
-			return &Config{}, fmt.Errorf("[ERROR] No token_key nor access_key and secret_key are provided")
-		}
-
-		_, err := config.ManagementClient()
-		if err != nil {
-			return &Config{}, err
-		}
 	}
 
 	return config, nil


### PR DESCRIPTION
Addresses #38 by moving the credentials check to right before instantiating the client so that the error is raised during run-time instead of apply time. Here's what the error looks like in practice if the credentials aren't provided:

![image](https://user-images.githubusercontent.com/800441/61311332-65c67400-a7b3-11e9-8390-885976986bc9.png)