### PR TITLE
Added always_pull_images argument to kube_api for rke clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## 1.6.1 (Unreleased)
+
+FEATURES:
+
+ENHANCEMENTS:
+
+* Added `always_pull_images` argument on `kube_api` argument on `rke_config` argument for `rancher2_clusters` resource
+
+BUG FIXES:
+
 ## 1.6.0 (October 08, 2019)
 
 FEATURES:

--- a/rancher2/schema_cluster_rke_config_services.go
+++ b/rancher2/schema_cluster_rke_config_services.go
@@ -158,6 +158,11 @@ func clusterRKEConfigServicesKubeControllerFields() map[string]*schema.Schema {
 
 func clusterRKEConfigServicesKubeAPIFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
+		"always_pull_images": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
 		"extra_args": {
 			Type:     schema.TypeMap,
 			Optional: true,

--- a/rancher2/structure_cluster_rke_config_services.go
+++ b/rancher2/structure_cluster_rke_config_services.go
@@ -136,6 +136,8 @@ func flattenClusterRKEConfigServicesKubeAPI(in *managementClient.KubeAPIService)
 		return []interface{}{}, nil
 	}
 
+	obj["always_pull_images"] = in.AlwaysPullImages
+
 	if len(in.ExtraArgs) > 0 {
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
 	}
@@ -514,6 +516,10 @@ func expandClusterRKEConfigServicesKubeAPI(p []interface{}) (*managementClient.K
 		return obj, nil
 	}
 	in := p[0].(map[string]interface{})
+
+	if v, ok := in["always_pull_images"].(bool); ok {
+		obj.AlwaysPullImages = v
+	}
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)

--- a/rancher2/structure_cluster_rke_config_services_test.go
+++ b/rancher2/structure_cluster_rke_config_services_test.go
@@ -122,6 +122,7 @@ func init() {
 		},
 	}
 	testClusterRKEConfigServicesKubeAPIConf = &managementClient.KubeAPIService{
+		AlwaysPullImages: true,
 		ExtraArgs: map[string]string{
 			"arg_one": "one",
 			"arg_two": "two",
@@ -135,6 +136,7 @@ func init() {
 	}
 	testClusterRKEConfigServicesKubeAPIInterface = []interface{}{
 		map[string]interface{}{
+			"always_pull_images": true,
 			"extra_args": map[string]interface{}{
 				"arg_one": "one",
 				"arg_two": "two",

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -579,6 +579,7 @@ The following attributes are exported:
 
 ###### Arguments
 
+* `always_pull_images` - (Optional) Always pull kube API images. Default: `false` (bool)
 * `extra_args` - (Optional/Computed) Extra arguments for kube API service (map)
 * `extra_binds` - (Optional) Extra binds for kube API service (list)
 * `extra_env` - (Optional) Extra environment for kube API service (list)


### PR DESCRIPTION
Fix issue #152 