### PR TITLE
Added retries config argument and isRancherActive() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ FEATURES:
 ENHANCEMENTS:
 
 * Added `wait_monitoring` argument to `rancher2_cluster_sync` resource
+* Added `retries` config argument and `isRancherActive()` function
 
 BUG FIXES:
 
 * Added `enable_json_parsing` argument to cluster and project logging
 * Sync resource delete with rancher API
+* Fix recipient update on cluster and project alert groups
 
 ## 1.7.3 (March 24, 2020)
 

--- a/rancher2/resource_rancher2_cluster_alert_group.go
+++ b/rancher2/resource_rancher2_cluster_alert_group.go
@@ -199,7 +199,9 @@ func resourceRancher2ClusterAlertGroupRecients(d *schema.ResourceData, meta inte
 			}
 
 			in["notifier_type"] = recipient.NotifierType
-			in["recipient"] = recipient.Recipient
+			if v, ok := in["default_recipient"].(bool); ok && v {
+				in["recipient"] = recipient.Recipient
+			}
 
 			recipients[i] = in
 		}

--- a/rancher2/resource_rancher2_pod_security_policy_template.go
+++ b/rancher2/resource_rancher2_pod_security_policy_template.go
@@ -2,9 +2,12 @@ package rancher2
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	managementClient "github.com/rancher/types/client/management/v3"
 )
 
 func resourceRancher2PodSecurityPolicyTemplate() *schema.Resource {
@@ -41,11 +44,6 @@ func resourceRancher2PodSecurityPolicyTemplateCreate(d *schema.ResourceData, met
 		return err
 	}
 
-	err = flattenPodSecurityPolicyTemplate(d, newPodSecurityPolicyTemplate)
-	if err != nil {
-		return err
-	}
-
 	d.SetId(newPodSecurityPolicyTemplate.ID)
 
 	return resourceRancher2PodSecurityPolicyTemplateRead(d, meta)
@@ -68,12 +66,7 @@ func resourceRancher2PodSecurityPolicyTemplateRead(d *schema.ResourceData, meta 
 		return err
 	}
 
-	err = flattenPodSecurityPolicyTemplate(d, pspt)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return flattenPodSecurityPolicyTemplate(d, pspt)
 }
 
 func resourceRancher2PodSecurityPolicyTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -99,16 +92,17 @@ func resourceRancher2PodSecurityPolicyTemplateUpdate(d *schema.ResourceData, met
 }
 
 func resourceRancher2PodSecurityPolicyTemplateDelete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[INFO] Deleting PodSecurityPolicyTemplate with ID %s", d.Id())
+	id := d.Id()
+	log.Printf("[INFO] Deleting PodSecurityPolicyTemplate with ID %s", id)
 	client, err := meta.(*Config).ManagementClient()
 	if err != nil {
 		return err
 	}
 
-	pspt, err := client.PodSecurityPolicyTemplate.ByID(d.Id())
+	pspt, err := client.PodSecurityPolicyTemplate.ByID(id)
 	if err != nil {
 		if IsNotFound(err) {
-			log.Printf("[INFO] PodSecurityPolicyTemplate with ID %s not found.", d.Id())
+			log.Printf("[INFO] PodSecurityPolicyTemplate with ID %s not found.", id)
 			d.SetId("")
 			return nil
 		}
@@ -120,6 +114,36 @@ func resourceRancher2PodSecurityPolicyTemplateDelete(d *schema.ResourceData, met
 		return fmt.Errorf("Error removing PodSecurityPolicyTemplate: %s", err)
 	}
 
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"active"},
+		Target:     []string{"removed"},
+		Refresh:    podSecurityPolicyTemplateStateRefreshFunc(client, id),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      1 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, waitErr := stateConf.WaitForState()
+	if waitErr != nil {
+		return fmt.Errorf(
+			"[ERROR] waiting for PodSecurityPolicyTemplate (%s) to be removed: %s", id, waitErr)
+	}
+
 	d.SetId("")
 	return nil
+}
+
+// podSecurityPolicyTemplateStateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher PodSecurityPolicyTemplate
+func podSecurityPolicyTemplateStateRefreshFunc(client *managementClient.Client, pspID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		obj, err := client.PodSecurityPolicyTemplate.ByID(pspID)
+		if err != nil {
+			if IsNotFound(err) {
+				return obj, "removed", nil
+			}
+			return nil, "", err
+		}
+
+		return obj, "active", nil
+	}
 }

--- a/rancher2/resource_rancher2_pod_security_policy_template_test.go
+++ b/rancher2/resource_rancher2_pod_security_policy_template_test.go
@@ -2,10 +2,11 @@ package rancher2
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	managementClient "github.com/rancher/types/client/management/v3"
-	"testing"
 )
 
 const testAccRancher2PSPTType = "rancher2_pod_security_policy_template"
@@ -191,7 +192,7 @@ resource "rancher2_pod_security_policy_template" "foo" {
 
 func init() {}
 
-func TestPspTemplateCreate(t *testing.T) {
+func TestAccRancher2PodSecurityPolicyTemplate_Basic(t *testing.T) {
 	var pspTemplate *managementClient.PodSecurityPolicyTemplate
 
 	resource.Test(t, resource.TestCase{
@@ -219,7 +220,7 @@ func TestPspTemplateCreate(t *testing.T) {
 	})
 }
 
-func testAccCheckRancher2NPodSecurityPolicyTemplateExists(n string, notifier *managementClient.PodSecurityPolicyTemplate) resource.TestCheckFunc {
+func testAccCheckRancher2NPodSecurityPolicyTemplateExists(n string, pspTemplate *managementClient.PodSecurityPolicyTemplate) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -236,7 +237,7 @@ func testAccCheckRancher2NPodSecurityPolicyTemplateExists(n string, notifier *ma
 			return err
 		}
 
-		foundNot, err := client.PodSecurityPolicyTemplate.ByID(rs.Primary.ID)
+		foundPSP, err := client.PodSecurityPolicyTemplate.ByID(rs.Primary.ID)
 		if err != nil {
 			if IsNotFound(err) {
 				return fmt.Errorf("PodSecurityPolicyTemplate not found")
@@ -244,7 +245,7 @@ func testAccCheckRancher2NPodSecurityPolicyTemplateExists(n string, notifier *ma
 			return err
 		}
 
-		notifier = foundNot
+		pspTemplate = foundPSP
 
 		return nil
 	}

--- a/rancher2/resource_rancher2_project_alert_group.go
+++ b/rancher2/resource_rancher2_project_alert_group.go
@@ -199,7 +199,9 @@ func resourceRancher2ProjectAlertGroupRecients(d *schema.ResourceData, meta inte
 			}
 
 			in["notifier_type"] = recipient.NotifierType
-			in["recipient"] = recipient.Recipient
+			if v, ok := in["default_recipient"].(bool); ok && v {
+				in["recipient"] = recipient.Recipient
+			}
 
 			recipients[i] = in
 		}

--- a/rancher2/schema_recipient.go
+++ b/rancher2/schema_recipient.go
@@ -32,6 +32,12 @@ func recipientFields() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Recipient",
 		},
+		"default_recipient": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Use notifier default recipient",
+		},
 	}
 	return s
 }

--- a/rancher2/structure_cluster_alert_group_test.go
+++ b/rancher2/structure_cluster_alert_group_test.go
@@ -25,9 +25,10 @@ func init() {
 	}
 	testClusterAlertGroupRecipientsInterface = []interface{}{
 		map[string]interface{}{
-			"notifier_id":   "notifier_id",
-			"notifier_type": "webhook",
-			"recipient":     "recipient",
+			"notifier_id":       "notifier_id",
+			"notifier_type":     "webhook",
+			"recipient":         "recipient",
+			"default_recipient": false,
 		},
 	}
 	testClusterAlertGroupConf = &managementClient.ClusterAlertGroup{

--- a/rancher2/structure_project_alert_group_test.go
+++ b/rancher2/structure_project_alert_group_test.go
@@ -25,9 +25,10 @@ func init() {
 	}
 	testProjectAlertGroupRecipientsInterface = []interface{}{
 		map[string]interface{}{
-			"notifier_id":   "notifier_id",
-			"notifier_type": "webhook",
-			"recipient":     "recipient",
+			"notifier_id":       "notifier_id",
+			"notifier_type":     "webhook",
+			"recipient":         "recipient",
+			"default_recipient": false,
 		},
 	}
 	testProjectAlertGroupConf = &managementClient.ProjectAlertGroup{

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -81,5 +81,6 @@ The following arguments are supported:
 * `ca_certs` - CA certificates used to sign Rancher server tls certificates. Mandatory if self signed tls and insecure option false. It can also be sourced from the `RANCHER_CA_CERTS` environment variable.
 * `insecure` - (Optional) Allow insecure connection to Rancher. Mandatory if self signed tls and not ca_certs provided. It can also be sourced from the `RANCHER_INSECURE` environment variable.
 * `bootstrap` - (Optional) Enable bootstrap mode to manage `rancher2_bootstrap` resource. It can also be sourced from the `RANCHER_BOOTSTRAP` environment variable. Default: `false`
+* `retries` - (Optional) Number of retries to connect to Rancher. Default: `5`
 
 

--- a/website/docs/r/clusterAlertGroup.html.markdown
+++ b/website/docs/r/clusterAlertGroup.html.markdown
@@ -52,6 +52,7 @@ The following attributes are exported:
 
 * `notifier_id` - (Required) Recipient notifier ID (string)
 * `recipient` - (Optional/Computed) Recipient (string)
+* `default_recipient` - (Optional) Use notifier default recipient, overriding `recipient` argument if set.  Default: `false` (bool)
 
 #### Attributes
 


### PR DESCRIPTION
This PR contains:
* Added `retries` config argument and `isRancherActive()` function, issue #284 
* Fix recipient update on cluster and project alert groups, issue #285 
