### PR TITLE
Fix: Allow AKS monitoring to be disabled

### DIFF
--- a/rancher2/schema_cluster_aks_config.go
+++ b/rancher2/schema_cluster_aks_config.go
@@ -38,7 +38,7 @@ type AzureKubernetesServiceConfig struct {
 	DNSServiceIP                       string            `json:"dnsServiceIp,omitempty" yaml:"dnsServiceIp,omitempty"`
 	DockerBridgeCIDR                   string            `json:"dockerBridgeCidr,omitempty" yaml:"dockerBridgeCidr,omitempty"`
 	EnableHTTPApplicationRouting       bool              `json:"enableHttpApplicationRouting,omitempty" yaml:"enableHttpApplicationRouting,omitempty"`
-	EnableMonitoring                   bool              `json:"enableMonitoring,omitempty" yaml:"enableMonitoring,omitempty"`
+	EnableMonitoring                   *bool             `json:"enableMonitoring,omitempty" yaml:"enableMonitoring,omitempty"`
 	KubernetesVersion                  string            `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
 	Location                           string            `json:"location,omitempty" yaml:"location,omitempty"`
 	LogAnalyticsWorkspace              string            `json:"logAnalyticsWorkspace,omitempty" yaml:"logAnalyticsWorkspace,omitempty"`

--- a/rancher2/structure_cluster_aks_config.go
+++ b/rancher2/structure_cluster_aks_config.go
@@ -77,7 +77,7 @@ func flattenClusterAKSConfig(in *AzureKubernetesServiceConfig) ([]interface{}, e
 	}
 
 	obj["enable_http_application_routing"] = in.EnableHTTPApplicationRouting
-	obj["enable_monitoring"] = in.EnableMonitoring
+	obj["enable_monitoring"] = *in.EnableMonitoring
 
 	if len(in.KubernetesVersion) > 0 {
 		obj["kubernetes_version"] = in.KubernetesVersion
@@ -239,7 +239,7 @@ func expandClusterAKSConfig(p []interface{}, name string) (*AzureKubernetesServi
 	}
 
 	if v, ok := in["enable_monitoring"].(bool); ok {
-		obj.EnableMonitoring = v
+		obj.EnableMonitoring = &v
 	}
 
 	if v, ok := in["kubernetes_version"].(string); ok && len(v) > 0 {

--- a/rancher2/structure_cluster_aks_config_test.go
+++ b/rancher2/structure_cluster_aks_config_test.go
@@ -30,7 +30,7 @@ func init() {
 		DNSServiceIP:                       "dns_ip",
 		DockerBridgeCIDR:                   "192.168.1.0/16",
 		EnableHTTPApplicationRouting:       true,
-		EnableMonitoring:                   true,
+		EnableMonitoring:                   newTrue(),
 		KubernetesVersion:                  "version",
 		Location:                           "location",
 		LogAnalyticsWorkspace:              "log_analytics_workspace",


### PR DESCRIPTION
`EnableMonitoring` attribute was previously not included in the marshaled JSON. Following the pattern for EKS/GKE configurations, I've switched this to a `*bool` type and updated the related code & tests.

This means `enabled_monitoring = false` is now functional for AKS clusters.