### PR TITLE
Fix the delete of a cluster when we don't have full read permission

### DIFF
--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -3,12 +3,10 @@ package rancher2
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/rancher/norman/clientbase"
 	norman "github.com/rancher/norman/types"
 	managementClient "github.com/rancher/types/client/management/v3"
 )
@@ -255,10 +253,7 @@ func clusterStateRefreshFunc(client *managementClient.Client, clusterID string) 
 		obj := &Cluster{}
 		err := client.APIBaseClient.ByID(managementClient.ClusterType, clusterID, obj)
 		if err != nil {
-			if IsNotFound(err) {
-				return obj, "removed", nil
-			} else if e, ok := err.(*clientbase.APIError); ok && e.StatusCode == http.StatusForbidden {
-				log.Printf("[INFO] Got access denied to the cluster, which means it has been removed")
+			if IsNotFound(err) || IsForbidden(err) {
 				return obj, "removed", nil
 			}
 			return nil, "", err

--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -253,6 +253,12 @@ func clusterStateRefreshFunc(client *managementClient.Client, clusterID string) 
 		obj := &Cluster{}
 		err := client.APIBaseClient.ByID(managementClient.ClusterType, clusterID, obj)
 		if err != nil {
+			// The IsForbidden check is used in the case the user performing the action does not have the
+			// right to retrieve the full list of clusters. If the user tries to retrieve the cluster that
+			// just got deleted, instead of getting a 404 not found response it will get a 403 forbidden
+			// eventhough it had the right to access the cluster before it was deleted. If we reach this
+			// code path, it means that the user had the right to access the cluster, delete it, hence
+			// meaning that the delete was successful.
 			if IsNotFound(err) || IsForbidden(err) {
 				return obj, "removed", nil
 			}

--- a/rancher2/util.go
+++ b/rancher2/util.go
@@ -169,6 +169,16 @@ func IsNotFound(err error) bool {
 	return clientbase.IsNotFound(err)
 }
 
+// IsForbidden checks if the given APIError is a Forbidden HTTP statuscode
+func IsForbidden(err error) bool {
+	apiError, ok := err.(*clientbase.APIError)
+	if !ok {
+		return false
+	}
+
+	return apiError.StatusCode == http.StatusForbidden
+}
+
 func splitTokenID(token string) string {
 	separator := ":"
 


### PR DESCRIPTION
This pull request fixes the following behaviour happening when a user does not have the permission to list all clusters:
* tries to delete a cluster
* delete succeeds
* polls the API to get the state of the cluster
* gets a 403 because the cluster does not exist anymore but we can't list all of them (so no 404)
* fails the terraform run

Test plan:
* integration test on a running rancher instance
* unit tests
```
$ make test
==> Checking that code complies with gofmt requirements...
go test -i "./rancher2" || exit 1
echo "./rancher2" | \
                xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 ./rancher2
ok      github.com/terraform-providers/terraform-provider-rancher2/rancher2     0.058s
```

This fixes #50 