### PR TITLE
Fix typo with node template ID fix function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ FEATURES:
 
 ENHANCEMENTS:
 
-* Added `fixNodeTempateID` to fix `rancher2_node_template` ID upgrading up to v2.3.3. Issue [#195](https://github.com/terraform-providers/terraform-provider-rancher2/issues/195)
+* Added `fixNodeTemplateID` to fix `rancher2_node_template` ID upgrading up to v2.3.3. Issue [#195](https://github.com/terraform-providers/terraform-provider-rancher2/issues/195)
 
 BUG FIXES:
 
@@ -45,7 +45,7 @@ ENHANCEMENTS:
   * Added `upgrade_strategy` argument to `rke_config` on `rancher2_cluster` resource
   * Added `scheduled_cluster_scan` argument on `rancher2_cluster` and `rancher2_cluster_template` resources
   * Added `rancher2_cluster_scan` datasource
-* Added `fixNodeTempateID` to fix `rancher2_node_template` ID upgrading up to v2.3.3. Issue [#195](https://github.com/terraform-providers/terraform-provider-rancher2/issues/195)
+* Added `fixNodeTemplateID` to fix `rancher2_node_template` ID upgrading up to v2.3.3. Issue [#195](https://github.com/terraform-providers/terraform-provider-rancher2/issues/195)
 
 BUG FIXES:
 
@@ -75,7 +75,7 @@ BUG FIXES:
 * Fix `audit_log.configuration.policy` argument to `rke_config.services.kube_api` argument on `rancher2_cluster` resource
 * Added `plugin` optional value `none` to `rke_config` argument on `rancher2_cluster` resource
 * Updated multiline arguments to trim spaces by default and avoid false diff
-* Updated `private_key_file` definition for openstack driver on `rancher2_node_template` docs 
+* Updated `private_key_file` definition for openstack driver on `rancher2_node_template` docs
 * Updated `private_key_file` definition for openstack driver on `rancher2_node_template` docs
 * Fixed `rke_config.cloud_provider.aws_cloud_provider.global` argument as computed to avoid false diff
 
@@ -92,7 +92,7 @@ ENHANCEMENTS:
 * Added `delete_not_ready_after_secs` and `node_taints` arguments to `node_pool` resource
 * Added `delete_not_ready_after_secs` and `node_taints` arguments to `rancher2_node_pool` resource
 * Updated `github.com/rancher/types` and `github.com/rancher/norman` go modules and vendor files to support rancher v2.3.3
-* Splitted schema, structure and test `cluster_rke_config_services` files for every rke service 
+* Splitted schema, structure and test `cluster_rke_config_services` files for every rke service
 * Added `ssh_cert_path` argument to `rke_config` argument on `rancher2_cluster` resource
 * Added `audit_log`, `event_rate_limit` and `secrets_encryption_config` arguments to `rke_config.services.kube_api` argument on `rancher2_cluster` resource
 * Added `generate_serving_certificate` argument to `rke_config.services.kubelet` argument on `rancher2_cluster` resource
@@ -141,7 +141,7 @@ BUG FIXES:
 
 * Fix `password` argument update for `rancher2_catalog` resource
 * Fix `rancher2_app` update issue on Rancher v2.3.2
-* Fix: set `key` argument as sensitive on `rancher2_certificate` resource. 
+* Fix: set `key` argument as sensitive on `rancher2_certificate` resource.
 * Fix continuous diff issues on `rancher2_project` resource
 * Fix `pod_security_policy_template_id` update on `rancher2_project` resource
 * Fix continuous diff issues on `rancher2_namespace` resource
@@ -202,7 +202,7 @@ ENHANCEMENTS:
 * Updated rancher to v2.2.8 and k3s to v0.8.0 on acceptance tests
 * Added `key_pair_name` argument on `eks_config` argument on `rancher2_cluster` resource
 * Set `kubernetes_version` argument as required on `eks_config` argument on `rancher2_cluster` resource
-* Set `quantity` argument as optional with default value `1` on `rancher2_node_pool` resource. Added validation that value >= 1 
+* Set `quantity` argument as optional with default value `1` on `rancher2_node_pool` resource. Added validation that value >= 1
 
 BUG FIXES:
 
@@ -280,7 +280,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-* Fix: index out of range issue on `vsphere_cloud_provider`-`cloud_provider`-`rke_config` argument on `rancher2_cluster` resource 
+* Fix: index out of range issue on `vsphere_cloud_provider`-`cloud_provider`-`rke_config` argument on `rancher2_cluster` resource
 
 ## 1.2.0 (June 12, 2019)
 

--- a/rancher2/config.go
+++ b/rancher2/config.go
@@ -91,7 +91,7 @@ func (c *Config) getK8SVersion() (string, error) {
 }
 
 // Fix breaking API change https://github.com/rancher/rancher/pull/23718
-func (c *Config) fixNodeTempateID(id string) string {
+func (c *Config) fixNodeTemplateID(id string) string {
 	if ok, _ := c.IsRancherVersionGreaterThanOrEqual(rancher2NodeTemplateChangeVersion); ok && len(id) > 0 {
 		if !strings.HasPrefix(id, rancher2NodeTemplateNewPrefix) {
 			id = strings.Replace(id, ":", "-", -1)
@@ -627,7 +627,6 @@ func (c *Config) CheckAuthConfigEnabled(id string) error {
 	}
 
 	return nil
-
 }
 
 func (c *Config) GetAuthConfig(in *managementClient.AuthConfig) (interface{}, error) {
@@ -847,7 +846,6 @@ func (c *Config) GetSetting(name string) (*managementClient.Setting, error) {
 	}
 
 	return client.Setting.ByID(name)
-
 }
 
 func (c *Config) SetSetting(name, value string) error {

--- a/rancher2/resource_rancher2_node_template.go
+++ b/rancher2/resource_rancher2_node_template.go
@@ -93,7 +93,7 @@ func resourceRancher2NodeTemplateRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	// Normalize node-template ID due to API change
-	d.SetId(meta.(*Config).fixNodeTempateID(d.Id()))
+	d.SetId(meta.(*Config).fixNodeTemplateID(d.Id()))
 
 	nodeTemplate := &NodeTemplate{}
 

--- a/website/docs/r/nodeTemplate.html.markdown
+++ b/website/docs/r/nodeTemplate.html.markdown
@@ -300,5 +300,5 @@ $ terraform import rancher2_node_template.foo <node_template_id>
 
 **Important** This process could update `rancher2_node_template` data on tfstate file. Be sure to save a copy of tfstate file before proceed
 
-Due to [this feature](https://github.com/rancher/rancher/pull/23718) included on Rancher v2.3.3, `rancher2_node_template` are now global scoped objects with RBAC around them, instead of user scoped objects as they were. This means that existing node templates `id` field is changing on upgrade. Provider implements `fixNodeTempateID()` that will update tfstate with proper id.
+Due to [this feature](https://github.com/rancher/rancher/pull/23718) included on Rancher v2.3.3, `rancher2_node_template` are now global scoped objects with RBAC around them, instead of user scoped objects as they were. This means that existing node templates `id` field is changing on upgrade. Provider implements `fixNodeTemplateID()` that will update tfstate with proper id.
 ```


### PR DESCRIPTION
Hello!

While looking at the fix for node template IDs I noticed the function name has a typo.

This MR changes all occurrences from `Tempate` to `Template`.