### PR TITLE
Dns policy ingress for RKE

### DIFF
--- a/rancher2/schema_cluster_rke_config_ingress.go
+++ b/rancher2/schema_cluster_rke_config_ingress.go
@@ -2,6 +2,23 @@ package rancher2
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+const (
+	clusterRKEConfigIngressDNSPolicyClusterFirst            = "ClusterFirst"
+	clusterRKEConfigIngressDNSPolicyClusterFirstWithHostNet = "ClusterFirstWithHostNet"
+	clusterRKEConfigIngressDNSPolicyDefault                 = "Default"
+	clusterRKEConfigIngressDNSPolicyNone                    = "None"
+)
+
+var (
+	clusterRKEConfigIngressDNSPolicyList = []string{
+		clusterRKEConfigIngressDNSPolicyClusterFirst,
+		clusterRKEConfigIngressDNSPolicyClusterFirstWithHostNet,
+		clusterRKEConfigIngressDNSPolicyDefault,
+		clusterRKEConfigIngressDNSPolicyNone,
+	}
 )
 
 //Schemas
@@ -29,9 +46,10 @@ func clusterRKEConfigIngressFields() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"dns_policy": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
+			Type:         schema.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.StringInSlice(clusterRKEConfigIngressDNSPolicyList, true),
 		},
 	}
 	return s

--- a/rancher2/schema_cluster_rke_config_ingress.go
+++ b/rancher2/schema_cluster_rke_config_ingress.go
@@ -28,6 +28,11 @@ func clusterRKEConfigIngressFields() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
+		"dns_policy": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
 	}
 	return s
 }

--- a/rancher2/structure_cluster_rke_config_ingress.go
+++ b/rancher2/structure_cluster_rke_config_ingress.go
@@ -12,6 +12,10 @@ func flattenClusterRKEConfigIngress(in *managementClient.IngressConfig) ([]inter
 		return []interface{}{}, nil
 	}
 
+	if len(in.DNSPolicy) > 0 {
+		obj["dns_policy"] = in.DNSPolicy
+	}
+
 	if len(in.ExtraArgs) > 0 {
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
 	}
@@ -39,6 +43,10 @@ func expandClusterRKEConfigIngress(p []interface{}) (*managementClient.IngressCo
 		return obj, nil
 	}
 	in := p[0].(map[string]interface{})
+
+	if v, ok := in["dns_policy"].(string); ok && len(v) > 0 {
+		obj.DNSPolicy = v
+	}
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)

--- a/rancher2/structure_cluster_rke_config_ingress_test.go
+++ b/rancher2/structure_cluster_rke_config_ingress_test.go
@@ -30,6 +30,7 @@ func init() {
 	}
 	testClusterRKEConfigIngressInterface = []interface{}{
 		map[string]interface{}{
+			"dns_policy": "test",
 			"extra_args": map[string]interface{}{
 				"arg_one": "one",
 				"arg_two": "two",

--- a/rancher2/structure_cluster_rke_config_ingress_test.go
+++ b/rancher2/structure_cluster_rke_config_ingress_test.go
@@ -14,6 +14,7 @@ var (
 
 func init() {
 	testClusterRKEConfigIngressConf = &managementClient.IngressConfig{
+		DNSPolicy: "test",
 		ExtraArgs: map[string]string{
 			"arg_one": "one",
 			"arg_two": "two",

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -450,6 +450,7 @@ The following attributes are exported:
 
 ##### Arguments
 
+* `dns_policy` - (Optional/Computed) DNS Policy for RKE Ingress (map)
 * `extra_args` - (Optional/Computed) Extra arguments for RKE Ingress (map)
 * `node_selector` - (Optional/Computed) Node selector for RKE Ingress (map)
 * `options` - (Optional/Computed) RKE options for Ingress (map)

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -450,7 +450,7 @@ The following attributes are exported:
 
 ##### Arguments
 
-* `dns_policy` - (Optional/Computed) DNS Policy for RKE Ingress (map)
+* `dns_policy` - (Optional/Computed) Ingress controller DNS policy. `ClusterFirstWithHostNet`, `ClusterFirst`, `Default`, and `None` are supported. [K8S dns Policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy) (string)
 * `extra_args` - (Optional/Computed) Extra arguments for RKE Ingress (map)
 * `node_selector` - (Optional/Computed) Node selector for RKE Ingress (map)
 * `options` - (Optional/Computed) RKE options for Ingress (map)


### PR DESCRIPTION
Adds the dnsPolicy to the RKE Ingress section when creating a cluster. Documentation updated. 