### PR TITLE
Add Not Null (API states has-value) to Alerts/Metric

### DIFF
--- a/rancher2/schema_alert_rule.go
+++ b/rancher2/schema_alert_rule.go
@@ -22,6 +22,7 @@ const (
 	metricRuleComparisonLessOrEqual             = "less-or-equal"
 	metricRuleComparisonLessThan                = "less-than"
 	metricRuleComparisonNotEqual                = "not-equal"
+	metricRuleComparisonNotNull                 = "has-value"
 	nodeRuleConditionCPU                        = "cpu"
 	nodeRuleConditionMem                        = "mem"
 	nodeRuleConditionNotReady                   = "notready"
@@ -50,6 +51,7 @@ var (
 		metricRuleComparisonLessOrEqual,
 		metricRuleComparisonLessThan,
 		metricRuleComparisonNotEqual,
+		metricRuleComparisonNotNull,
 	}
 	nodeRuleConditions = []string{
 		nodeRuleConditionCPU,

--- a/website/docs/r/clusterAlertRule.html.markdown
+++ b/website/docs/r/clusterAlertRule.html.markdown
@@ -73,7 +73,7 @@ The following attributes are exported:
 * `duration` - (Required) Metric rule duration (string)
 * `expression` - (Required) Metric rule expression (string)
 * `threshold_value` - (Required) Metric rule threshold value (float64)
-* `comparison` - (Optional) Metric rule comparison. Supported values : `"equal" | "greater-or-equal" | "greater-than" | "less-or-equal" | "less-than" | "not-equal"`. Default: `equal`  (string)
+* `comparison` - (Optional) Metric rule comparison. Supported values : `"equal" | "greater-or-equal" | "greater-than" | "less-or-equal" | "less-than" | "not-equal" | "has-value"`. Default: `equal`  (string)
 * `description` - (Optional) Metric rule description (string)
 
 ### `node_rule`

--- a/website/docs/r/projectAlertRule.html.markdown
+++ b/website/docs/r/projectAlertRule.html.markdown
@@ -89,7 +89,7 @@ The following attributes are exported:
 * `duration` - (Required) Metric rule duration (string)
 * `expression` - (Required) Metric rule expression (string)
 * `threshold_value` - (Required) Metric rule threshold value (float64)
-* `comparison` - (Optional) Metric rule comparison. Supported values : `"equal" | "greater-or-equal" | "greater-than" | "less-or-equal" | "less-than" | "not-equal"`. Default: `equal`  (string)
+* `comparison` - (Optional) Metric rule comparison. Supported values : `"equal" | "greater-or-equal" | "greater-than" | "less-or-equal" | "less-than" | "not-equal" | "has-value"`. Default: `equal`  (string)
 * `description` - (Optional) Metric rule description (string)
 
 ### `pod_rule`


### PR DESCRIPTION
Rancher Alerts allow for metric rule of Not Null (API states this is has-value so mapped accordingly). 

Tested against Rancher 2.3.3