### PR TITLE
Added node template support for Opennebula

### DIFF
--- a/rancher2/resource_rancher2_node_template.go
+++ b/rancher2/resource_rancher2_node_template.go
@@ -150,6 +150,8 @@ func resourceRancher2NodeTemplateUpdate(d *schema.ResourceData, meta interface{}
 		update["digitaloceanConfig"] = expandDigitaloceanConfig(d.Get("digitalocean_config").([]interface{}))
 	case openstackConfigDriver:
 		update["openstackConfig"] = expandOpenstackConfig(d.Get("openstack_config").([]interface{}))
+	case opennebulaConfigDriver:
+		update["opennebulaConfig"] = expandOpennebulaConfig(d.Get("opennebula_config").([]interface{}))
 	case vmwarevsphereConfigDriver:
 		update["vmwarevsphereConfig"] = expandVsphereConfig(d.Get("vsphere_config").([]interface{}))
 	}

--- a/rancher2/resource_rancher2_node_template_test.go
+++ b/rancher2/resource_rancher2_node_template_test.go
@@ -205,6 +205,45 @@ resource "rancher2_node_template" "foo" {
   }
 }
 `
+	testAccRancher2NodeTemplateConfigOpennebula = `
+resource "rancher2_node_template" "foo" {
+  name = "foo"
+  description = "Terraform node driver opennebula acceptance test"
+  opennebula_config {
+	user = "apiuser"
+	password =  "password123"
+	ssh_user = "rancher"
+	template_name = "template-YYYYYYYY"
+	xml_rpc_url = "http://XXXXXXXX/RPC2"
+  }
+}
+`
+	testAccRancher2NodeTemplateUpdateConfigOpennebula = `
+resource "rancher2_node_template" "foo" {
+  name = "foo2"
+  description = "Terraform node driver opennebula acceptance test - updated"
+  opennebula_config {
+  	user = "apiuser"
+	password =  "password123"
+	ssh_user = "rancher"
+	template_name = "template-YYYYYYYY"
+	xml_rpc_url = "http://XXXXXXXX/RPC2"
+  }
+}
+`
+	testAccRancher2NodeTemplateRecreateConfigOpennebula = `
+resource "rancher2_node_template" "foo" {
+  name = "foo"
+  description = "Terraform node driver opennbula acceptance test"
+  opennebula_config {
+	user = "apiuser"
+	password =  "password123"
+	ssh_user = "rancher"
+	template_name = "template-YYYYYYYY"
+	xml_rpc_url = "http://XXXXXXXX/RPC2"
+  }
+}
+`
 )
 
 func TestAccRancher2NodeTemplate_basic_Amazonec2(t *testing.T) {
@@ -530,6 +569,72 @@ func TestAccRancher2NodeTemplate_disappears_Vsphere(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccRancher2NodeTemplateConfigVsphere,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2NodeTemplateExists(testAccRancher2NodeTemplateType+".foo", nodeTemplate),
+					testAccRancher2NodeTemplateDisappears(nodeTemplate),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccRancher2NodeTemplate_basic_Opennebula(t *testing.T) {
+	var nodeTemplate *NodeTemplate
+
+	name := testAccRancher2NodeTemplateType + ".foo"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2NodeTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2NodeTemplateConfigOpennebula,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2NodeTemplateExists(name, nodeTemplate),
+					resource.TestCheckResourceAttr(name, "name", "foo"),
+					resource.TestCheckResourceAttr(name, "description", "Terraform node driver opennebula acceptance test"),
+					resource.TestCheckResourceAttr(name, "driver", opennebulaConfigDriver),
+					resource.TestCheckResourceAttr(name, "opennebula_config.0.template_name", "template-YYYYYYYY"),
+					resource.TestCheckResourceAttr(name, "opennebula_config.0.ssh_user", "user-XXXXXXXX"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2NodeTemplateUpdateConfigOpennebula,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2NodeTemplateExists(name, nodeTemplate),
+					resource.TestCheckResourceAttr(name, "name", "foo2"),
+					resource.TestCheckResourceAttr(name, "description", "Terraform node driver opennebula acceptance test - updated"),
+					resource.TestCheckResourceAttr(name, "driver", opennebulaConfigDriver),
+					resource.TestCheckResourceAttr(name, "opennebula_config.0.template_name", "template-YYYYYYYY"),
+					resource.TestCheckResourceAttr(name, "opennebula_config.0.ssh_user", "user-XXXXXXXX"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2NodeTemplateRecreateConfigOpennebula,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2NodeTemplateExists(name, nodeTemplate),
+					resource.TestCheckResourceAttr(name, "name", "foo"),
+					resource.TestCheckResourceAttr(name, "description", "Terraform node driver opennebula acceptance test"),
+					resource.TestCheckResourceAttr(name, "driver", opennebulaConfigDriver),
+					resource.TestCheckResourceAttr(name, "opennebula_config.0.template_name", "template-YYYYYYYY"),
+					resource.TestCheckResourceAttr(name, "opennebula_config.0.ssh_user", "user-XXXXXXXX"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2NodeTemplate_disappears_Opennebula(t *testing.T) {
+	var nodeTemplate *NodeTemplate
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2NodeTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2NodeTemplateConfigOpennebula,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2NodeTemplateExists(testAccRancher2NodeTemplateType+".foo", nodeTemplate),
 					testAccRancher2NodeTemplateDisappears(nodeTemplate),

--- a/rancher2/resource_rancher2_node_template_test.go
+++ b/rancher2/resource_rancher2_node_template_test.go
@@ -124,6 +124,57 @@ resource "rancher2_node_template" "foo" {
   }
 }
 `
+	testAccRancher2NodeTemplateConfigOpennebulaDriver = `
+resource "rancher2_node_driver" "opennebula" {
+    active = true
+    builtin = false
+    name = "opennebula"
+    url = "https://github.com/OpenNebula/docker-machine-opennebula/releases/download/release-0.2.0/docker-machine-driver-opennebula.tgz"
+}
+`
+
+	testAccRancher2NodeTemplateConfigOpennebula = testAccRancher2NodeTemplateConfigOpennebulaDriver + `
+resource "rancher2_node_template" "foo" {
+  name = "foo"
+  description = "Terraform node template opennebula acceptance test"
+  driver_id = rancher2_node_driver.opennebula.id
+  opennebula_config {
+	user = "apiuser"
+	password =  "password123"
+	ssh_user = "rancher"
+	template_name = "template-YYYYYYYY"
+	xml_rpc_url = "http://XXXXXXXX/RPC2"
+  }
+}
+`
+	testAccRancher2NodeTemplateUpdateConfigOpennebula = testAccRancher2NodeTemplateConfigOpennebulaDriver + `
+resource "rancher2_node_template" "foo" {
+  name = "foo2"
+  description = "Terraform node template opennebula acceptance test - updated"
+  driver_id = rancher2_node_driver.opennebula.id
+  opennebula_config {
+  	user = "apiuser"
+	password =  "password123"
+	ssh_user = "rancher2"
+	template_name = "template-XXXXXXXX"
+	xml_rpc_url = "http://XXXXXXXX/RPC2"
+  }
+}
+`
+	testAccRancher2NodeTemplateRecreateConfigOpennebula = testAccRancher2NodeTemplateConfigOpennebulaDriver + `
+resource "rancher2_node_template" "foo" {
+  name = "foo"
+  description = "Terraform node template opennebula acceptance test"
+  driver_id = rancher2_node_driver.opennebula.id
+  opennebula_config {
+	user = "apiuser"
+	password =  "password123"
+	ssh_user = "rancher"
+	template_name = "template-YYYYYYYY"
+	xml_rpc_url = "http://XXXXXXXX/RPC2"
+  }
+}
+`
 	testAccRancher2NodeTemplateConfigOpenstack = testAccRancher2CloudCredentialConfigOpenstack + `
 resource "rancher2_node_template" "foo" {
   name = "foo"
@@ -202,45 +253,6 @@ resource "rancher2_node_template" "foo" {
 	cpu_count = "4"
 	disk_size = "10240"
 	pool =  "pool-XXXXXXXX"
-  }
-}
-`
-	testAccRancher2NodeTemplateConfigOpennebula = `
-resource "rancher2_node_template" "foo" {
-  name = "foo"
-  description = "Terraform node driver opennebula acceptance test"
-  opennebula_config {
-	user = "apiuser"
-	password =  "password123"
-	ssh_user = "rancher"
-	template_name = "template-YYYYYYYY"
-	xml_rpc_url = "http://XXXXXXXX/RPC2"
-  }
-}
-`
-	testAccRancher2NodeTemplateUpdateConfigOpennebula = `
-resource "rancher2_node_template" "foo" {
-  name = "foo2"
-  description = "Terraform node driver opennebula acceptance test - updated"
-  opennebula_config {
-  	user = "apiuser"
-	password =  "password123"
-	ssh_user = "rancher"
-	template_name = "template-YYYYYYYY"
-	xml_rpc_url = "http://XXXXXXXX/RPC2"
-  }
-}
-`
-	testAccRancher2NodeTemplateRecreateConfigOpennebula = `
-resource "rancher2_node_template" "foo" {
-  name = "foo"
-  description = "Terraform node driver opennbula acceptance test"
-  opennebula_config {
-	user = "apiuser"
-	password =  "password123"
-	ssh_user = "rancher"
-	template_name = "template-YYYYYYYY"
-	xml_rpc_url = "http://XXXXXXXX/RPC2"
   }
 }
 `
@@ -444,6 +456,72 @@ func TestAccRancher2NodeTemplate_disappears_Digitalocean(t *testing.T) {
 	})
 }
 
+func TestAccRancher2NodeTemplate_basic_Opennebula(t *testing.T) {
+	var nodeTemplate *NodeTemplate
+
+	name := testAccRancher2NodeTemplateType + ".foo"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2NodeTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2NodeTemplateConfigOpennebula,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2NodeTemplateExists(name, nodeTemplate),
+					resource.TestCheckResourceAttr(name, "name", "foo"),
+					resource.TestCheckResourceAttr(name, "description", "Terraform node template opennebula acceptance test"),
+					resource.TestCheckResourceAttr(name, "driver", opennebulaConfigDriver),
+					resource.TestCheckResourceAttr(name, "opennebula_config.0.template_name", "template-YYYYYYYY"),
+					resource.TestCheckResourceAttr(name, "opennebula_config.0.ssh_user", "rancher"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2NodeTemplateUpdateConfigOpennebula,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2NodeTemplateExists(name, nodeTemplate),
+					resource.TestCheckResourceAttr(name, "name", "foo2"),
+					resource.TestCheckResourceAttr(name, "description", "Terraform node template opennebula acceptance test - updated"),
+					resource.TestCheckResourceAttr(name, "driver", opennebulaConfigDriver),
+					resource.TestCheckResourceAttr(name, "opennebula_config.0.template_name", "template-XXXXXXXX"),
+					resource.TestCheckResourceAttr(name, "opennebula_config.0.ssh_user", "rancher2"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancher2NodeTemplateRecreateConfigOpennebula,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2NodeTemplateExists(name, nodeTemplate),
+					resource.TestCheckResourceAttr(name, "name", "foo"),
+					resource.TestCheckResourceAttr(name, "description", "Terraform node template opennebula acceptance test"),
+					resource.TestCheckResourceAttr(name, "driver", opennebulaConfigDriver),
+					resource.TestCheckResourceAttr(name, "opennebula_config.0.template_name", "template-YYYYYYYY"),
+					resource.TestCheckResourceAttr(name, "opennebula_config.0.ssh_user", "rancher"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2NodeTemplate_disappears_Opennebula(t *testing.T) {
+	var nodeTemplate *NodeTemplate
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2NodeTemplateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancher2NodeTemplateConfigOpennebula,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2NodeTemplateExists(testAccRancher2NodeTemplateType+".foo", nodeTemplate),
+					testAccRancher2NodeTemplateDisappears(nodeTemplate),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccRancher2NodeTemplate_basic_Openstack(t *testing.T) {
 	var nodeTemplate *NodeTemplate
 
@@ -569,72 +647,6 @@ func TestAccRancher2NodeTemplate_disappears_Vsphere(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccRancher2NodeTemplateConfigVsphere,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRancher2NodeTemplateExists(testAccRancher2NodeTemplateType+".foo", nodeTemplate),
-					testAccRancher2NodeTemplateDisappears(nodeTemplate),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
-func TestAccRancher2NodeTemplate_basic_Opennebula(t *testing.T) {
-	var nodeTemplate *NodeTemplate
-
-	name := testAccRancher2NodeTemplateType + ".foo"
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckRancher2NodeTemplateDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccRancher2NodeTemplateConfigOpennebula,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRancher2NodeTemplateExists(name, nodeTemplate),
-					resource.TestCheckResourceAttr(name, "name", "foo"),
-					resource.TestCheckResourceAttr(name, "description", "Terraform node driver opennebula acceptance test"),
-					resource.TestCheckResourceAttr(name, "driver", opennebulaConfigDriver),
-					resource.TestCheckResourceAttr(name, "opennebula_config.0.template_name", "template-YYYYYYYY"),
-					resource.TestCheckResourceAttr(name, "opennebula_config.0.ssh_user", "user-XXXXXXXX"),
-				),
-			},
-			resource.TestStep{
-				Config: testAccRancher2NodeTemplateUpdateConfigOpennebula,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRancher2NodeTemplateExists(name, nodeTemplate),
-					resource.TestCheckResourceAttr(name, "name", "foo2"),
-					resource.TestCheckResourceAttr(name, "description", "Terraform node driver opennebula acceptance test - updated"),
-					resource.TestCheckResourceAttr(name, "driver", opennebulaConfigDriver),
-					resource.TestCheckResourceAttr(name, "opennebula_config.0.template_name", "template-YYYYYYYY"),
-					resource.TestCheckResourceAttr(name, "opennebula_config.0.ssh_user", "user-XXXXXXXX"),
-				),
-			},
-			resource.TestStep{
-				Config: testAccRancher2NodeTemplateRecreateConfigOpennebula,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRancher2NodeTemplateExists(name, nodeTemplate),
-					resource.TestCheckResourceAttr(name, "name", "foo"),
-					resource.TestCheckResourceAttr(name, "description", "Terraform node driver opennebula acceptance test"),
-					resource.TestCheckResourceAttr(name, "driver", opennebulaConfigDriver),
-					resource.TestCheckResourceAttr(name, "opennebula_config.0.template_name", "template-YYYYYYYY"),
-					resource.TestCheckResourceAttr(name, "opennebula_config.0.ssh_user", "user-XXXXXXXX"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccRancher2NodeTemplate_disappears_Opennebula(t *testing.T) {
-	var nodeTemplate *NodeTemplate
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckRancher2NodeTemplateDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccRancher2NodeTemplateConfigOpennebula,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2NodeTemplateExists(testAccRancher2NodeTemplateType+".foo", nodeTemplate),
 					testAccRancher2NodeTemplateDisappears(nodeTemplate),

--- a/rancher2/schema_node_template.go
+++ b/rancher2/schema_node_template.go
@@ -14,7 +14,7 @@ type NodeTemplate struct {
 	DigitaloceanConfig  *digitaloceanConfig  `json:"digitaloceanConfig,omitempty" yaml:"digitaloceanConfig,omitempty"`
 	OpenstackConfig     *openstackConfig     `json:"openstackConfig,omitempty" yaml:"openstackConfig,omitempty"`
 	VmwarevsphereConfig *vmwarevsphereConfig `json:"vmwarevsphereConfig,omitempty" yaml:"vmwarevsphereConfig,omitempty"`
-	OpennebulaConfig    *opennebulaConfig    `json:"opennebula,omitempty" yaml:"opennebula,omitempty"`
+	OpennebulaConfig    *opennebulaConfig    `json:"opennebulaConfig,omitempty" yaml:"opennebulaConfig,omitempty"`
 }
 
 //Schemas

--- a/rancher2/schema_node_template.go
+++ b/rancher2/schema_node_template.go
@@ -14,6 +14,7 @@ type NodeTemplate struct {
 	DigitaloceanConfig  *digitaloceanConfig  `json:"digitaloceanConfig,omitempty" yaml:"digitaloceanConfig,omitempty"`
 	OpenstackConfig     *openstackConfig     `json:"openstackConfig,omitempty" yaml:"openstackConfig,omitempty"`
 	VmwarevsphereConfig *vmwarevsphereConfig `json:"vmwarevsphereConfig,omitempty" yaml:"vmwarevsphereConfig,omitempty"`
+	OpennebulaConfig    *opennebulaConfig    `json:"opennebula,omitempty" yaml:"opennebula,omitempty"`
 }
 
 //Schemas
@@ -28,7 +29,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"azure_config", "digitalocean_config", "openstack_config", "vsphere_config"},
+			ConflictsWith: []string{"azure_config", "digitalocean_config", "openstack_config", "vsphere_config", "opennebula_config"},
 			Elem: &schema.Resource{
 				Schema: amazonec2ConfigFields(),
 			},
@@ -47,7 +48,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "digitalocean_config", "openstack_config", "vsphere_config"},
+			ConflictsWith: []string{"amazonec2_config", "digitalocean_config", "openstack_config", "vsphere_config", "opennebula_config"},
 			Elem: &schema.Resource{
 				Schema: azureConfigFields(),
 			},
@@ -64,7 +65,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "openstack_config", "vsphere_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "openstack_config", "vsphere_config", "opennebula_config"},
 			Elem: &schema.Resource{
 				Schema: digitaloceanConfigFields(),
 			},
@@ -117,7 +118,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "vsphere_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "vsphere_config", "opennebula_config"},
 			Elem: &schema.Resource{
 				Schema: openstackConfigFields(),
 			},
@@ -131,9 +132,18 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "openstack_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "openstack_config", "opennebula_config"},
 			Elem: &schema.Resource{
 				Schema: vsphereConfigFields(),
+			},
+		},
+		"opennebula_config": &schema.Schema{
+			Type:          schema.TypeList,
+			MaxItems:      1,
+			Optional:      true,
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "openstack_config", "vsphere_config"},
+			Elem: &schema.Resource{
+				Schema: opennebulaConfigFields(),
 			},
 		},
 		"annotations": &schema.Schema{

--- a/rancher2/schema_node_template.go
+++ b/rancher2/schema_node_template.go
@@ -29,7 +29,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"azure_config", "digitalocean_config", "openstack_config", "vsphere_config", "opennebula_config"},
+			ConflictsWith: []string{"azure_config", "digitalocean_config", "opennebula_config", "openstack_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: amazonec2ConfigFields(),
 			},
@@ -48,7 +48,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "digitalocean_config", "openstack_config", "vsphere_config", "opennebula_config"},
+			ConflictsWith: []string{"amazonec2_config", "digitalocean_config", "opennebula_config", "openstack_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: azureConfigFields(),
 			},
@@ -65,7 +65,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "openstack_config", "vsphere_config", "opennebula_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "opennebula_config", "openstack_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: digitaloceanConfigFields(),
 			},
@@ -118,7 +118,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "vsphere_config", "opennebula_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "opennebula_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: openstackConfigFields(),
 			},
@@ -132,7 +132,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "openstack_config", "opennebula_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "opennebula_config", "openstack_config"},
 			Elem: &schema.Resource{
 				Schema: vsphereConfigFields(),
 			},

--- a/rancher2/schema_node_template_opennebula.go
+++ b/rancher2/schema_node_template_opennebula.go
@@ -20,8 +20,8 @@ type opennebulaConfig struct {
 	ImageID      string `json:"imageId,omitempty" yaml:"imageId,omitempty"`
 	ImageOwner   string `json:"imageOwner,omitempty" yaml:"imageOwner,omitempty"`
 	Memory       string `json:"memory,omitempty" yaml:"memory,omitempty"`
-	NetworkName  string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
 	NetworkID    string `json:"networkId,omitempty" yaml:"networkId,omitempty"`
+	NetworkName  string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
 	NetworkOwner string `json:"networkOwner,omitempty" yaml:"networkOwner,omitempty"`
 	Password     string `json:"password,omitempty" yaml:"password,omitempty"`
 	SSHUser      string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`

--- a/rancher2/schema_node_template_opennebula.go
+++ b/rancher2/schema_node_template_opennebula.go
@@ -11,44 +11,44 @@ const (
 //Types
 
 type opennebulaConfig struct {
-	b2dsize      string `json:"b2dSize,omitempty" yaml:"b2dSize,omitempty"`
-	devprefix    string `json:"devPrefix,omitempty" yaml:"devPrefix,omitempty"`
-	diskresize   string `json:"diskResize,omitempty" yaml:"diskResize,omitempty"`
-	imagename    string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
-	memory       string `json:"memory,omitempty" yaml:"memory,omitempty"`
-	networkname  string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
-	password     string `json:"password,omitempty" yaml:"password,omitempty"`
-	templateid   string `json:"templateId,omitempty" yaml:"templateId,omitempty"`
-	user         string `json:"user,omitempty" yaml:"user,omitempty"`
-	xmlrpcurl    string `json:"xmlrpcurl,omitempty" yaml:"xmlrpcurl,omitempty"`
-	cpu          string `json:"cpu,omitempty" yaml:"cpu,omitempty"`
-	disablevnc   bool   `json:"disableVnc,omitempty" yaml:"disableVnc,omitempty"`
-	imageid      string `json:"imageId,omitempty" yaml:"imageId,omitempty"`
-	imageowner   string `json:"imageOwner,omitempty" yaml:"imageOwner,omitempty"`
-	networkid    string `json:"networkId,omitempty" yaml:"networkId,omitempty"`
-	networkowner string `json:"networkOwner,omitempty" yaml:"networkOwner,omitempty"`
-	sshuser      string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
-	templatename string `json:"templateName,omitempty" yaml:"templateName,omitempty"`
-	vcpu         string `json:"vcpu,omitempty" yaml:"vcpu,omitempty"`
+	B2dSize      string `json:"b2dSize,omitempty" yaml:"b2dSize,omitempty"`
+	DevPrefix    string `json:"devPrefix,omitempty" yaml:"devPrefix,omitempty"`
+	DiskResize   string `json:"diskResize,omitempty" yaml:"diskResize,omitempty"`
+	ImageName    string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
+	Memory       string `json:"memory,omitempty" yaml:"memory,omitempty"`
+	NetworkName  string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
+	Password     string `json:"password,omitempty" yaml:"password,omitempty"`
+	TemplateID   string `json:"templateId,omitempty" yaml:"templateId,omitempty"`
+	User         string `json:"user,omitempty" yaml:"user,omitempty"`
+	XMLRPCURL    string `json:"xmlrpcurl,omitempty" yaml:"xmlrpcurl,omitempty"`
+	CPU          string `json:"cpu,omitempty" yaml:"cpu,omitempty"`
+	DisableVnc   bool   `json:"disableVnc,omitempty" yaml:"disableVnc,omitempty"`
+	ImageID      string `json:"imageId,omitempty" yaml:"imageId,omitempty"`
+	ImageOwner   string `json:"imageOwner,omitempty" yaml:"imageOwner,omitempty"`
+	NetworkID    string `json:"networkId,omitempty" yaml:"networkId,omitempty"`
+	NetworkOwner string `json:"networkOwner,omitempty" yaml:"networkOwner,omitempty"`
+	SSHUser      string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	TemplateName string `json:"templateName,omitempty" yaml:"templateName,omitempty"`
+	Vcpu         string `json:"vcpu,omitempty" yaml:"vcpu,omitempty"`
 }
 
 //Schemas
 
 func opennebulaConfigFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
-		"b2dsize": &schema.Schema{
+		"b2d_size": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		"devprefix": &schema.Schema{
+		"dev_prefix": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		"diskresize": &schema.Schema{
+		"disk_resize": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		"imagename": &schema.Schema{
+		"image_name": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},
@@ -56,7 +56,7 @@ func opennebulaConfigFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		"networkname": &schema.Schema{
+		"network_name": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},
@@ -64,7 +64,7 @@ func opennebulaConfigFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		"templateid": &schema.Schema{
+		"template_id": &schema.Schema{
 			Type:     schema.TypeString,
 			Required: true,
 		},
@@ -72,7 +72,7 @@ func opennebulaConfigFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Required: true,
 		},
-		"xmlrpcurl": &schema.Schema{
+		"xml_rpc_url": &schema.Schema{
 			Type:     schema.TypeString,
 			Required: true,
 		},
@@ -80,33 +80,32 @@ func opennebulaConfigFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		"disablevnc": &schema.Schema{
+		"disable_vnc": &schema.Schema{
 			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		"imageid": &schema.Schema{
+		"image_id": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		"imageowner": &schema.Schema{
+		"image_owner": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		"networkid": &schema.Schema{
+		"network_id": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		"networkowner": &schema.Schema{
+		"network_owner": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
-			Default:  false,
 		},
-		"sshuser": &schema.Schema{
+		"ssh_user": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 			Default:  "docker",
 		},
-		"templatename": &schema.Schema{
+		"template_name": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},

--- a/rancher2/schema_node_template_opennebula.go
+++ b/rancher2/schema_node_template_opennebula.go
@@ -1,0 +1,119 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+const (
+	opennebulaConfigDriver = "opennebula"
+)
+
+//Types
+
+type opennebulaConfig struct {
+	b2dsize      string `json:"b2dSize,omitempty" yaml:"b2dSize,omitempty"`
+	devprefix    string `json:"devPrefix,omitempty" yaml:"devPrefix,omitempty"`
+	diskresize   string `json:"diskResize,omitempty" yaml:"diskResize,omitempty"`
+	imagename    string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
+	memory       string `json:"memory,omitempty" yaml:"memory,omitempty"`
+	networkname  string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
+	password     string `json:"password,omitempty" yaml:"password,omitempty"`
+	templateid   string `json:"templateId,omitempty" yaml:"templateId,omitempty"`
+	user         string `json:"user,omitempty" yaml:"user,omitempty"`
+	xmlrpcurl    string `json:"xmlrpcurl,omitempty" yaml:"xmlrpcurl,omitempty"`
+	cpu          string `json:"cpu,omitempty" yaml:"cpu,omitempty"`
+	disablevnc   bool   `json:"disableVnc,omitempty" yaml:"disableVnc,omitempty"`
+	imageid      string `json:"imageId,omitempty" yaml:"imageId,omitempty"`
+	imageowner   string `json:"imageOwner,omitempty" yaml:"imageOwner,omitempty"`
+	networkid    string `json:"networkId,omitempty" yaml:"networkId,omitempty"`
+	networkowner string `json:"networkOwner,omitempty" yaml:"networkOwner,omitempty"`
+	sshuser      string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	templatename string `json:"templateName,omitempty" yaml:"templateName,omitempty"`
+	vcpu         string `json:"vcpu,omitempty" yaml:"vcpu,omitempty"`
+}
+
+//Schemas
+
+func opennebulaConfigFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"b2dsize": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"devprefix": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"diskresize": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"imagename": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"memory": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"networkname": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"password": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"templateid": &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"user": &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"xmlrpcurl": &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"cpu": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"disablevnc": &schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"imageid": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"imageowner": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"networkid": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"networkowner": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  false,
+		},
+		"sshuser": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  "docker",
+		},
+		"templatename": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"vcpu": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	}
+	return s
+}

--- a/rancher2/schema_node_template_opennebula.go
+++ b/rancher2/schema_node_template_opennebula.go
@@ -12,31 +12,48 @@ const (
 
 type opennebulaConfig struct {
 	B2dSize      string `json:"b2dSize,omitempty" yaml:"b2dSize,omitempty"`
+	CPU          string `json:"cpu,omitempty" yaml:"cpu,omitempty"`
 	DevPrefix    string `json:"devPrefix,omitempty" yaml:"devPrefix,omitempty"`
 	DiskResize   string `json:"diskResize,omitempty" yaml:"diskResize,omitempty"`
-	ImageName    string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
-	Memory       string `json:"memory,omitempty" yaml:"memory,omitempty"`
-	NetworkName  string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
-	Password     string `json:"password,omitempty" yaml:"password,omitempty"`
-	TemplateID   string `json:"templateId,omitempty" yaml:"templateId,omitempty"`
-	User         string `json:"user,omitempty" yaml:"user,omitempty"`
-	XMLRPCURL    string `json:"xmlrpcurl,omitempty" yaml:"xmlrpcurl,omitempty"`
-	CPU          string `json:"cpu,omitempty" yaml:"cpu,omitempty"`
 	DisableVnc   bool   `json:"disableVnc,omitempty" yaml:"disableVnc,omitempty"`
+	ImageName    string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
 	ImageID      string `json:"imageId,omitempty" yaml:"imageId,omitempty"`
 	ImageOwner   string `json:"imageOwner,omitempty" yaml:"imageOwner,omitempty"`
+	Memory       string `json:"memory,omitempty" yaml:"memory,omitempty"`
+	NetworkName  string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
 	NetworkID    string `json:"networkId,omitempty" yaml:"networkId,omitempty"`
 	NetworkOwner string `json:"networkOwner,omitempty" yaml:"networkOwner,omitempty"`
+	Password     string `json:"password,omitempty" yaml:"password,omitempty"`
 	SSHUser      string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	TemplateID   string `json:"templateId,omitempty" yaml:"templateId,omitempty"`
 	TemplateName string `json:"templateName,omitempty" yaml:"templateName,omitempty"`
+	User         string `json:"user,omitempty" yaml:"user,omitempty"`
 	Vcpu         string `json:"vcpu,omitempty" yaml:"vcpu,omitempty"`
+	XMLRPCURL    string `json:"xmlrpcurl,omitempty" yaml:"xmlrpcurl,omitempty"`
 }
 
 //Schemas
 
 func opennebulaConfigFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
+		"password": &schema.Schema{
+			Type:      schema.TypeString,
+			Required:  true,
+			Sensitive: true,
+		},
+		"user": &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"xml_rpc_url": &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+		},
 		"b2d_size": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"cpu": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},
@@ -44,11 +61,23 @@ func opennebulaConfigFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"disable_vnc": &schema.Schema{
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
 		"disk_resize": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"image_id": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		"image_name": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"image_owner": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
 		},
@@ -60,38 +89,6 @@ func opennebulaConfigFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		"password": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"template_id": &schema.Schema{
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"user": &schema.Schema{
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"xml_rpc_url": &schema.Schema{
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		"cpu": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"disable_vnc": &schema.Schema{
-			Type:     schema.TypeBool,
-			Optional: true,
-		},
-		"image_id": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"image_owner": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-		},
 		"network_id": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
@@ -100,14 +97,18 @@ func opennebulaConfigFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		"ssh_user": &schema.Schema{
+		"template_id": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
-			Default:  "docker",
 		},
 		"template_name": &schema.Schema{
 			Type:     schema.TypeString,
 			Optional: true,
+		},
+		"ssh_user": &schema.Schema{
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  "docker",
 		},
 		"vcpu": &schema.Schema{
 			Type:     schema.TypeString,

--- a/rancher2/structure_node_template.go
+++ b/rancher2/structure_node_template.go
@@ -38,6 +38,10 @@ func flattenNodeTemplate(d *schema.ResourceData, in *NodeTemplate) error {
 		if in.VmwarevsphereConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires vsphere_config", in.Driver)
 		}
+	case opennebulaConfigDriver:
+		if in.OpennebulaConfig == nil {
+			return fmt.Errorf("[ERROR] Node template driver %s requires opennebula_config", in.Driver)
+		}
 	default:
 		return fmt.Errorf("[ERROR] Unsupported driver on node template: %s", in.Driver)
 	}
@@ -195,6 +199,11 @@ func expandNodeTemplate(in *schema.ResourceData) *NodeTemplate {
 	if v, ok := in.Get("openstack_config").([]interface{}); ok && len(v) > 0 {
 		obj.OpenstackConfig = expandOpenstackConfig(v)
 		obj.Driver = openstackConfigDriver
+	}
+
+	if v, ok := in.Get("opennebula_config").([]interface{}); ok && len(v) > 0 {
+		obj.OpennebulaConfig = expandOpennebulaConfig(v)
+		obj.Driver = opennebulaConfigDriver
 	}
 
 	if v, ok := in.Get("use_internal_ip_address").(bool); ok {

--- a/rancher2/structure_node_template_opennebula.go
+++ b/rancher2/structure_node_template_opennebula.go
@@ -8,25 +8,25 @@ func flattenOpenNebulaConfig(in *opennebulaConfig) []interface{} {
 		return []interface{}{}
 	}
 
-	obj["b2dSize"] = in.b2dsize
-	obj["devPrefix"] = in.devprefix
-	obj["diskResize"] = in.diskresize
-	obj["imageName"] = in.imagename
-	obj["memory"] = in.memory
-	obj["networkName"] = in.networkname
-	obj["password"] = in.password
-	obj["templateId"] = in.templateid
-	obj["user"] = in.user
-	obj["xmlrpcurl"] = in.xmlrpcurl
-	obj["cpu"] = in.cpu
-	obj["disableVnc"] = in.disablevnc
-	obj["imageId"] = in.imageid
-	obj["imageOwner"] = in.imageowner
-	obj["networkId"] = in.networkid
-	obj["networkOwner"] = in.networkowner
-	obj["sshUser"] = in.sshuser
-	obj["templateName"] = in.templatename
-	obj["vcpu"] = in.vcpu
+	obj["b2d_size"] = in.B2dSize
+	obj["dev_prefix"] = in.DevPrefix
+	obj["disk_resize"] = in.DiskResize
+	obj["image_name"] = in.ImageName
+	obj["memory"] = in.Memory
+	obj["network_name"] = in.NetworkName
+	obj["password"] = in.Password
+	obj["template_id"] = in.TemplateID
+	obj["user"] = in.User
+	obj["xml_rpc_url"] = in.XMLRPCURL
+	obj["cpu"] = in.CPU
+	obj["disable_vnc"] = in.DisableVnc
+	obj["image_id"] = in.ImageID
+	obj["image_owner"] = in.ImageOwner
+	obj["network_id"] = in.NetworkID
+	obj["network_owner"] = in.NetworkOwner
+	obj["ssh_user"] = in.SSHUser
+	obj["template_name"] = in.TemplateName
+	obj["vcpu"] = in.Vcpu
 
 	return []interface{}{obj}
 }
@@ -40,62 +40,62 @@ func expandOpennebulaConfig(p []interface{}) *opennebulaConfig {
 	}
 	in := p[0].(map[string]interface{})
 
-	if v, ok := in["b2dSize"].(string); ok && len(v) > 0 {
-		obj.b2dsize = v
+	if v, ok := in["b2d_size"].(string); ok && len(v) > 0 {
+		obj.B2dSize = v
 	}
-	if v, ok := in["devPrefix"].(string); ok && len(v) > 0 {
-		obj.devprefix = v
+	if v, ok := in["dev_prefix"].(string); ok && len(v) > 0 {
+		obj.DevPrefix = v
 	}
-	if v, ok := in["diskResize"].(string); ok && len(v) > 0 {
-		obj.diskresize = v
+	if v, ok := in["disk_resize"].(string); ok && len(v) > 0 {
+		obj.DiskResize = v
 	}
-	if v, ok := in["imageName"].(string); ok && len(v) > 0 {
-		obj.imagename = v
+	if v, ok := in["image_name"].(string); ok && len(v) > 0 {
+		obj.ImageName = v
 	}
 	if v, ok := in["memory"].(string); ok && len(v) > 0 {
-		obj.memory = v
+		obj.Memory = v
 	}
-	if v, ok := in["networkName"].(string); ok && len(v) > 0 {
-		obj.networkname = v
+	if v, ok := in["network_name"].(string); ok && len(v) > 0 {
+		obj.NetworkName = v
 	}
 	if v, ok := in["password"].(string); ok && len(v) > 0 {
-		obj.password = v
+		obj.Password = v
 	}
-	if v, ok := in["templateId"].(string); ok && len(v) > 0 {
-		obj.templateid = v
+	if v, ok := in["template_id"].(string); ok && len(v) > 0 {
+		obj.TemplateID = v
 	}
 	if v, ok := in["user"].(string); ok && len(v) > 0 {
-		obj.user = v
+		obj.User = v
 	}
-	if v, ok := in["xmlrpcurl"].(string); ok && len(v) > 0 {
-		obj.xmlrpcurl = v
+	if v, ok := in["xml_rpc_url"].(string); ok && len(v) > 0 {
+		obj.XMLRPCURL = v
 	}
 	if v, ok := in["cpu"].(string); ok && len(v) > 0 {
-		obj.cpu = v
+		obj.CPU = v
 	}
-	if v, ok := in["disableVnc"].(bool); ok {
-		obj.disablevnc = v
+	if v, ok := in["disable_vnc"].(bool); ok {
+		obj.DisableVnc = v
 	}
-	if v, ok := in["imageId"].(string); ok && len(v) > 0 {
-		obj.imageid = v
+	if v, ok := in["image_id"].(string); ok && len(v) > 0 {
+		obj.ImageID = v
 	}
-	if v, ok := in["imageOwner"].(string); ok && len(v) > 0 {
-		obj.imageowner = v
+	if v, ok := in["image_owner"].(string); ok && len(v) > 0 {
+		obj.ImageOwner = v
 	}
-	if v, ok := in["networkId"].(string); ok && len(v) > 0 {
-		obj.networkid = v
+	if v, ok := in["network_id"].(string); ok && len(v) > 0 {
+		obj.NetworkID = v
 	}
-	if v, ok := in["networkOwner"].(string); ok && len(v) > 0 {
-		obj.networkowner = v
+	if v, ok := in["network_owner"].(string); ok && len(v) > 0 {
+		obj.NetworkOwner = v
 	}
-	if v, ok := in["sshUser"].(string); ok && len(v) > 0 {
-		obj.sshuser = v
+	if v, ok := in["ssh_user"].(string); ok && len(v) > 0 {
+		obj.SSHUser = v
 	}
-	if v, ok := in["templateName"].(string); ok && len(v) > 0 {
-		obj.templatename = v
+	if v, ok := in["template_name"].(string); ok && len(v) > 0 {
+		obj.TemplateName = v
 	}
 	if v, ok := in["vcpu"].(string); ok && len(v) > 0 {
-		obj.vcpu = v
+		obj.Vcpu = v
 	}
 
 	return obj

--- a/rancher2/structure_node_template_opennebula.go
+++ b/rancher2/structure_node_template_opennebula.go
@@ -1,0 +1,102 @@
+package rancher2
+
+// Flatteners
+
+func flattenOpenNebulaConfig(in *opennebulaConfig) []interface{} {
+	obj := make(map[string]interface{})
+	if in == nil {
+		return []interface{}{}
+	}
+
+	obj["b2dSize"] = in.b2dsize
+	obj["devPrefix"] = in.devprefix
+	obj["diskResize"] = in.diskresize
+	obj["imageName"] = in.imagename
+	obj["memory"] = in.memory
+	obj["networkName"] = in.networkname
+	obj["password"] = in.password
+	obj["templateId"] = in.templateid
+	obj["user"] = in.user
+	obj["xmlrpcurl"] = in.xmlrpcurl
+	obj["cpu"] = in.cpu
+	obj["disableVnc"] = in.disablevnc
+	obj["imageId"] = in.imageid
+	obj["imageOwner"] = in.imageowner
+	obj["networkId"] = in.networkid
+	obj["networkOwner"] = in.networkowner
+	obj["sshUser"] = in.sshuser
+	obj["templateName"] = in.templatename
+	obj["vcpu"] = in.vcpu
+
+	return []interface{}{obj}
+}
+
+// Expanders
+
+func expandOpennebulaConfig(p []interface{}) *opennebulaConfig {
+	obj := &opennebulaConfig{}
+	if len(p) == 0 || p[0] == nil {
+		return obj
+	}
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["b2dSize"].(string); ok && len(v) > 0 {
+		obj.b2dsize = v
+	}
+	if v, ok := in["devPrefix"].(string); ok && len(v) > 0 {
+		obj.devprefix = v
+	}
+	if v, ok := in["diskResize"].(string); ok && len(v) > 0 {
+		obj.diskresize = v
+	}
+	if v, ok := in["imageName"].(string); ok && len(v) > 0 {
+		obj.imagename = v
+	}
+	if v, ok := in["memory"].(string); ok && len(v) > 0 {
+		obj.memory = v
+	}
+	if v, ok := in["networkName"].(string); ok && len(v) > 0 {
+		obj.networkname = v
+	}
+	if v, ok := in["password"].(string); ok && len(v) > 0 {
+		obj.password = v
+	}
+	if v, ok := in["templateId"].(string); ok && len(v) > 0 {
+		obj.templateid = v
+	}
+	if v, ok := in["user"].(string); ok && len(v) > 0 {
+		obj.user = v
+	}
+	if v, ok := in["xmlrpcurl"].(string); ok && len(v) > 0 {
+		obj.xmlrpcurl = v
+	}
+	if v, ok := in["cpu"].(string); ok && len(v) > 0 {
+		obj.cpu = v
+	}
+	if v, ok := in["disableVnc"].(bool); ok {
+		obj.disablevnc = v
+	}
+	if v, ok := in["imageId"].(string); ok && len(v) > 0 {
+		obj.imageid = v
+	}
+	if v, ok := in["imageOwner"].(string); ok && len(v) > 0 {
+		obj.imageowner = v
+	}
+	if v, ok := in["networkId"].(string); ok && len(v) > 0 {
+		obj.networkid = v
+	}
+	if v, ok := in["networkOwner"].(string); ok && len(v) > 0 {
+		obj.networkowner = v
+	}
+	if v, ok := in["sshUser"].(string); ok && len(v) > 0 {
+		obj.sshuser = v
+	}
+	if v, ok := in["templateName"].(string); ok && len(v) > 0 {
+		obj.templatename = v
+	}
+	if v, ok := in["vcpu"].(string); ok && len(v) > 0 {
+		obj.vcpu = v
+	}
+
+	return obj
+}

--- a/website/docs/r/nodeTemplate.html.markdown
+++ b/website/docs/r/nodeTemplate.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a Rancher v2 Node Template resource. This can be used to create Node Template for Rancher v2 and retrieve their information.
 
-amazonec2, azure, digitalocean, openstack, vsphere and opennebula drivers are supported for node templates.
+amazonec2, azure, digitalocean, opennebula, openstack, and vsphere drivers are supported for node templates.
 
 **Note** If you are upgrading to Rancher v2.3.3, please take a look to [final section](#Upgrading-to-Rancher-v2.3.3)
 
@@ -185,25 +185,25 @@ The following attributes are exported:
 
 #### Arguments
 
+* `image_id` - (Required*) Image ID to use as the VM OS. Conflicts with `image_name` (string)
+* `image_name` - (Required*) Opennebula image to use as the VM OS. Conflicts with `image_id` (string)
+* `template_id` - (Required*) Opennebula template ID to use. Conflicts with `template_name` (string)
+* `template_name` - (Required*) Name of the Opennbula template to use. Conflicts with `template_id` (string)
+* `password` - (Required/Sensitive) Set the password for the XML-RPC API authentication (string)
+* `user` - (Required) Set the user for the XML-RPC API authentication (string)
+* `xml_rpc_url` - (Required) Set the url for the Opennebula XML-RPC API (string)
 * `b2d_size` - (Optional) Size of the Volatile disk in MB - only for b2d (string)
 * `cpu` - (Optional) CPU value for the VM (string)
 * `dev_prefix` - (Optional) Dev prefix to use for the images. E.g.: 'vd', 'sd', 'hd' (string)
-* `disk_resize` - (Optional) Size of the disk for the VM in MB (string)
 * `disable_vnc` - (Optional) VNC is enabled by default. Disable it with this flag (bool)
-* `image_id` - (Required*) Image ID to use as the VM OS (string)
-* `image_name` - (Required*) Opennebula image to use as the VM OS (string)
+* `disk_resize` - (Optional) Size of the disk for the VM in MB (string)
 * `image_owner` - (Optional) Owner of the image to use as the VM OS (string)
 * `memory`- (Optional) Size of the memory for the VM in MB (string)
-* `network_id` - (Optional) Opennebula network ID to connect the machine to (string)
-* `network_name` - (Optional) Opennebula network to connect the machine to (string)
+* `network_id` - (Optional) Opennebula network ID to connect the machine to. Conflicts with `network_name` (string)
+* `network_name` - (Optional) Opennebula network to connect the machine to. Conflicts with `network_id` (string)
 * `network_owner` - (Optional) Opennebula user ID of the Network to connect the machine to (string)
-* `password` - (Required) Set the password for the XML-RPC API authentication (string)
 * `ssh_user` - (Optional) Set the name of the SSH user. Defaults to docker (string)
-* `template_id` - (Required*) Opennebula template ID to use (string)
-* `template_name` - (Required*) Name of the Opennbula template to use (string)
-* `user` - (Required) Set the user for the XML-RPC API authentication (string)
 * `vcpu` - (Optional) VCPUs for the VM (string)
-* `xml_rpc_url` - (Required) Set the url for the Opennebula XML-RPC API (string)
 
 > **Note**: `Required*` denotes that one of image_name / image_id or template_name / template_id is required but you cannot combine them.
 

--- a/website/docs/r/nodeTemplate.html.markdown
+++ b/website/docs/r/nodeTemplate.html.markdown
@@ -8,9 +8,9 @@ description: |-
 
 # rancher2\_node\_template
 
-Provides a Rancher v2 Node Template resource. This can be used to create Node Template for Rancher v2 and retrieve their information. 
+Provides a Rancher v2 Node Template resource. This can be used to create Node Template for Rancher v2 and retrieve their information.
 
-amazonec2, azure, digitalocean, openstack and vsphere drivers are supported for node templates.
+amazonec2, azure, digitalocean, openstack, vsphere and opennebula drivers are supported for node templates.
 
 **Note** If you are upgrading to Rancher v2.3.3, please take a look to [final section](#Upgrading-to-Rancher-v2.3.3)
 
@@ -79,6 +79,7 @@ The following arguments are supported:
 * `engine_opt` - (Optional) Engine options for the node template (map)
 * `engine_registry_mirror` - (Optional) Engine registry mirror for the node template (list)
 * `engine_storage_driver` - (Optional) Engine storage driver for the node template (string)
+* `opennebula_config` - (Optional) Opennebula config for the Node Template (list maxitems:1)
 * `openstack_config` - (Optional) Openstack config for the Node Template (list maxitems:1)
 * `use_internal_ip_address` - (Optional) Engine storage driver for the node template (bool)
 * `vsphere_config` - (Optional) vSphere config for the Node Template (list maxitems:1)
@@ -179,6 +180,32 @@ The following attributes are exported:
 * `ssh_user` - (Optional) SSH username. Default `root` (string)
 * `tags` - (Optional) Comma-separated list of tags to apply to the Droplet (string)
 * `userdata` - (Optional) Path to file with cloud-init user-data (string)
+
+### `opennebula_config`
+
+#### Arguments
+
+* `b2d_size` - (Optional) Size of the Volatile disk in MB - only for b2d (string)
+* `cpu` - (Optional) CPU value for the VM (string)
+* `dev_prefix` - (Optional) Dev prefix to use for the images. E.g.: 'vd', 'sd', 'hd' (string)
+* `disk_resize` - (Optional) Size of the disk for the VM in MB (string)
+* `disable_vnc` - (Optional) VNC is enabled by default. Disable it with this flag (bool)
+* `image_id` - (Required*) Image ID to use as the VM OS (string)
+* `image_name` - (Required*) Opennebula image to use as the VM OS (string)
+* `image_owner` - (Optional) Owner of the image to use as the VM OS (string)
+* `memory`- (Optional) Size of the memory for the VM in MB (string)
+* `network_id` - (Optional) Opennebula network ID to connect the machine to (string)
+* `network_name` - (Optional) Opennebula network to connect the machine to (string)
+* `network_owner` - (Optional) Opennebula user ID of the Network to connect the machine to (string)
+* `password` - (Required) Set the password for the XML-RPC API authentication (string)
+* `ssh_user` - (Optional) Set the name of the SSH user. Defaults to docker (string)
+* `template_id` - (Required*) Opennebula template ID to use (string)
+* `template_name` - (Required*) Name of the Opennbula template to use (string)
+* `user` - (Required) Set the user for the XML-RPC API authentication (string)
+* `vcpu` - (Optional) VCPUs for the VM (string)
+* `xml_rpc_url` - (Required) Set the url for the Opennebula XML-RPC API (string)
+
+> **Note**: `Required*` denotes that one of image_name / image_id or template_name / template_id is required but you cannot combine them.
 
 ### `openstack_config`
 


### PR DESCRIPTION
This PR is a follow-up of the discussion in #105. 

Similar as in #216 the pre-condition is an installed Opennebula driver (See example below).

```
resource "rancher2_node_driver" "opennebula" {
    active = true
    builtin = false
    name = "opennebula"
    url = "https://github.com/OpenNebula/docker-machine-opennebula/releases/download/release-0.2.0/docker-machine-driver-opennebula.tgz"
}
```

This is a minimal example how to use the node template in Terraform:
```
resource "rancher2_node_template" "opennebula" {
  depends_on = [rancher2_node_driver.opennebula]
  name = "opennebula node template"
  description = "Some meaningful description"
  opennebula_config {
      user  = "<Opennebula user here>"
      password = "<Opennebula password here>"
      templateid = "<Some template id here>"
      xmlrpcurl = "<URL of the Opennebula XML RPC API>"
  }
}
```

See the official Opennebula docker machine documentation for all possible configs:
https://github.com/OpenNebula/docker-machine-opennebula#available-driver-options