### PR TITLE
Fix rancher2_app and rancher_multi_cluster_app to consistent manage external_id and template_version_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-
+* Fix `expandAppExternalID` function on `rancher2_app` resource. Function was generating a wrong `ExternalID` catalog URL, on `cluster` and `project` scope
+* Fix `flattenMultiClusterApp` function on `rancher2_multi-cluster_app` resource. Function wasn't updating fine `catalog_name`, `template_name` and/or `template_version` arguments, when contains char `-`
 
 ## 1.5.0 (September 06, 2019)
 

--- a/rancher2/data_source_rancher2_multi_cluster_app.go
+++ b/rancher2/data_source_rancher2_multi_cluster_app.go
@@ -125,5 +125,10 @@ func dataSourceRancher2MultiClusterAppRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("[ERROR] found %d multi cluster app with name \"%s\"", count, name)
 	}
 
-	return flattenMultiClusterApp(d, &multiClusterApps.Data[0])
+	templateVersion, err := client.TemplateVersion.ByID(multiClusterApps.Data[0].TemplateVersionID)
+	if err != nil {
+		return err
+	}
+
+	return flattenMultiClusterApp(d, &multiClusterApps.Data[0], templateVersion.ExternalID)
 }

--- a/rancher2/resource_rancher2_multi_cluster_app.go
+++ b/rancher2/resource_rancher2_multi_cluster_app.go
@@ -94,7 +94,12 @@ func resourceRancher2MultiClusterAppRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	return flattenMultiClusterApp(d, multiClusterApp)
+	templateVersion, err := client.TemplateVersion.ByID(multiClusterApp.TemplateVersionID)
+	if err != nil {
+		return err
+	}
+
+	return flattenMultiClusterApp(d, multiClusterApp, templateVersion.ExternalID)
 }
 
 func resourceRancher2MultiClusterAppUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/rancher2/structure_app.go
+++ b/rancher2/structure_app.go
@@ -7,6 +7,10 @@ import (
 	projectClient "github.com/rancher/types/client/project/v3"
 )
 
+const (
+	AppTemplateExternalIDPrefix = "catalog://?"
+)
+
 // Flatteners
 
 func flattenAppExternalID(d *schema.ResourceData, in string) {
@@ -14,7 +18,7 @@ func flattenAppExternalID(d *schema.ResourceData, in string) {
 	//Cluster catalog url: catalog://?catalog=c-XXXXX/test&type=clusterCatalog&template=test&version=1.23.0
 	//Project catalog url: catalog://?catalog=p-XXXXX/test&type=projectCatalog&template=test&version=1.23.0
 
-	str := strings.TrimPrefix(in, "catalog://?")
+	str := strings.TrimPrefix(in, AppTemplateExternalIDPrefix)
 	values := strings.Split(str, "&")
 	out := make(map[string]string, len(values))
 	for _, v := range values {
@@ -91,20 +95,20 @@ func expandAppExternalID(in *schema.ResourceData) string {
 	appName := in.Get("template_name").(string)
 	appVersion := in.Get("template_version").(string)
 
-	catalogPart := "catalog://?catalog=" + catalogName
-	appNamePart := "&template=" + appName
-	appVersionPart := "&version=" + appVersion
-
 	if strings.HasPrefix(catalogName, "c-") {
 		catalogName = strings.Replace(catalogName, ":", "/", -1)
-		catalogPart = catalogPart + "&type=clusterCatalog"
+		catalogName = catalogName + "&type=clusterCatalog"
 	}
 	if strings.HasPrefix(catalogName, "p-") {
 		catalogName = strings.Replace(catalogName, ":", "/", -1)
-		catalogPart = catalogPart + "&type=projectCatalog"
+		catalogName = catalogName + "&type=projectCatalog"
 	}
 
-	return catalogPart + appNamePart + appVersionPart
+	catalogPart := "catalog=" + catalogName
+	appNamePart := "&template=" + appName
+	appVersionPart := "&version=" + appVersion
+
+	return AppTemplateExternalIDPrefix + catalogPart + appNamePart + appVersionPart
 }
 
 func expandApp(in *schema.ResourceData) *projectClient.App {

--- a/rancher2/structure_app_test.go
+++ b/rancher2/structure_app_test.go
@@ -9,12 +9,16 @@ import (
 )
 
 var (
-	testAppConf      *projectClient.App
-	testAppInterface map[string]interface{}
+	testAppConfGlobal       *projectClient.App
+	testAppInterfaceGlobal  map[string]interface{}
+	testAppConfCluster      *projectClient.App
+	testAppInterfaceCluster map[string]interface{}
+	testAppConfProject      *projectClient.App
+	testAppInterfaceProject map[string]interface{}
 )
 
 func init() {
-	testAppConf = &projectClient.App{
+	testAppConfGlobal = &projectClient.App{
 		ExternalID:      "catalog://?catalog=test&template=test&version=1.23.0",
 		Name:            "name",
 		ProjectID:       "project:test",
@@ -35,9 +39,97 @@ func init() {
 			"option2": "value2",
 		},
 	}
-	testAppInterface = map[string]interface{}{
+	testAppInterfaceGlobal = map[string]interface{}{
 		"catalog_name": "test",
 		//"external_id":      "catalog://?catalog=test&template=test&version=1.23.0",
+		"name":             "name",
+		"project_id":       "project:test",
+		"target_namespace": "target_namespace",
+		"template_name":    "test",
+		"answers": map[string]interface{}{
+			"answers1": "one",
+			"answers2": "two",
+		},
+		"description":      "description",
+		"revision_id":      "revision_id",
+		"template_version": "1.23.0",
+		"values_yaml":      "values_yaml",
+		"annotations": map[string]interface{}{
+			"node_one": "one",
+			"node_two": "two",
+		},
+		"labels": map[string]interface{}{
+			"option1": "value1",
+			"option2": "value2",
+		},
+	}
+	testAppConfCluster = &projectClient.App{
+		ExternalID:      "catalog://?catalog=c-XXXXX/test&type=clusterCatalog&template=test&version=1.23.0",
+		Name:            "name",
+		ProjectID:       "project:test",
+		TargetNamespace: "target_namespace",
+		Answers: map[string]string{
+			"answers1": "one",
+			"answers2": "two",
+		},
+		Description:   "description",
+		AppRevisionID: "revision_id",
+		ValuesYaml:    "values_yaml",
+		Annotations: map[string]string{
+			"node_one": "one",
+			"node_two": "two",
+		},
+		Labels: map[string]string{
+			"option1": "value1",
+			"option2": "value2",
+		},
+	}
+	testAppInterfaceCluster = map[string]interface{}{
+		"catalog_name":     "c-XXXXX:test",
+		"name":             "name",
+		"project_id":       "project:test",
+		"target_namespace": "target_namespace",
+		"template_name":    "test",
+		"answers": map[string]interface{}{
+			"answers1": "one",
+			"answers2": "two",
+		},
+		"description":      "description",
+		"revision_id":      "revision_id",
+		"template_version": "1.23.0",
+		"values_yaml":      "values_yaml",
+		"annotations": map[string]interface{}{
+			"node_one": "one",
+			"node_two": "two",
+		},
+		"labels": map[string]interface{}{
+			"option1": "value1",
+			"option2": "value2",
+		},
+	}
+	testAppConfProject = &projectClient.App{
+		ExternalID:      "catalog://?catalog=p-XXXXX/test&type=projectCatalog&template=test&version=1.23.0",
+		Name:            "name",
+		ProjectID:       "project:test",
+		TargetNamespace: "target_namespace",
+		Answers: map[string]string{
+			"answers1": "one",
+			"answers2": "two",
+		},
+		Description:   "description",
+		AppRevisionID: "revision_id",
+		ValuesYaml:    "values_yaml",
+		Annotations: map[string]string{
+			"node_one": "one",
+			"node_two": "two",
+		},
+		Labels: map[string]string{
+			"option1": "value1",
+			"option2": "value2",
+		},
+	}
+	testAppInterfaceProject = map[string]interface{}{
+		"catalog_name":     "p-XXXXX:test",
 		"name":             "name",
 		"project_id":       "project:test",
 		"target_namespace": "target_namespace",
@@ -68,8 +160,16 @@ func TestFlattenApp(t *testing.T) {
 		ExpectedOutput map[string]interface{}
 	}{
 		{
-			testAppConf,
-			testAppInterface,
+			testAppConfGlobal,
+			testAppInterfaceGlobal,
+		},
+		{
+			testAppConfCluster,
+			testAppInterfaceCluster,
+		},
+		{
+			testAppConfProject,
+			testAppInterfaceProject,
 		},
 	}
 
@@ -97,8 +197,16 @@ func TestExpandApp(t *testing.T) {
 		ExpectedOutput interface{}
 	}{
 		{
-			testAppInterface,
-			testAppConf,
+			testAppInterfaceGlobal,
+			testAppConfGlobal,
+		},
+		{
+			testAppInterfaceCluster,
+			testAppConfCluster,
+		},
+		{
+			testAppInterfaceProject,
+			testAppConfProject,
 		},
 	}
 

--- a/rancher2/structure_multi_cluster_app_test.go
+++ b/rancher2/structure_multi_cluster_app_test.go
@@ -20,6 +20,7 @@ var (
 	testMultiClusterAppRollingUpdateInterface   []interface{}
 	testMultiClusterAppUpgradeStrategyConf      *managementClient.UpgradeStrategy
 	testMultiClusterAppUpgradeStrategyInterface []interface{}
+	testMultiClusterAppExternalID               string
 	testMultiClusterAppConf                     *managementClient.MultiClusterApp
 	testMultiClusterAppInterface                map[string]interface{}
 )
@@ -96,6 +97,7 @@ func init() {
 			"rolling_update": testMultiClusterAppRollingUpdateInterface,
 		},
 	}
+	testMultiClusterAppExternalID = "catalog://?catalog=test&template=test-demo&version=1.23.0"
 	testMultiClusterAppConf = &managementClient.MultiClusterApp{
 		Name:                 "foo",
 		Targets:              testMultiClusterAppTargetsConf,
@@ -158,7 +160,7 @@ func TestFlattenMultiClusterApp(t *testing.T) {
 
 	for _, tc := range cases {
 		output := schema.TestResourceDataRaw(t, multiClusterAppFields(), map[string]interface{}{})
-		err := flattenMultiClusterApp(output, tc.Input)
+		err := flattenMultiClusterApp(output, tc.Input, testMultiClusterAppExternalID)
 		if err != nil {
 			t.Fatalf("[ERROR] on flattener: %#v", err)
 		}
@@ -167,7 +169,7 @@ func TestFlattenMultiClusterApp(t *testing.T) {
 			expectedOutput[k] = output.Get(k)
 		}
 		if !reflect.DeepEqual(expectedOutput, tc.ExpectedOutput) {
-			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven: %#v", tc.ExpectedOutput, output)
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven: %#v", tc.ExpectedOutput, expectedOutput)
 		}
 	}
 }

--- a/website/docs/r/app.html.markdown
+++ b/website/docs/r/app.html.markdown
@@ -72,19 +72,18 @@ resource "rancher2_app" "foo" {
 
 The following arguments are supported:
 
-* `catalog_name` - (Required) Catalog name of the app. For use scoped catalogs:
+* `catalog_name` - (Required) Catalog name of the app. If modified, app will be upgraded. For use scoped catalogs:
   * add cluster ID before name, `c-XXXXX:<name>`
   * add project ID before name, `p-XXXXX:<name>`
-* `external_id` - (Required) The url of the app template on a catalog. If modified, app will be upgraded (string)
 * `name` - (Required/ForceNew) The name of the app (string)
 * `project_id` - (Required/ForceNew) The project id where the app will be installed (string)
 * `target_namespace` - (Required/ForceNew) The namespace name where the app will be installed (string)
-* `template_name` - (Required) Template name of the app (string)
+* `template_name` - (Required) Template name of the app. If modified, app will be upgraded (string)
 * `answers` - (Optional/Computed) Answers for the app template. If modified, app will be upgraded (map)
 * `description` - (Optional/Computed) Description for the app (string)
 * `force_upgrade` - (Optional) Force app upgrade (string)
 * `revision_id` - (Optional/Computed) Current revision id for the app. If modified, If this argument is provided or modified, app will be rollbacked to `revision_id` (string)
-* `template_version` - (Optional/Computed) Template version of the app. Default: `latest` (string)
+* `template_version` - (Optional/Computed) Template version of the app. If modified, app will be upgraded. Default: `latest` (string)
 * `values_yaml` - (Optional/Computed) values.yaml file content for the app template. If modified, app will be upgraded (string)
 * `annotations` - (Optional/Computed) Annotations for App object (map)
 * `labels` - (Optional/Computed) Labels for App object (map)
@@ -94,6 +93,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - (Computed) The ID of the resource (string)
+* `external_id` - (Computed) The url of the app template on a catalog (string)
 
 ## Timeouts
 

--- a/website/docs/r/multiClusterApp.html.markdown
+++ b/website/docs/r/multiClusterApp.html.markdown
@@ -85,6 +85,13 @@ The following arguments are supported:
 * `annotations` - (Optional/Computed) Annotations for multi cluster app object (map)
 * `labels` - (Optional/Computed) Labels for multi cluster app object (map)
 
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - (Computed) The ID of the resource (string)
+* `template_version_id` - (Computed) The multi cluster app template version ID (string)
+
 ## Nested blocks
 
 ### `targets`
@@ -124,13 +131,6 @@ The following arguments are supported:
 
 * `batch_size` - (Optional) Rolling update batch size. Default `1` (int)
 * `interval` - (Optional) Rolling update interval. Default `1` (int)
-
-## Attributes Reference
-
-The following attributes are exported:
-
-* `id` - (Computed) The ID of the resource (string)
-* `template_version_id` - (Computed) The multi cluster app template version ID (string)
 
 ## Timeouts
 


### PR DESCRIPTION
This PR contains:
* Fix `expandAppExternalID` function on `rancher2_app` resource. Function was generating a wrong `ExternalID` catalog URL, on `cluster` and `project` scope
* Fix `flattenMultiClusterApp` function on `rancher2_multi-cluster_app` resource. Function wasn't updating fine `catalog_name`, `template_name` and/or `template_version` arguments, when contains char `-`