### PR TITLE
Add missing url path for rancher_url

### DIFF
--- a/website/docs/r/authConfigAzureAD.html.markdown
+++ b/website/docs/r/authConfigAzureAD.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 * `application_secret` - (Required/Sensitive) AzureAD auth application secret (string)
 * `auth_endpoint` - (Required) AzureAD auth endpoint (string)
 * `graph_endpoint` - (Required) AzureAD graph endpoint (string)
-* `rancher_url` - (Required) Rancher URL (string)
+* `rancher_url` - (Required) Rancher URL (string). "<rancher_url>/verify-auth-azure"
 * `tenant_id` - (Required) AzureAD tenant ID (string)
 * `token_endpoint` - (Required) AzureAD token endpoint (string)
 * `endpoint` - (Optional) AzureAD endpoint. Default `https://login.microsoftonline.com/` (string)


### PR DESCRIPTION
When creating the azure ad authentication via the web interface in rancher the URL vill have this path:

`*/verify-auth-azure`

In terraform you need to specify that path otherwise you get into a login loop when trying to login with an azure ad account.