### PR TITLE
Make kube_config sensitive

### DIFF
--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -113,8 +113,8 @@ func clusterFields() map[string]*schema.Schema {
 			ValidateFunc: validation.StringInSlice(clusterDrivers, true),
 		},
 		"kube_config": &schema.Schema{
-			Type:     schema.TypeString,
-			Computed: true,
+			Type:      schema.TypeString,
+			Computed:  true,
 			Sensitive: true,
 		},
 		"rke_config": &schema.Schema{

--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -115,6 +115,7 @@ func clusterFields() map[string]*schema.Schema {
 		"kube_config": &schema.Schema{
 			Type:     schema.TypeString,
 			Computed: true,
+			Sensitive: true,
 		},
 		"rke_config": &schema.Schema{
 			Type:          schema.TypeList,

--- a/website/docs/r/cluster.html.markdown
+++ b/website/docs/r/cluster.html.markdown
@@ -205,7 +205,7 @@ The following attributes are exported:
 * `cluster_registration_token` - (Computed) Cluster Registration Token generated for the cluster (list maxitems:1)
 * `default_project_id` - (Computed) Default project ID for the cluster (string)
 * `driver` - (Computed) The driver used for the Cluster. `imported`, `azurekubernetesservice`, `amazonelasticcontainerservice`, `googlekubernetesengine` and `rancherKubernetesEngine` are supported (string)
-* `kube_config` - (Computed) Kube Config generated for the cluster (string)
+* `kube_config` - (Computed/Sensitive) Kube Config generated for the cluster (string)
 * `system_project_id` - (Computed) System project ID for the cluster (string)
 
 ## Nested blocks


### PR DESCRIPTION
Closes #250

The kube_config attribute of the rancher2_cluster resource contains administrator credentials, and it is printed to console in plaintext in the Terraform plan. By making it sensitive, it will not be printed.