### PR TITLE
Add Send Resolved to Notifier Resource

### DIFF
--- a/rancher2/resource_rancher2_notifier.go
+++ b/rancher2/resource_rancher2_notifier.go
@@ -107,11 +107,12 @@ func resourceRancher2NotifierUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	update := map[string]interface{}{
-		"name":        d.Get("name").(string),
-		"description": d.Get("description").(string),
-		"clusterId":   d.Get("cluster_id").(string),
-		"annotations": toMapString(d.Get("annotations").(map[string]interface{})),
-		"labels":      toMapString(d.Get("labels").(map[string]interface{})),
+		"name":         d.Get("name").(string),
+		"description":  d.Get("description").(string),
+		"clusterId":    d.Get("cluster_id").(string),
+		"sendResolved": d.Get("send_resolved").(bool),
+		"annotations":  toMapString(d.Get("annotations").(map[string]interface{})),
+		"labels":       toMapString(d.Get("labels").(map[string]interface{})),
 	}
 
 	if notifier.PagerdutyConfig != nil && d.HasChange("pagerduty_config") {

--- a/rancher2/resource_rancher2_notifier_test.go
+++ b/rancher2/resource_rancher2_notifier_test.go
@@ -37,6 +37,7 @@ func init() {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "true"
   description = "Terraform notifier acceptance test"
   pagerduty_config {
     service_key = "XXXXXXXX"
@@ -49,6 +50,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "false"
   description = "Terraform notifier acceptance test - updated"
   pagerduty_config {
     service_key = "YYYYYYYY"
@@ -61,6 +63,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "true"
   description = "Terraform notifier acceptance test"
   pagerduty_config {
     service_key = "XXXXXXXX"
@@ -73,6 +76,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "true"
   description = "Terraform notifier acceptance test"
   slack_config {
     default_recipient = "XXXXXXXX"
@@ -86,6 +90,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "false"
   description = "Terraform notifier acceptance test - updated"
   slack_config {
     default_recipient = "YYYYYYYY"
@@ -99,6 +104,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "true"
   description = "Terraform notifier acceptance test"
   slack_config {
     default_recipient = "XXXXXXXX"
@@ -112,6 +118,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "true"
   description = "Terraform notifier acceptance test"
   smtp_config {
     default_recipient = "XXXXXXXX"
@@ -127,6 +134,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "false"
   description = "Terraform notifier acceptance test - updated"
   smtp_config {
     default_recipient = "YYYYYYYY"
@@ -142,6 +150,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "true"
   description = "Terraform notifier acceptance test"
   smtp_config {
     default_recipient = "XXXXXXXX"
@@ -157,6 +166,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "true"
   description = "Terraform notifier acceptance test"
   webhook_config {
     url = "http://url.test.io"
@@ -169,6 +179,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "false"
   description = "Terraform notifier acceptance test - updated"
   webhook_config {
     url = "http://url2.test.io"
@@ -181,6 +192,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "true"
   description = "Terraform notifier acceptance test"
   webhook_config {
     url = "http://url.test.io"
@@ -193,6 +205,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "true"
   description = "Terraform notifier acceptance test"
   wechat_config {
     agent = "agent_id"
@@ -208,6 +221,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "false"
   description = "Terraform notifier acceptance test - updated"
   wechat_config {
     agent = "agent_id"
@@ -223,6 +237,7 @@ resource "rancher2_notifier" "foo" {
 resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "` + testAccRancher2ClusterID + `"
+  send_resolved = "true"
   description = "Terraform notifier acceptance test"
   wechat_config {
     agent = "agent_id"
@@ -250,6 +265,7 @@ func TestAccRancher2Notifier_basic_Pagerduty(t *testing.T) {
 					testAccCheckRancher2NotifierExists(testAccRancher2NotifierType+".foo", notifier),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "description", "Terraform notifier acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "send_resolved", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "pagerduty_config.0.service_key", "XXXXXXXX"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "pagerduty_config.0.proxy_url", "http://proxy.test.io"),
 				),
@@ -260,6 +276,7 @@ func TestAccRancher2Notifier_basic_Pagerduty(t *testing.T) {
 					testAccCheckRancher2NotifierExists(testAccRancher2NotifierType+".foo", notifier),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "description", "Terraform notifier acceptance test - updated"),
+					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "send_resolved", "false"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "pagerduty_config.0.proxy_url", "http://proxy2.test.io"),
 				),
 			},
@@ -269,6 +286,7 @@ func TestAccRancher2Notifier_basic_Pagerduty(t *testing.T) {
 					testAccCheckRancher2NotifierExists(testAccRancher2NotifierType+".foo", notifier),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "description", "Terraform notifier acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "send_resolved", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "pagerduty_config.0.service_key", "XXXXXXXX"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "pagerduty_config.0.proxy_url", "http://proxy.test.io"),
 				),
@@ -311,6 +329,7 @@ func TestAccRancher2Notifier_basic_Slack(t *testing.T) {
 					testAccCheckRancher2NotifierExists(testAccRancher2NotifierType+".foo", notifier),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "description", "Terraform notifier acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "send_resolved", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "slack_config.0.default_recipient", "XXXXXXXX"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "slack_config.0.url", "http://url.test.io"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "slack_config.0.proxy_url", "http://proxy.test.io"),
@@ -332,6 +351,7 @@ func TestAccRancher2Notifier_basic_Slack(t *testing.T) {
 					testAccCheckRancher2NotifierExists(testAccRancher2NotifierType+".foo", notifier),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "description", "Terraform notifier acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "send_resolved", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "slack_config.0.default_recipient", "XXXXXXXX"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "slack_config.0.url", "http://url.test.io"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "slack_config.0.proxy_url", "http://proxy.test.io"),
@@ -375,6 +395,7 @@ func TestAccRancher2Notifier_basic_SMTP(t *testing.T) {
 					testAccCheckRancher2NotifierExists(testAccRancher2NotifierType+".foo", notifier),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "description", "Terraform notifier acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "send_resolved", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "smtp_config.0.default_recipient", "XXXXXXXX"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "smtp_config.0.host", "host.test.io"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "smtp_config.0.sender", "sender@test.io"),
@@ -396,6 +417,7 @@ func TestAccRancher2Notifier_basic_SMTP(t *testing.T) {
 					testAccCheckRancher2NotifierExists(testAccRancher2NotifierType+".foo", notifier),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "description", "Terraform notifier acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "send_resolved", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "smtp_config.0.default_recipient", "XXXXXXXX"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "smtp_config.0.host", "host.test.io"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "smtp_config.0.sender", "sender@test.io"),
@@ -439,6 +461,7 @@ func TestAccRancher2Notifier_basic_Webhook(t *testing.T) {
 					testAccCheckRancher2NotifierExists(testAccRancher2NotifierType+".foo", notifier),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "description", "Terraform notifier acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "send_resolved", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "webhook_config.0.url", "http://url.test.io"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "webhook_config.0.proxy_url", "http://proxy.test.io"),
 				),
@@ -458,6 +481,7 @@ func TestAccRancher2Notifier_basic_Webhook(t *testing.T) {
 					testAccCheckRancher2NotifierExists(testAccRancher2NotifierType+".foo", notifier),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "description", "Terraform notifier acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "send_resolved", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "webhook_config.0.url", "http://url.test.io"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "webhook_config.0.proxy_url", "http://proxy.test.io"),
 				),
@@ -500,6 +524,7 @@ func TestAccRancher2Notifier_basic_Wechat(t *testing.T) {
 					testAccCheckRancher2NotifierExists(testAccRancher2NotifierType+".foo", notifier),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "description", "Terraform notifier acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "send_resolved", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "wechat_config.0.default_recipient", "XXXXXXXX"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "wechat_config.0.secret", "XXXXXXXX"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "wechat_config.0.proxy_url", "http://proxy.test.io"),
@@ -521,6 +546,7 @@ func TestAccRancher2Notifier_basic_Wechat(t *testing.T) {
 					testAccCheckRancher2NotifierExists(testAccRancher2NotifierType+".foo", notifier),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "name", "foo"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "description", "Terraform notifier acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "send_resolved", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "wechat_config.0.default_recipient", "XXXXXXXX"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "wechat_config.0.secret", "XXXXXXXX"),
 					resource.TestCheckResourceAttr(testAccRancher2NotifierType+".foo", "wechat_config.0.proxy_url", "http://proxy.test.io"),

--- a/rancher2/schema_notifier.go
+++ b/rancher2/schema_notifier.go
@@ -28,6 +28,7 @@ func notifierFields() map[string]*schema.Schema {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Description: "Notifier send resolved",
+			Default:     false,
 		},
 		"pagerduty_config": &schema.Schema{
 			Type:          schema.TypeList,

--- a/rancher2/schema_notifier.go
+++ b/rancher2/schema_notifier.go
@@ -24,6 +24,11 @@ func notifierFields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Notifier description",
 		},
+		"send_resolved": &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Notifier send resolved",
+		},
 		"pagerduty_config": &schema.Schema{
 			Type:          schema.TypeList,
 			MaxItems:      1,

--- a/rancher2/structure_notifier.go
+++ b/rancher2/structure_notifier.go
@@ -22,6 +22,8 @@ func flattenNotifier(d *schema.ResourceData, in *managementClient.Notifier) erro
 		d.Set("description", in.Description)
 	}
 
+	d.Set("send_resolved", in.SendResolved)
+
 	if in.PagerdutyConfig != nil {
 		v, ok := d.Get("pagerduty_config").([]interface{})
 		if !ok {
@@ -98,6 +100,10 @@ func expandNotifier(in *schema.ResourceData) (*managementClient.Notifier, error)
 
 	if v, ok := in.Get("description").(string); ok && len(v) > 0 {
 		obj.Description = v
+	}
+
+	if v, ok := in.Get("send_resolved").(bool); ok {
+		obj.SendResolved = v
 	}
 
 	if v, ok := in.Get("pagerduty_config").([]interface{}); ok && len(v) > 0 {

--- a/website/docs/d/notifier.html.markdown
+++ b/website/docs/d/notifier.html.markdown
@@ -28,6 +28,7 @@ data "rancher2_notifier" "foo" {
 
 * `id` - (Computed) The ID of the resource (string)
 * `description` - (Computed) The notifier description (string)
+* `send_resolved` - (Computed) If the notifier sends resolved notifications (bool)
 * `pagerduty_config` - (Computed) Pagerduty config for notifier (list maxitems:1)
 * `slack_config` - (Computed) Slack config for notifier (list maxitems:1)
 * `smtp_config` - (Computed) SMTP config for notifier (list maxitems:1)

--- a/website/docs/r/notifier.html.markdown
+++ b/website/docs/r/notifier.html.markdown
@@ -18,6 +18,7 @@ resource "rancher2_notifier" "foo" {
   name = "foo"
   cluster_id = "<cluster_id>"
   description = "Terraform notifier acceptance test"
+  send_resolved = "true"
   pagerduty_config {
     service_key = "XXXXXXXX"
     proxy_url = "http://proxy.test.io"
@@ -32,6 +33,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the notifier (string)
 * `cluster_id` - (Required/ForceNew) The cluster id where create notifier (string)
 * `description` - (Optional) The notifier description (string)
+* `send_resolved` = (Optional) Enable the notifier to send resolved notifications. Default `false` (bool)
 * `pagerduty_config` - (Optional) Pagerduty config for notifier (list maxitems:1)
 * `slack_config` - (Optional) Slack config for notifier (list maxitems:1)
 * `smtp_config` - (Optional) SMTP config for notifier (list maxitems:1)


### PR DESCRIPTION
Add send-resolve to the notifier resource. tested on Rancher 2.3.3 but had issues getting make testacc working successfully; appreciate if anyone has a working test env. that could verify the tests for me, otherwise I'll continue to get a full acceptance test working when I have the time to do so. 