### PR TITLE
add windows_prefered_cluster option to cluster schema/structure

### DIFF
--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -274,6 +274,12 @@ func clusterFields() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
+		"windows_prefered_cluster": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Windows preferred cluster",
+		},
 	}
 
 	return s

--- a/rancher2/structure_cluster.go
+++ b/rancher2/structure_cluster.go
@@ -179,6 +179,8 @@ func flattenCluster(d *schema.ResourceData, in *Cluster, clusterRegToken *manage
 		return err
 	}
 
+	d.Set("windows_prefered_cluster", in.WindowsPreferedCluster)
+
 	return nil
 }
 
@@ -345,6 +347,10 @@ func expandCluster(in *schema.ResourceData) (*Cluster, error) {
 
 	if v, ok := in.Get("labels").(map[string]interface{}); ok && len(v) > 0 {
 		obj.Labels = toMapString(v)
+	}
+
+	if v, ok := in.Get("windows_prefered_cluster").(bool); ok {
+		obj.WindowsPreferedCluster = v
 	}
 
 	return obj, nil

--- a/rancher2/structure_cluster_test.go
+++ b/rancher2/structure_cluster_test.go
@@ -230,6 +230,7 @@ func init() {
 		"driver":                                  clusterDriverRKE,
 		"rke_config":                              testClusterRKEConfigInterface,
 		"system_project_id":                       "system_project_id",
+		"windows_prefered_cluster":                false,
 	}
 	testClusterConfTemplate = &Cluster{}
 	testClusterConfTemplate.Name = "test"
@@ -263,6 +264,7 @@ func init() {
 		"cluster_template_revision_id":            "cluster_template_revision_id",
 		"rke_config":                              []interface{}{},
 		"system_project_id":                       "system_project_id",
+		"windows_prefered_cluster":                false,
 	}
 }
 

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -180,6 +180,7 @@ The following arguments are supported:
 * `enable_network_policy` - (Optional) Enable project network isolation. Default `false` (bool)
 * `annotations` - (Optional/Computed) Annotations for Node Pool object (map)
 * `labels` - (Optional/Computed) Labels for Node Pool object (map)
+* `windows_prefered_cluster` - (Optional) Windows preferred cluster. Default: `false` (bool)
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds the ability to set the `windows_prefered_cluster` field 

It also copies the spelling from the `cluster_template` files. (The word "preferred" is misspelled.) I wanted to keep it consistent however. If I should fix the spelling, please let me know.