### PR TITLE
Fix: crash `rancher2_cluster` datasource  if `enableNetworkPolicy` doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ BUG FIXES:
 * Fix: `container_resource_limit` argument update issue on `rancher2_namespace` and `rancher2_project` resources update
 * Fix: `sidebar_current` definition on datasources docs
 * Fix: set `access_key` and `secret_key` arguments as optional on `s3_backup_config`
+* Fix: crash `rancher2_cluster`  datasource and resource if `enableNetworkPolicy` doesn't exist
 
 ## 1.4.1 (August 16, 2019)
 

--- a/rancher2/structure_cluster.go
+++ b/rancher2/structure_cluster.go
@@ -73,7 +73,10 @@ func flattenCluster(d *schema.ResourceData, in *Cluster, clusterRegToken *manage
 	}
 
 	d.Set("enable_cluster_monitoring", in.EnableClusterMonitoring)
-	d.Set("enable_network_policy", *in.EnableNetworkPolicy)
+
+	if in.EnableNetworkPolicy != nil {
+		d.Set("enable_network_policy", *in.EnableNetworkPolicy)
+	}
 
 	err = d.Set("annotations", toMapInterface(in.Annotations))
 	if err != nil {


### PR DESCRIPTION
Fix issue #119 