### PR TITLE
WIP: Allow pull EKS config AWS creds from env vars and update creds before delete

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,7 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-ini/ini v1.23.1 h1:amNPHl+tCb4BolL2NAIQaKLY+ZiL1Ju7OqZ9Fx6PTBQ=
 github.com/go-ini/ini v1.23.1/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
+github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/rancher2/schema_cluster_eks_config.go
+++ b/rancher2/schema_cluster_eks_config.go
@@ -37,15 +37,26 @@ func clusterEKSConfigFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"access_key": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Sensitive:   true,
 			Description: "The AWS Client ID to use",
 		},
 		"secret_key": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Sensitive:   true,
 			Description: "The AWS Client Secret associated with the Client ID",
+		},
+		"session_token": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
+			Description: "A session token to use with the client key and secret if applicable",
+		},
+		"aws_creds_from_env": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Get AWS credentials from environment variables",
 		},
 		"ami": {
 			Type:        schema.TypeString,
@@ -106,12 +117,6 @@ func clusterEKSConfigFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "The service role to use to perform the cluster operations in AWS",
-		},
-		"session_token": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Sensitive:   true,
-			Description: "A session token to use with the client key and secret if applicable",
 		},
 		"subnets": {
 			Type:        schema.TypeList,

--- a/rancher2/structure_cluster.go
+++ b/rancher2/structure_cluster.go
@@ -106,7 +106,11 @@ func flattenCluster(d *schema.ResourceData, in *Cluster, clusterRegToken *manage
 			return err
 		}
 	case clusterDriverEKS:
-		eksConfig, err := flattenClusterEKSConfig(in.AmazonElasticContainerServiceConfig)
+		v, ok := d.Get("rke_config").([]interface{})
+		if !ok {
+			v = []interface{}{}
+		}
+		eksConfig, err := flattenClusterEKSConfig(in.AmazonElasticContainerServiceConfig, v)
 		if err != nil {
 			return err
 		}

--- a/rancher2/structure_cluster_eks_config_test.go
+++ b/rancher2/structure_cluster_eks_config_test.go
@@ -1,13 +1,16 @@
 package rancher2
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
 
 var (
-	testClusterEKSConfigConf      *AmazonElasticContainerServiceConfig
-	testClusterEKSConfigInterface []interface{}
+	testClusterEKSConfigConf                  *AmazonElasticContainerServiceConfig
+	testClusterEKSConfigInterface             []interface{}
+	testClusterEKSConfigConfCredsFromEnv      *AmazonElasticContainerServiceConfig
+	testClusterEKSConfigInterfaceCredsFromEnv []interface{}
 )
 
 func init() {
@@ -50,22 +53,41 @@ func init() {
 			"virtual_network":                 "network",
 		},
 	}
+	testClusterEKSConfigConfCredsFromEnv = &AmazonElasticContainerServiceConfig{
+		AccessKey:                   "env_XXXXXXXX",
+		SecretKey:                   "env_YYYYYYYY",
+		SessionToken:                "env_session_token",
+		AssociateWorkerNodePublicIP: newTrue(),
+		DisplayName:                 "test",
+	}
+	testClusterEKSConfigInterfaceCredsFromEnv = []interface{}{
+		map[string]interface{}{
+			"aws_creds_from_env":              true,
+			"associate_worker_node_public_ip": true,
+		},
+	}
 }
 
 func TestFlattenClusterEKSConfig(t *testing.T) {
-
 	cases := []struct {
 		Input          *AmazonElasticContainerServiceConfig
+		Config         []interface{}
 		ExpectedOutput []interface{}
 	}{
 		{
 			testClusterEKSConfigConf,
+			[]interface{}{},
 			testClusterEKSConfigInterface,
+		},
+		{
+			testClusterEKSConfigConfCredsFromEnv,
+			testClusterEKSConfigInterfaceCredsFromEnv,
+			testClusterEKSConfigInterfaceCredsFromEnv,
 		},
 	}
 
 	for _, tc := range cases {
-		output, err := flattenClusterEKSConfig(tc.Input)
+		output, err := flattenClusterEKSConfig(tc.Input, tc.Config)
 		if err != nil {
 			t.Fatalf("[ERROR] on flattener: %#v", err)
 		}
@@ -80,22 +102,80 @@ func TestExpandClusterEKSConfig(t *testing.T) {
 
 	cases := []struct {
 		Input          []interface{}
+		ExtraEnv       map[string]string
 		ExpectedOutput *AmazonElasticContainerServiceConfig
+		ExpectedError  error
 	}{
 		{
 			testClusterEKSConfigInterface,
+			map[string]string{},
 			testClusterEKSConfigConf,
+			nil,
+		},
+		{
+			testClusterEKSConfigInterfaceCredsFromEnv,
+			map[string]string{
+				"AWS_ACCESS_KEY_ID":     "env_XXXXXXXX",
+				"AWS_SECRET_ACCESS_KEY": "env_YYYYYYYY",
+				"AWS_SESSION_TOKEN":     "env_session_token",
+			},
+			testClusterEKSConfigConfCredsFromEnv,
+			nil,
+		},
+		{
+			[]interface{}{
+				map[string]interface{}{},
+			},
+			map[string]string{},
+			&AmazonElasticContainerServiceConfig{},
+			fmt.Errorf("[ERROR] 'aws_creds_from_env=false' or not set but 'access_key' not set"),
+		},
+		{
+			[]interface{}{
+				map[string]interface{}{
+					"access_key": "XXXXXXXX",
+				},
+			},
+			map[string]string{},
+			&AmazonElasticContainerServiceConfig{},
+			fmt.Errorf("[ERROR] 'aws_creds_from_env=false' or not set but 'secret_key' not set"),
+		},
+		{
+			testClusterEKSConfigInterfaceCredsFromEnv,
+			map[string]string{},
+			testClusterEKSConfigConfCredsFromEnv,
+			fmt.Errorf("[ERROR] 'aws_creds_from_env=true' but env var AWS_ACCESS_KEY_ID is not set"),
+		},
+		{
+			testClusterEKSConfigInterfaceCredsFromEnv,
+			map[string]string{
+				"AWS_ACCESS_KEY_ID": "env_XXXXXXXX",
+			},
+			testClusterEKSConfigConfCredsFromEnv,
+			fmt.Errorf("[ERROR] 'aws_creds_from_env=true' but env var AWS_SECRET_ACCESS_KEY is not set"),
 		},
 	}
 
 	for _, tc := range cases {
-		output, err := expandClusterEKSConfig(tc.Input, "test")
-		if err != nil {
-			t.Fatalf("[ERROR] on expander: %#v", err)
-		}
-		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
-			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
-				tc.ExpectedOutput, output)
-		}
+		runWithEnv(tc.ExtraEnv, func() {
+			output, err := expandClusterEKSConfig(tc.Input, "test")
+
+			if tc.ExpectedError != nil {
+				if !reflect.DeepEqual(err, tc.ExpectedError) {
+					t.Fatalf("Unexpected error from expander.\nExpected: %#v\nGiven:    %#v",
+						tc.ExpectedError, err)
+				} else {
+					return
+				}
+			}
+
+			if err != nil {
+				t.Fatalf("[ERROR] on expander: %#v", err)
+			}
+			if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+				t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+					tc.ExpectedOutput, output)
+			}
+		})
 	}
 }

--- a/rancher2/structure_cluster_test.go
+++ b/rancher2/structure_cluster_test.go
@@ -257,6 +257,9 @@ func TestFlattenCluster(t *testing.T) {
 		if tc.ExpectedOutput["driver"] == clusterDriverRKE {
 			expectedOutput["rke_config"], _ = flattenClusterRKEConfig(tc.Input.RancherKubernetesEngineConfig, []interface{}{})
 		}
+		if tc.ExpectedOutput["driver"] == clusterDriverEKS {
+			expectedOutput["eks_config"], _ = flattenClusterEKSConfig(tc.Input.AmazonElasticContainerServiceConfig, []interface{}{})
+		}
 		expectedOutput["id"] = "id"
 		if !reflect.DeepEqual(expectedOutput, tc.ExpectedOutput) {
 			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",

--- a/rancher2/util.go
+++ b/rancher2/util.go
@@ -279,3 +279,26 @@ func newFalse() *bool {
 	b := false
 	return &b
 }
+
+func runWithEnv(newEnv map[string]string, f func()) {
+	oldEnv := map[string]*string{}
+	for k, v := range newEnv {
+		if oldValue, ok := os.LookupEnv(k); ok {
+			oldEnv[k] = &oldValue
+		} else {
+			oldEnv[k] = nil
+		}
+		os.Setenv(k, v)
+	}
+	defer func() {
+		for k, v := range oldEnv {
+			if v != nil {
+				os.Setenv(k, *v)
+			} else {
+				os.Unsetenv(k)
+			}
+		}
+	}()
+
+	f()
+}

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -15,7 +15,7 @@ Provides a Rancher v2 Cluster resource. This can be used to create Clusters for 
 Creating Rancher v2 imported cluster
 
 ```hcl
-# Create a new rancher2 imported Cluster 
+# Create a new rancher2 imported Cluster
 resource "rancher2_cluster" "foo-imported" {
   name = "foo-imported"
   description = "Foo rancher2 imported cluster"
@@ -25,7 +25,7 @@ resource "rancher2_cluster" "foo-imported" {
 Creating Rancher v2 rke cluster
 
 ```hcl
-# Create a new rancher2 rke Cluster 
+# Create a new rancher2 rke Cluster
 resource "rancher2_cluster" "foo-custom" {
   name = "foo-custom"
   description = "Foo rancher2 custom cluster"
@@ -40,7 +40,7 @@ resource "rancher2_cluster" "foo-custom" {
 Creating Rancher v2 rke cluster assigning a node pool (overlapped planes)
 
 ```hcl
-# Create a new rancher2 rke Cluster 
+# Create a new rancher2 rke Cluster
 resource "rancher2_cluster" "foo-custom" {
   name = "foo-custom"
   description = "Foo rancher2 custom cluster"
@@ -586,10 +586,18 @@ The following arguments are supported:
 
 #### Arguments
 
-The following arguments are supported:
+Valid AWS credentials must be provided by setting:
+
+* `aws_creds_from_env` - (Optional) Pull the AWS credentials from the [standard environment variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html). (bool)
+
+or explicitely setting:
 
 * `access_key` - (Required/Sensitive) The AWS Client ID to use (string)
 * `secret_key` - (Required/Sensitive) The AWS Client Secret associated with the Client ID (string)
+* `session_token` - (Optional/Sensitive) A session token to use with the client key and secret if applicable (string)
+
+The following additional arguments are supported:
+
 * `ami` - (Optional) AMI ID to use for the worker nodes instead of the default (string)
 * `associate_worker_node_public_ip` - (Optional) Associate public ip EKS worker nodes. Default `true` (bool)
 * `instance_type` - (Optional) The type of machine to use for worker nodes. Default `t2.medium` (string)
@@ -600,7 +608,6 @@ The following arguments are supported:
 * `region` - (Optional) The AWS Region to create the EKS cluster in. Default `us-west-2` (string)
  `security_groups` - (Optional) List of security groups to use for the cluster. If it's not specified Rancher will create a new security group (list)
 * `service_role` - (Optional) The service role to use to perform the cluster operations in AWS. If it's not specified Rancher will create a new service role (string)
-* `session_token` - (Optional/Sensitive) A session token to use with the client key and secret if applicable (string)
 * `subnets` - (Optional) List of subnets in the virtual network to use. If it's not specified Rancher will create 3 news subnets (list)
 * `user_data` - (Optional/Computed) Pass user-data to the nodes to perform automated configuration tasks (string)
 * `virtual_network` - (Optional) The name of the virtual network to use. If it's not specified Rancher will create a new VPC (string)


### PR DESCRIPTION
What?
----

This commit allows pull the AWS credentials for the EKS cluster from the
standard AWS cli environment variables: `AWS_ACCESS_KEY_ID`,
`AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`

By pulling the credentials from the environment we can ensure that we
always get the latest credentials, including during the delete operation,
and use a external tool to assume the role or get the STS token.

This, combined with update the rancher stored AWS creds before deletion,
solves the issue described [1] were we cannot delete a cluster without
apply first new credentials.

[1] https://github.com/terraform-providers/terraform-provider-rancher2/issues/74

Tests
-----

 - Pulling creds from environment has been unit tested
 - Update the cluster before delete, tested manually as there are no
   integration tests for EKS (AFAIK)