### PR TITLE
Added node template support for hetzner cloud

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/terraform-providers/terraform-provider-rancher2
 go 1.12
 
 require (
-	github.com/google/btree v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.2.0
+	github.com/hashicorp/terraform v0.12.19
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
 	github.com/rancher/norman v0.0.0-20191126011629-6269ccdbeace
 	github.com/rancher/types v0.0.0-20191126013101-de3dc217d60f

--- a/rancher2/resource_rancher2_node_template.go
+++ b/rancher2/resource_rancher2_node_template.go
@@ -146,6 +146,8 @@ func resourceRancher2NodeTemplateUpdate(d *schema.ResourceData, meta interface{}
 		update["azureConfig"] = expandAzureConfig(d.Get("azure_config").([]interface{}))
 	case digitaloceanConfigDriver:
 		update["digitaloceanConfig"] = expandDigitaloceanConfig(d.Get("digitalocean_config").([]interface{}))
+	case hetznerConfigDriver:
+		update["hetznerConfig"] = expandHetznercloudConfig(d.Get("hetzner_config").([]interface{}))
 	case openstackConfigDriver:
 		update["openstackConfig"] = expandOpenstackConfig(d.Get("openstack_config").([]interface{}))
 	case vmwarevsphereConfigDriver:

--- a/rancher2/schema_node_template.go
+++ b/rancher2/schema_node_template.go
@@ -14,6 +14,7 @@ type NodeTemplate struct {
 	DigitaloceanConfig  *digitaloceanConfig  `json:"digitaloceanConfig,omitempty" yaml:"digitaloceanConfig,omitempty"`
 	OpenstackConfig     *openstackConfig     `json:"openstackConfig,omitempty" yaml:"openstackConfig,omitempty"`
 	VmwarevsphereConfig *vmwarevsphereConfig `json:"vmwarevsphereConfig,omitempty" yaml:"vmwarevsphereConfig,omitempty"`
+	HetznercloudConfig  *hetznerConfig       `json:"hetznerConfig,omitempty" yaml:"hetznerConfig,omitempty"`
 }
 
 //Schemas
@@ -28,7 +29,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"azure_config", "digitalocean_config", "openstack_config", "vsphere_config"},
+			ConflictsWith: []string{"azure_config", "digitalocean_config", "openstack_config", "hetzner_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: amazonec2ConfigFields(),
 			},
@@ -47,7 +48,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "digitalocean_config", "openstack_config", "vsphere_config"},
+			ConflictsWith: []string{"amazonec2_config", "digitalocean_config", "openstack_config", "hetzner_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: azureConfigFields(),
 			},
@@ -64,7 +65,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "openstack_config", "vsphere_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "openstack_config", "hetzner_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: digitaloceanConfigFields(),
 			},
@@ -108,11 +109,20 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"hetzner_config": &schema.Schema{
+			Type:          schema.TypeList,
+			MaxItems:      1,
+			Optional:      true,
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "openstack_config", "vsphere_config"},
+			Elem: &schema.Resource{
+				Schema: hetznerConfigFields(),
+			},
+		},
 		"openstack_config": &schema.Schema{
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "vsphere_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "hetzner_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: openstackConfigFields(),
 			},
@@ -126,7 +136,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "openstack_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "hetzner_config", "openstack_config"},
 			Elem: &schema.Resource{
 				Schema: vsphereConfigFields(),
 			},

--- a/rancher2/schema_node_template_hetznercloud.go
+++ b/rancher2/schema_node_template_hetznercloud.go
@@ -1,0 +1,69 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+const (
+	hetznerConfigDriver = "hetzner"
+)
+
+//Types
+
+type hetznerConfig struct {
+	APIToken       string `json:"apiToken,omitempty" yaml:"apiToken,omitempty"`
+	Image          string `json:"image,omitempty" yaml:"image,omitempty"`
+	ServerLocation string `json:"serverLocation,omitempty" yaml:"serverLocation,omitempty"`
+	ServerType     string `json:"serverType,omitempty" yaml:"serverType,omitempty"`
+	Networks       string `json:"networks,omitempty" yaml:"networks,omitempty"`
+	Volumes        string `json:"volumes,omitempty" yaml:"volumes,omitempty"`
+	Userdata       string `json:"userData,omitempty" yaml:"userData,omitempty"`
+}
+
+//Schemas
+
+func hetznerConfigFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"api_token": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Hetzner Cloud project API token",
+		},
+		"image": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "ubuntu-18.04",
+			Description: "Hetzner Cloud server image",
+		},
+		"server_location": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "nbg1",
+			Description: "Hetzner Cloud datacenter",
+		},
+		"server_type": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "cx11",
+			Description: "Hetzner Cloud server type",
+		},
+		"networks": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Comma-separated list of network IDs or names which should be attached to the server private network interface",
+		},
+		"volumes": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Comma-separated list of volume IDs or names which should be attached to the server",
+		},
+		"userdata": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Path to file with cloud-init user-data",
+		},
+	}
+
+	return s
+}

--- a/rancher2/schema_node_template_hetznercloud.go
+++ b/rancher2/schema_node_template_hetznercloud.go
@@ -1,7 +1,7 @@
 package rancher2
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 const (

--- a/rancher2/structure_node_template.go
+++ b/rancher2/structure_node_template.go
@@ -30,6 +30,10 @@ func flattenNodeTemplate(d *schema.ResourceData, in *NodeTemplate) error {
 		if in.DigitaloceanConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires digitalocean_config", in.Driver)
 		}
+	case hetznerConfigDriver:
+		if in.HetznercloudConfig == nil {
+			return fmt.Errorf("[ERROR] Node template driver %s requires hetzner_config", in.Driver)
+		}
 	case openstackConfigDriver:
 		if in.OpenstackConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires openstack_config", in.Driver)
@@ -190,6 +194,11 @@ func expandNodeTemplate(in *schema.ResourceData) *NodeTemplate {
 
 	if v, ok := in.Get("engine_storage_driver").(string); ok && len(v) > 0 {
 		obj.EngineStorageDriver = v
+	}
+
+	if v, ok := in.Get("hetzner_config").([]interface{}); ok && len(v) > 0 {
+		obj.HetznercloudConfig = expandHetznercloudConfig(v)
+		obj.Driver = hetznerConfigDriver
 	}
 
 	if v, ok := in.Get("openstack_config").([]interface{}); ok && len(v) > 0 {

--- a/rancher2/structure_node_template_hetznercloud.go
+++ b/rancher2/structure_node_template_hetznercloud.go
@@ -1,0 +1,80 @@
+package rancher2
+
+// Flatteners
+
+func flattenHetznercloudConfig(in *hetznerConfig) []interface{} {
+	obj := make(map[string]interface{})
+	if in == nil {
+		return []interface{}{}
+	}
+
+	if len(in.APIToken) > 0 {
+		obj["api_token"] = in.APIToken
+	}
+
+	if len(in.Image) > 0 {
+		obj["image"] = in.Image
+	}
+
+	if len(in.ServerLocation) > 0 {
+		obj["server_location"] = in.ServerLocation
+	}
+
+	if len(in.ServerType) > 0 {
+		obj["server_type"] = in.ServerType
+	}
+
+	if len(in.Networks) > 0 {
+		obj["networks"] = in.Networks
+	}
+
+	if len(in.Volumes) > 0 {
+		obj["volumes"] = in.Volumes
+	}
+
+	if len(in.Userdata) > 0 {
+		obj["userdata"] = in.Userdata
+	}
+
+	return []interface{}{obj}
+}
+
+// Expanders
+
+func expandHetznercloudConfig(p []interface{}) *hetznerConfig {
+	obj := &hetznerConfig{}
+	if len(p) == 0 || p[0] == nil {
+		return obj
+	}
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["api_token"].(string); ok && len(v) > 0 {
+		obj.APIToken = v
+	}
+
+	if v, ok := in["image"].(string); ok && len(v) > 0 {
+		obj.Image = v
+	}
+
+	if v, ok := in["server_location"].(string); ok && len(v) > 0 {
+		obj.ServerLocation = v
+	}
+
+	if v, ok := in["server_type"].(string); ok && len(v) > 0 {
+		obj.ServerType = v
+	}
+
+	if v, ok := in["networks"].(string); ok && len(v) > 0 {
+		obj.Networks = v
+	}
+
+	if v, ok := in["volumes"].(string); ok && len(v) > 0 {
+		obj.Volumes = v
+	}
+
+	if v, ok := in["userdata"].(string); ok && len(v) > 0 {
+		obj.Userdata = v
+	}
+
+	return obj
+}


### PR DESCRIPTION
This PR is the basis for solving #105. Rather than solving the problem for all providers, this PR adds specific support for the Hetzner Cloud driver.

To make this work, the rancher instance must have the Hetzner Cloud driver installed. The following terraform snippet, shows how this can be achieved:

```terraform
# Add the Hetzner node driver
resource "rancher2_node_driver" "hetzner" {
    active = true
    builtin = false
    description = "Rancher UI driver for the Hetzner Cloud docker driver."
    external_id = "https://github.com/mxschmitt/ui-driver-hetzner"
    name = "hetzner"
    ui_url = "https://storage.googleapis.com/hcloud-rancher-v2-ui-driver/component.js"
    url = "https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases/download/2.0.1/docker-machine-driver-hetzner_2.0.1_linux_amd64.tar.gz"
    whitelist_domains = ["storage.googleapis.com"]
}
```

The `external_id` contains the [link](https://github.com/mxschmitt/ui-driver-hetzner) to the Github repo for the UI. From what I could find, the repo uses a custom [docker machine driver](https://jonasprogrammer.github.io/docker-machine-driver-hetzner/) to do the actual work of setting up the Hetzner VMs.

The following snippet shows how the config can be used to create a node template:

```terraform 
resource "rancher2_node_template" "my_hetzner_node_template" {
  depends_on = [rancher2_node_driver.hetzner]
  engine_install_url = "https://get.docker.com"
  name = "my_hetzner_node_template"
  hetzner_config {
    api_token = <Hetzner Token goes here>
    image = "ubuntu-18.04"
    server_location = "nbg1"
    server_type = "cx11"
  }
}
```

## Caveats

I have not quite figured out how to write the tests for this. The existing examples all use built-in drivers with cloud credentials. Would be happy to finish this, but would need some pointers.