### PR TITLE
Added container_resource_limit and pod_security_policy_template_id arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ FEATURES:
 ENHANCEMENTS:
 
 * Set `session_token` argument as sensitive on `eks_config` argument on `rancher2_cluster` resource
+* Set default value to `engine_install_url` argument on `rancher2_node_template` resource
 * Added `enable_cluster_monitoring` argument to `rancher2_cluster` resource and datasource
 * Added `enable_project_monitoring` argument to `rancher2_project` resource and datasource
 * Added `token` argument on `cluster_registration_token` argument to rancher2_cluster resource and datasource
@@ -33,6 +34,8 @@ ENHANCEMENTS:
 * Updated rancher to v2.2.6 and k3s to v0.7.0 on acceptance tests
 * Added cluster and project scope support on `rancher2_catalog` resource and datasource
 * Updated `provider` config validation to enable bootstrap and resource creation at same run
+* Added `container_resource_limit` argument on `rancher2_namespace` and `rancher2_project` resources and datasources
+* Added `pod_security_policy_template_id` on `rancher2_project` resource
 
 BUG FIXES:
 

--- a/rancher2/data_source_rancher2_namespace.go
+++ b/rancher2/data_source_rancher2_namespace.go
@@ -21,6 +21,14 @@ func dataSourceRancher2Namespace() *schema.Resource {
 				Required:    true,
 				Description: "Name of the k8s namespace managed by rancher v2",
 			},
+			"container_resource_limit": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: containerResourceLimitFields(),
+				},
+			},
 			"description": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/rancher2/data_source_rancher2_project.go
+++ b/rancher2/data_source_rancher2_project.go
@@ -24,6 +24,14 @@ func dataSourceRancher2Project() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"container_resource_limit": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: containerResourceLimitFields(),
+				},
+			},
 			"description": {
 				Description: "Description of the project",
 				Type:        schema.TypeString,
@@ -33,6 +41,18 @@ func dataSourceRancher2Project() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable built-in project monitoring",
+			},
+			"pod_security_policy_template_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_quota": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: projectResourceQuotaFields(),
+				},
 			},
 			"uuid": {
 				Description: "UUID of the project",
@@ -119,6 +139,25 @@ func dataSourceRancher2ProjectRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("description", project.Description)
 	d.Set("name", project.Name)
 	d.Set("uuid", project.UUID)
+
+	if project.ContainerDefaultResourceLimit != nil {
+		containerLimit := flattenProjectContainerResourceLimit(project.ContainerDefaultResourceLimit)
+		err := d.Set("container_resource_limit", containerLimit)
+		if err != nil {
+			return err
+		}
+	}
+
+	d.Set("pod_security_policy_template_id", project.PodSecurityPolicyTemplateName)
+
+	if project.ResourceQuota != nil && project.NamespaceDefaultResourceQuota != nil {
+		resourceQuota := flattenProjectResourceQuota(project.ResourceQuota, project.NamespaceDefaultResourceQuota)
+		err := d.Set("resource_quota", resourceQuota)
+		if err != nil {
+			return err
+		}
+	}
+
 	err = d.Set("annotations", toMapInterface(project.Annotations))
 	if err != nil {
 		return err

--- a/rancher2/schema_container_resource_limit.go
+++ b/rancher2/schema_container_resource_limit.go
@@ -1,0 +1,34 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+//Schemas
+
+func containerResourceLimitFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"limits_cpu": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"limits_memory": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"requests_cpu": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"requests_memory": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+	}
+
+	return s
+}

--- a/rancher2/schema_namespace.go
+++ b/rancher2/schema_namespace.go
@@ -105,6 +105,15 @@ func namespaceFields() map[string]*schema.Schema {
 			ForceNew:    true,
 			Description: "Name of the k8s namespace managed by rancher v2",
 		},
+		"container_resource_limit": {
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: containerResourceLimitFields(),
+			},
+		},
 		"description": &schema.Schema{
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/rancher2/schema_project.go
+++ b/rancher2/schema_project.go
@@ -104,6 +104,14 @@ func projectFields() map[string]*schema.Schema {
 			Required: true,
 			ForceNew: true,
 		},
+		"container_resource_limit": {
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: containerResourceLimitFields(),
+			},
+		},
 		"description": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
@@ -113,6 +121,10 @@ func projectFields() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     false,
 			Description: "Enable built-in project monitoring",
+		},
+		"pod_security_policy_template_id": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 		"resource_quota": {
 			Type:     schema.TypeList,

--- a/rancher2/structure_namespace.go
+++ b/rancher2/structure_namespace.go
@@ -7,6 +7,28 @@ import (
 
 // Flatteners
 
+func flattenNamespaceContainerResourceLimit(in *clusterClient.ContainerResourceLimit) []interface{} {
+	obj := make(map[string]interface{})
+	if in == nil {
+		return []interface{}{}
+	}
+
+	if len(in.LimitsCPU) > 0 {
+		obj["limits_cpu"] = in.LimitsCPU
+	}
+	if len(in.LimitsMemory) > 0 {
+		obj["limits_memory"] = in.LimitsMemory
+	}
+	if len(in.RequestsCPU) > 0 {
+		obj["requests_cpu"] = in.RequestsCPU
+	}
+	if len(in.RequestsMemory) > 0 {
+		obj["requests_memory"] = in.RequestsMemory
+	}
+
+	return []interface{}{obj}
+}
+
 func flattenNamespaceResourceQuotaLimit(in *clusterClient.ResourceQuotaLimit) []interface{} {
 	obj := make(map[string]interface{})
 	if in == nil {
@@ -96,8 +118,14 @@ func flattenNamespace(d *schema.ResourceData, in *clusterClient.Namespace) error
 	d.Set("name", in.Name)
 	d.Set("description", in.Description)
 
+	containerLimit := flattenNamespaceContainerResourceLimit(in.ContainerDefaultResourceLimit)
+	err := d.Set("container_resource_limit", containerLimit)
+	if err != nil {
+		return err
+	}
+
 	resourceQuota := flattenNamespaceResourceQuota(in.ResourceQuota)
-	err := d.Set("resource_quota", resourceQuota)
+	err = d.Set("resource_quota", resourceQuota)
 	if err != nil {
 		return err
 	}
@@ -117,6 +145,29 @@ func flattenNamespace(d *schema.ResourceData, in *clusterClient.Namespace) error
 }
 
 // Expanders
+
+func expandNamespaceContainerResourceLimit(p []interface{}) *clusterClient.ContainerResourceLimit {
+	obj := &clusterClient.ContainerResourceLimit{}
+	if len(p) == 0 || p[0] == nil {
+		return obj
+	}
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["limits_cpu"].(string); ok && len(v) > 0 {
+		obj.LimitsCPU = v
+	}
+	if v, ok := in["limits_memory"].(string); ok && len(v) > 0 {
+		obj.LimitsMemory = v
+	}
+	if v, ok := in["requests_cpu"].(string); ok && len(v) > 0 {
+		obj.RequestsCPU = v
+	}
+	if v, ok := in["requests_memory"].(string); ok && len(v) > 0 {
+		obj.RequestsMemory = v
+	}
+
+	return obj
+}
 
 func expandNamespaceResourceQuotaLimit(p []interface{}) *clusterClient.ResourceQuotaLimit {
 	obj := &clusterClient.ResourceQuotaLimit{}
@@ -211,6 +262,11 @@ func expandNamespace(in *schema.ResourceData) *clusterClient.Namespace {
 	obj.ProjectID = projectID
 	obj.Name = in.Get("name").(string)
 	obj.Description = in.Get("description").(string)
+
+	if v, ok := in.Get("container_resource_limit").([]interface{}); ok && len(v) > 0 {
+		containerLimit := expandNamespaceContainerResourceLimit(v)
+		obj.ContainerDefaultResourceLimit = containerLimit
+	}
 
 	if v, ok := in.Get("resource_quota").([]interface{}); ok && len(v) > 0 {
 		resourceQuota := expandNamespaceResourceQuota(v)

--- a/rancher2/structure_namespace_test.go
+++ b/rancher2/structure_namespace_test.go
@@ -9,15 +9,31 @@ import (
 )
 
 var (
-	testNamespaceResourceQuotaLimitConf      *clusterClient.ResourceQuotaLimit
-	testNamespaceResourceQuotaLimitInterface []interface{}
-	testNamespaceResourceQuotaConf           *clusterClient.NamespaceResourceQuota
-	testNamespaceResourceQuotaInterface      []interface{}
-	testNamespaceConf                        *clusterClient.Namespace
-	testNamespaceInterface                   map[string]interface{}
+	testNamespaceContainerResourceLimitConf      *clusterClient.ContainerResourceLimit
+	testNamespaceContainerResourceLimitInterface []interface{}
+	testNamespaceResourceQuotaLimitConf          *clusterClient.ResourceQuotaLimit
+	testNamespaceResourceQuotaLimitInterface     []interface{}
+	testNamespaceResourceQuotaConf               *clusterClient.NamespaceResourceQuota
+	testNamespaceResourceQuotaInterface          []interface{}
+	testNamespaceConf                            *clusterClient.Namespace
+	testNamespaceInterface                       map[string]interface{}
 )
 
 func init() {
+	testNamespaceContainerResourceLimitConf = &clusterClient.ContainerResourceLimit{
+		LimitsCPU:      "limits_cpu",
+		LimitsMemory:   "limits_memory",
+		RequestsCPU:    "requests_cpu",
+		RequestsMemory: "requests_memory",
+	}
+	testNamespaceContainerResourceLimitInterface = []interface{}{
+		map[string]interface{}{
+			"limits_cpu":      "limits_cpu",
+			"limits_memory":   "limits_memory",
+			"requests_cpu":    "requests_cpu",
+			"requests_memory": "requests_memory",
+		},
+	}
 	testNamespaceResourceQuotaLimitConf = &clusterClient.ResourceQuotaLimit{
 		ConfigMaps:             "config",
 		LimitsCPU:              "cpu",
@@ -59,16 +75,39 @@ func init() {
 		},
 	}
 	testNamespaceConf = &clusterClient.Namespace{
-		ProjectID:     "project:test",
-		Name:          "test",
-		Description:   "description",
-		ResourceQuota: testNamespaceResourceQuotaConf,
+		ProjectID:                     "project:test",
+		Name:                          "test",
+		ContainerDefaultResourceLimit: testNamespaceContainerResourceLimitConf,
+		Description:                   "description",
+		ResourceQuota:                 testNamespaceResourceQuotaConf,
 	}
 	testNamespaceInterface = map[string]interface{}{
-		"project_id":     "project:test",
-		"name":           "test",
-		"description":    "description",
-		"resource_quota": testNamespaceResourceQuotaInterface,
+		"project_id":               "project:test",
+		"name":                     "test",
+		"container_resource_limit": testNamespaceContainerResourceLimitInterface,
+		"description":              "description",
+		"resource_quota":           testNamespaceResourceQuotaInterface,
+	}
+}
+
+func TestFlattenNamespaceContainerResourceLimit(t *testing.T) {
+
+	cases := []struct {
+		Input          *clusterClient.ContainerResourceLimit
+		ExpectedOutput []interface{}
+	}{
+		{
+			testNamespaceContainerResourceLimitConf,
+			testNamespaceContainerResourceLimitInterface,
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenNamespaceContainerResourceLimit(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
 	}
 }
 
@@ -139,6 +178,26 @@ func TestFlattenNamespace(t *testing.T) {
 		if !reflect.DeepEqual(expectedOutput, tc.ExpectedOutput) {
 			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
 				expectedOutput, output)
+		}
+	}
+}
+
+func TestExpandNamespaceContainerResourceLimit(t *testing.T) {
+
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *clusterClient.ContainerResourceLimit
+	}{
+		{
+			testNamespaceContainerResourceLimitInterface,
+			testNamespaceContainerResourceLimitConf,
+		},
+	}
+
+	for _, tc := range cases {
+		output := expandNamespaceContainerResourceLimit(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven: %#v", tc.ExpectedOutput, output)
 		}
 	}
 }

--- a/rancher2/structure_project.go
+++ b/rancher2/structure_project.go
@@ -7,6 +7,28 @@ import (
 
 // Flatteners
 
+func flattenProjectContainerResourceLimit(in *managementClient.ContainerResourceLimit) []interface{} {
+	obj := make(map[string]interface{})
+	if in == nil {
+		return []interface{}{}
+	}
+
+	if len(in.LimitsCPU) > 0 {
+		obj["limits_cpu"] = in.LimitsCPU
+	}
+	if len(in.LimitsMemory) > 0 {
+		obj["limits_memory"] = in.LimitsMemory
+	}
+	if len(in.RequestsCPU) > 0 {
+		obj["requests_cpu"] = in.RequestsCPU
+	}
+	if len(in.RequestsMemory) > 0 {
+		obj["requests_memory"] = in.RequestsMemory
+	}
+
+	return []interface{}{obj}
+}
+
 func flattenProjectResourceQuotaLimit(in *managementClient.ResourceQuotaLimit) []interface{} {
 	obj := make(map[string]interface{})
 	if in == nil {
@@ -98,6 +120,16 @@ func flattenProject(d *schema.ResourceData, in *managementClient.Project) error 
 	d.Set("description", in.Description)
 	d.Set("enable_project_monitoring", in.EnableProjectMonitoring)
 
+	if in.ContainerDefaultResourceLimit != nil {
+		containerLimit := flattenProjectContainerResourceLimit(in.ContainerDefaultResourceLimit)
+		err := d.Set("container_resource_limit", containerLimit)
+		if err != nil {
+			return err
+		}
+	}
+
+	d.Set("pod_security_policy_template_id", in.PodSecurityPolicyTemplateName)
+
 	if in.ResourceQuota != nil && in.NamespaceDefaultResourceQuota != nil {
 		resourceQuota := flattenProjectResourceQuota(in.ResourceQuota, in.NamespaceDefaultResourceQuota)
 		err := d.Set("resource_quota", resourceQuota)
@@ -121,6 +153,29 @@ func flattenProject(d *schema.ResourceData, in *managementClient.Project) error 
 }
 
 // Expanders
+
+func expandProjectContainerResourceLimit(p []interface{}) *managementClient.ContainerResourceLimit {
+	obj := &managementClient.ContainerResourceLimit{}
+	if len(p) == 0 || p[0] == nil {
+		return obj
+	}
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["limits_cpu"].(string); ok && len(v) > 0 {
+		obj.LimitsCPU = v
+	}
+	if v, ok := in["limits_memory"].(string); ok && len(v) > 0 {
+		obj.LimitsMemory = v
+	}
+	if v, ok := in["requests_cpu"].(string); ok && len(v) > 0 {
+		obj.RequestsCPU = v
+	}
+	if v, ok := in["requests_memory"].(string); ok && len(v) > 0 {
+		obj.RequestsMemory = v
+	}
+
+	return obj
+}
 
 func expandProjectResourceQuotaLimit(p []interface{}) *managementClient.ResourceQuotaLimit {
 	obj := &managementClient.ResourceQuotaLimit{}
@@ -221,9 +276,16 @@ func expandProject(in *schema.ResourceData) *managementClient.Project {
 	obj.Name = in.Get("name").(string)
 	obj.Description = in.Get("description").(string)
 
+	if v, ok := in.Get("container_resource_limit").([]interface{}); ok && len(v) > 0 {
+		containerLimit := expandProjectContainerResourceLimit(v)
+		obj.ContainerDefaultResourceLimit = containerLimit
+	}
+
 	if v, ok := in.Get("enable_project_monitoring").(bool); ok {
 		obj.EnableProjectMonitoring = v
 	}
+
+	obj.PodSecurityPolicyTemplateName = in.Get("pod_security_policy_template_id").(string)
 
 	if v, ok := in.Get("resource_quota").([]interface{}); ok && len(v) > 0 {
 		resourceQuota, nsResourceQuota := expandProjectResourceQuota(v)

--- a/rancher2/structure_project_test.go
+++ b/rancher2/structure_project_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 var (
+	testProjectContainerResourceLimitConf           *managementClient.ContainerResourceLimit
+	testProjectContainerResourceLimitInterface      []interface{}
 	testProjectResourceQuotaLimitConf               *managementClient.ResourceQuotaLimit
 	testProjectResourceQuotaLimitInterface          []interface{}
 	testProjectResourceQuotaLimitNamespaceConf      *managementClient.ResourceQuotaLimit
@@ -21,6 +23,20 @@ var (
 )
 
 func init() {
+	testProjectContainerResourceLimitConf = &managementClient.ContainerResourceLimit{
+		LimitsCPU:      "limits_cpu",
+		LimitsMemory:   "limits_memory",
+		RequestsCPU:    "requests_cpu",
+		RequestsMemory: "requests_memory",
+	}
+	testProjectContainerResourceLimitInterface = []interface{}{
+		map[string]interface{}{
+			"limits_cpu":      "limits_cpu",
+			"limits_memory":   "limits_memory",
+			"requests_cpu":    "requests_cpu",
+			"requests_memory": "requests_memory",
+		},
+	}
 	testProjectResourceQuotaLimitConf = &managementClient.ResourceQuotaLimit{
 		ConfigMaps:             "config",
 		LimitsCPU:              "cpu",
@@ -100,17 +116,42 @@ func init() {
 	testProjectConf = &managementClient.Project{
 		ClusterID:                     "cluster-test",
 		Name:                          "test",
+		ContainerDefaultResourceLimit: testProjectContainerResourceLimitConf,
 		Description:                   "description",
 		EnableProjectMonitoring:       true,
+		PodSecurityPolicyTemplateName: "pod_security_policy_template_id",
 		ResourceQuota:                 testProjectResourceQuotaConf,
 		NamespaceDefaultResourceQuota: testProjectNamespaceResourceQuotaConf,
 	}
 	testProjectInterface = map[string]interface{}{
-		"cluster_id":                "cluster-test",
-		"name":                      "test",
-		"description":               "description",
-		"enable_project_monitoring": true,
-		"resource_quota":            testProjectResourceQuotaInterface,
+		"cluster_id":                      "cluster-test",
+		"name":                            "test",
+		"container_resource_limit":        testProjectContainerResourceLimitInterface,
+		"description":                     "description",
+		"enable_project_monitoring":       true,
+		"pod_security_policy_template_id": "pod_security_policy_template_id",
+		"resource_quota":                  testProjectResourceQuotaInterface,
+	}
+}
+
+func TestFlattenProjectContainerResourceLimit(t *testing.T) {
+
+	cases := []struct {
+		Input          *managementClient.ContainerResourceLimit
+		ExpectedOutput []interface{}
+	}{
+		{
+			testProjectContainerResourceLimitConf,
+			testProjectContainerResourceLimitInterface,
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenProjectContainerResourceLimit(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
 	}
 }
 
@@ -183,6 +224,26 @@ func TestFlattenProject(t *testing.T) {
 		if !reflect.DeepEqual(expectedOutput, tc.ExpectedOutput) {
 			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
 				expectedOutput, output)
+		}
+	}
+}
+
+func TestExpandProjectContainerResourceLimit(t *testing.T) {
+
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *managementClient.ContainerResourceLimit
+	}{
+		{
+			testProjectContainerResourceLimitInterface,
+			testProjectContainerResourceLimitConf,
+		},
+	}
+
+	for _, tc := range cases {
+		output := expandProjectContainerResourceLimit(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven: %#v", tc.ExpectedOutput, output)
 		}
 	}
 }

--- a/website/docs/d/namespace.html.markdown
+++ b/website/docs/d/namespace.html.markdown
@@ -27,6 +27,7 @@ data "rancher2_namespace" "foo" {
 ## Attributes Reference
 
 * `id` - (Computed) The ID of the resource (string)
+* `container_resource_limit` - (Computed) Default containers resource limits on namespace (List maxitem:1)
 * `description` - (Computed) A namespace description (string)
 * `resource_quota` - (Computed) Resource quota for namespace. Rancher v2.1.x or higher (list maxitems:1)
 * `annotations` - (Computed) Annotations for Node Pool object (map)

--- a/website/docs/d/project.html.markdown
+++ b/website/docs/d/project.html.markdown
@@ -33,14 +33,17 @@ resource "kubernetes_namespace" "my_namespace" {
 
 ## Argument Reference
 
- * `cluster_id` - (Required) ID of the Rancher 2 cluster.
- * `name` - (Required) The project name.
+ * `cluster_id` - (Required) ID of the Rancher 2 cluster (string)
+ * `name` - (Required) The project name (string)
 
 ## Attributes Reference
 
- * `id` - Cluster-wide unique ID of the Rancher 2 project.
- * `uuid` - UUID of the project as stored by Rancher 2.
- * `description` - The project's description.
+ * `id` - (Computed) Cluster-wide unique ID of the Rancher 2 project (string)
+ * `container_resource_limit` - (Computed) Default containers resource limits on project (List maxitem:1)
  * `enable_project_monitoring` - (Computed) Enable built-in project monitoring. Default `false` (bool)
- * `annotations` - Annotations of the rancher2 project (map).
- * `labels` - Labels of the rancher2 project (map).
+ * `pod_security_policy_template_id` - (Computed) Default Pod Security Policy ID for the project (string)
+ * `resource_quota` - (Computed) Resource quota for project. Rancher v2.1.x or higher (list maxitems:1)
+ * `uuid` - (Computed) UUID of the project as stored by Rancher 2 (string)
+ * `description` - (Computed) The project's description (string)
+ * `annotations` - (Computed) Annotations of the rancher2 project (map)
+ * `labels` - (Computed) Labels of the rancher2 project (map)

--- a/website/docs/r/namespace.html.markdown
+++ b/website/docs/r/namespace.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the namespace (string)
 * `project_id` - (Required) The project id where assign namespace. It's on the form `project_id=<cluster_id>:<id>`. Updating `<id>` part on same `<cluster_id>` namespace will be moved between projects (string)
+* `container_resource_limit` - (Optional/Computed) Default containers resource limits on namespace (List maxitem:1)
 * `description` - (Optional) A namespace description (string)
 * `resource_quota` - (Optional/Computed) Resource quota for namespace. Rancher v2.1.x or higher (list maxitems:1)
 * `annotations` - (Optional/Computed) Annotations for Node Pool object (map)
@@ -72,6 +73,15 @@ The following attributes are exported:
 * `id` - (Computed) The ID of the resource (string)
 
 ## Nested blocks
+
+### `container_resource_limit`
+
+#### Arguments
+
+* `limits_cpu` - (Optional) CPU limit for containers, measured in milli CPUs (string)
+* `limits_memory` - (Optional) Memory limit for containers, measured in MiB (string)
+* `requests_cpu` - (Optional) CPU reservation for containers, measured in milli CPUs (string)
+* `requests_memory` - (Optional) Memory reservation for containers, measured in MiB (string)
 
 ### `resource_quota`
 

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -38,8 +38,10 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the project (string)
 * `cluster_id` - (Required) The cluster id where create project (string)
+* `container_resource_limit` - (Optional) Default containers resource limits on project (List maxitem:1)
 * `description` - (Optional) A project description (string)
 * `enable_project_monitoring` - (Optional) Enable built-in project monitoring. Default `false` (bool)
+* `pod_security_policy_template_id` - (Optional) Default Pod Security Policy ID for the project (string)
 * `resource_quota` - (Optional) Resource quota for project. Rancher v2.1.x or higher (list maxitems:1)
 * `annotations` - (Optional/Computed) Annotations for Node Pool object (map)
 * `labels` - (Optional/Computed) Labels for Node Pool object (map)
@@ -51,6 +53,15 @@ The following attributes are exported:
 * `id` - (Computed) The ID of the resource (string)
 
 ## Nested blocks
+
+### `container_resource_limit`
+
+#### Arguments
+
+* `limits_cpu` - (Optional) CPU limit for containers, measured in milli CPUs (string)
+* `limits_memory` - (Optional) Memory limit for containers, measured in MiB (string)
+* `requests_cpu` - (Optional) CPU reservation for containers, measured in milli CPUs (string)
+* `requests_memory` - (Optional) Memory reservation for containers, measured in MiB (string)
 
 ### `resource_quota`
 


### PR DESCRIPTION
This PR constains:
- Added `container_resource_limit` argument on `rancher2_namespace` and `rancher2_project` resources and datasources
- Added `pod_security_policy_template_id` on `rancher2_project` resource and datasource
- Updated CHANGELOG.md

Fix issue #77 