### PR TITLE
Fix: set access_key and secret_key arguments as optional on s3_backup_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ BUG FIXES:
 
 * Fix: `container_resource_limit` argument update issue on `rancher2_namespace` and `rancher2_project` resources update
 * Fix: `sidebar_current` definition on datasources docs
-
+* Fix: set `access_key` and `secret_key` arguments as optional on `s3_backup_config`
 
 ## 1.4.1 (August 16, 2019)
 

--- a/rancher2/schema_cluster_rke_config_services.go
+++ b/rancher2/schema_cluster_rke_config_services.go
@@ -205,7 +205,7 @@ func clusterRKEConfigServicesEtcdBackupConfigS3Fields() map[string]*schema.Schem
 	s := map[string]*schema.Schema{
 		"access_key": {
 			Type:      schema.TypeString,
-			Required:  true,
+			Optional:  true,
 			Sensitive: true,
 		},
 		"bucket_name": {
@@ -230,7 +230,7 @@ func clusterRKEConfigServicesEtcdBackupConfigS3Fields() map[string]*schema.Schem
 		},
 		"secret_key": {
 			Type:      schema.TypeString,
-			Required:  true,
+			Optional:  true,
 			Sensitive: true,
 		},
 	}

--- a/rancher2/structure_cluster_rke_config_services.go
+++ b/rancher2/structure_cluster_rke_config_services.go
@@ -177,7 +177,10 @@ func flattenClusterRKEConfigServicesEtcdBackupConfigS3(in *managementClient.S3Ba
 		return []interface{}{}
 	}
 
-	obj["access_key"] = in.AccessKey
+	if len(in.AccessKey) > 0 {
+		obj["access_key"] = in.AccessKey
+	}
+
 	obj["bucket_name"] = in.BucketName
 	obj["endpoint"] = in.Endpoint
 

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -479,13 +479,13 @@ The following attributes are exported:
 
 ###### Arguments
 
-* `access_key` - (Required/Sensitive) Access key for S3 service (string)
+* `access_key` - (Optional/Sensitive) Access key for S3 service (string)
 * `bucket_name` - (Required) Bucket name for S3 service (string)
 * `custom_ca` - (Optional) Base64 encoded custom CA for S3 service. Use filebase64(<FILE>) for encoding file. Available from rancher v2.2.5 (string)
 * `endpoint` - (Required) Endpoint for S3 service (string)
 * `folder` - (Optional) Folder for S3 service. Available from rancher v2.2.7 (string)
 * `region` - (Optional) Region for S3 service (string)
-* `secret_key` - (Required/Sensitive) Secret key for S3 service (string)
+* `secret_key` - (Optional/Sensitive) Secret key for S3 service (string)
 
 ##### `kube_api`
 

--- a/website/docs/r/etcdBackup.html.markdown
+++ b/website/docs/r/etcdBackup.html.markdown
@@ -68,13 +68,13 @@ The following attributes are exported:
 
 ##### Arguments
 
-* `access_key` - (Required/Sensitive) Access key for S3 service (string)
+* `access_key` - (Optional/Sensitive) Access key for S3 service (string)
 * `bucket_name` - (Required) Bucket name for S3 service (string)
 * `custom_ca` - (Optional) Base64 encoded custom CA for S3 service. Use filebase64(<FILE>) for encoding file. Available from rancher v2.2.5 (string)
 * `endpoint` - (Required) Endpoint for S3 service (string)
 * `folder` - (Optional) Folder for S3 service. Available from rancher v2.2.7 (string)
 * `region` - (Optional) Region for S3 service (string)
-* `secret_key` - (Required/Sensitive) Secret key for S3 service (string)
+* `secret_key` - (Optional/Sensitive) Secret key for S3 service (string)
 
 ## Timeouts
 


### PR DESCRIPTION
Fix issue #31 