### PR TITLE
Updated annotations and labels arguments to supress diff when name contains `cattle.io/` or `rancher.io/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,26 @@ FEATURES:
 
 ENHANCEMENTS:
 
-* Updated acceptance tests to run rancher HA on k3s v1.18.2-k3s1
-* Updating local cluster on `rancher2_bootstrap` resource, due to issue https://github.com/rancher/rancher/issues/16213
+* Updated acceptance tests: 
+  * run rancher HA environment on k3s v1.18.2-k3s1 
+  * integrated rancher update scenario from v2.3.6 to v2.4.5
+* Updated local cluster on `rancher2_bootstrap` resource, due to issue https://github.com/rancher/rancher/issues/16213
 * Added `load_balancer_sku` argument to `azure_cloud_provider` configuration
-* Add `nodelocal` argument to `rke_config.dns` argument on `rancher2_cluster` resource
-* Update golang to 1.13
+* Added `nodelocal` argument to `rke_config.dns` argument on `rancher2_cluster` resource
 * Added `view` verb to `rules` argument for `rancher2_node_template` resource
 * Updated golang to v1.13, modules and vendor files
+* Updated Rancher support to v2.4.5
 * Added full feature to `rke_config.monitoring` argument
 * Added `external` as allowed value on `rke_config.cloud_provider` argument on `rancher2_cluster` resource
 * Added `region` argument on `gke_config` for `rancher2_cluster` resource
+* Updated `annotations` and `labels` arguments to supress diff when name contains `cattle.io/` or `rancher.io/`
 
 BUG FIXES:
 
-* Fix `nodeTemplateStateRefreshFunc` function on `rancher2_node_template` resource to check if returned error is forbidden
+* Fixed `nodeTemplateStateRefreshFunc` function on `rancher2_node_template` resource to check if returned error is forbidden
 * Updated `rancher2_app` resource to fix local cluster scoped catalogs
-* Updated api bool fields with default=true to *bool. Related to https://github.com/rancher/types/pull/1083
-* Fix update on `rancher2_cluster_template` resource. Related to https://github.com/terraform-providers/terraform-provider-rancher2/issues/365
+* Updated api bool fields with default=true to `*bool`. Related to https://github.com/rancher/types/pull/1083
+* Fixed update on `rancher2_cluster_template` resource. Related to https://github.com/terraform-providers/terraform-provider-rancher2/issues/365
 
 ## 1.8.3 (April 09, 2020)
 

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
-	github.com/rancher/norman v0.0.0-20200520181341-ab75acb55410
-	github.com/rancher/types v0.0.0-20200529180016-a8a73960f6b9
+	github.com/rancher/norman v0.0.0-20200609224801-7afd2e9bf37f
+	github.com/rancher/types v0.0.0-20200609171948-b18f4c194419
 	golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708
 	gopkg.in/yaml.v2 v2.2.5
 	k8s.io/apimachinery v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -663,6 +663,8 @@ github.com/rancher/norman v0.0.0-20200321231028-b5f2e33b54fa h1:UFR4z0K74/tnqkNa
 github.com/rancher/norman v0.0.0-20200321231028-b5f2e33b54fa/go.mod h1:b+483H276jRBXYosdWrNKFpxH+JYMs3UIdlV60dhdg0=
 github.com/rancher/norman v0.0.0-20200520181341-ab75acb55410 h1:iPheUCT5yzEWhMsILMUeFfbcwkhKur5BsuMTL/pGC5s=
 github.com/rancher/norman v0.0.0-20200520181341-ab75acb55410/go.mod h1:j0ffXOmInpTVfy/4M8zLrpgkUOwEe6YFBJ/tzkBss78=
+github.com/rancher/norman v0.0.0-20200609224801-7afd2e9bf37f h1:A88Zbs3ztrHMe3ZrFklkJ6Kp3oCkXVSpnTXrgLzgLvw=
+github.com/rancher/norman v0.0.0-20200609224801-7afd2e9bf37f/go.mod h1:j0ffXOmInpTVfy/4M8zLrpgkUOwEe6YFBJ/tzkBss78=
 github.com/rancher/rke v1.1.0 h1:A9FydBnODhdyIvSL3UbfE16WBLK/KmnUdrqQ2jBypq8=
 github.com/rancher/rke v1.1.0/go.mod h1:Fw4u45cKMFBTu81jAxN5wtZeMgS4862RxVixhRc5p3E=
 github.com/rancher/types v0.0.0-20200310014905-93eb46890274 h1:eXojciVteOmfcsL0NpPjrGgOc00A+1z/zzi19npEdnY=
@@ -671,6 +673,8 @@ github.com/rancher/types v0.0.0-20200326224903-b4612bd96d9b h1:nLJOQuk36vCXFQuD0
 github.com/rancher/types v0.0.0-20200326224903-b4612bd96d9b/go.mod h1:k5LoTlUpefw0eAzFSJsZI0gf+C4WE41yrc1jm/MS1nM=
 github.com/rancher/types v0.0.0-20200529180016-a8a73960f6b9 h1:ZdLUDbF4uvwzbIuDDkyImbXkox3QhuNlx1pIPrJWm0U=
 github.com/rancher/types v0.0.0-20200529180016-a8a73960f6b9/go.mod h1:J6XqSEmTbADDyC4Dp6LLiceNtnlYvyHEcV4o7zG/0hg=
+github.com/rancher/types v0.0.0-20200609171948-b18f4c194419 h1:UdhVgG4irjMaNVoZlJygXv1AD7eDYeS4srnLHjMezbg=
+github.com/rancher/types v0.0.0-20200609171948-b18f4c194419/go.mod h1:J6XqSEmTbADDyC4Dp6LLiceNtnlYvyHEcV4o7zG/0hg=
 github.com/rancher/wrangler v0.4.1/go.mod h1:1cR91WLhZgkZ+U4fV9nVuXqKurWbgXcIReU4wnQvTN8=
 github.com/rancher/wrangler v0.5.0 h1:zTchAfY9DzchLvXpRpQuNB0PbNfl/HSuvFL1wHN6mDU=
 github.com/rancher/wrangler v0.5.0/go.mod h1:txHSBkPtVgNH/0pUCvdP0Ak0HptAOc9ffBmFxQnL4z4=

--- a/rancher2/0_provider_upgrade_test.go
+++ b/rancher2/0_provider_upgrade_test.go
@@ -36,7 +36,7 @@ resource "rancher2_namespace" "testacc" {
   project_id = rancher2_cluster_sync.testacc.default_project_id
 }
 `
-	testAccCheckRancher2UpgradeVersion = []string{"v2.3.6", "v2.4.2"}
+	testAccCheckRancher2UpgradeVersion = []string{"v2.3.6", "v2.4.5"}
 	testAccCheckRancher2UpgradeCluster = os.Getenv("RANCHER_ACC_CLUSTER_NAME")
 	testAccCheckRancher2UpgradeCatalogV24 = testAccRancher2CatalogGlobal + testAccRancher2CatalogCluster + testAccRancher2CatalogProject
 	testAccCheckRancher2UpgradeCertificateV24 = testAccRancher2Certificate + testAccRancher2CertificateNs

--- a/rancher2/resource_rancher2_app_test.go
+++ b/rancher2/resource_rancher2_app_test.go
@@ -34,6 +34,12 @@ resource "rancher2_app" "foo" {
   answers = {
     "ingress_host" = "test.xip.io"
   }
+  annotations = {
+    "testacc.terraform.io/test" = "true"
+  }
+  labels = {
+    "testacc.terraform.io/test" = "true"
+  }
 }
 `
 	testAccRancher2AppUpdate = `
@@ -47,6 +53,12 @@ resource "rancher2_app" "foo" {
   target_namespace = rancher2_namespace.testacc.name
   answers = {
     "ingress_host" = "test2.xip.io"
+  }
+  annotations = {
+    "testacc.terraform.io/test" = "false"
+  }
+  labels = {
+    "testacc.terraform.io/test" = "false"
   }
 }
 `
@@ -70,6 +82,8 @@ func TestAccRancher2App_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "target_namespace", "testacc"),
 					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "external_id", "catalog://?catalog=library&template=docker-registry&version=1.8.1"),
 					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "answers.ingress_host", "test.xip.io"),
+					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "annotations.testacc.terraform.io/test", "true"),
+					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "labels.testacc.terraform.io/test", "true"),
 				),
 			},
 			{
@@ -81,6 +95,8 @@ func TestAccRancher2App_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "target_namespace", "testacc"),
 					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "external_id", "catalog://?catalog=library&template=docker-registry&version=1.8.1"),
 					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "answers.ingress_host", "test2.xip.io"),
+					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "annotations.testacc.terraform.io/test", "false"),
+					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "labels.testacc.terraform.io/test", "false"),
 				),
 			},
 			{
@@ -92,6 +108,8 @@ func TestAccRancher2App_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "target_namespace", "testacc"),
 					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "external_id", "catalog://?catalog=library&template=docker-registry&version=1.8.1"),
 					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "answers.ingress_host", "test.xip.io"),
+					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "annotations.testacc.terraform.io/test", "true"),
+					resource.TestCheckResourceAttr(testAccRancher2AppType+".foo", "labels.testacc.terraform.io/test", "true"),
 				),
 			},
 		},

--- a/rancher2/resource_rancher2_catalog_test.go
+++ b/rancher2/resource_rancher2_catalog_test.go
@@ -17,6 +17,12 @@ resource "` + testAccRancher2CatalogType + `" "foo-global" {
   url = "http://foo.com:8080"
   description= "Terraform catalog acceptance test"
   version = "helm_v3"
+  annotations = {
+    "testacc.terraform.io/test" = "true"
+  }
+  labels = {
+    "testacc.terraform.io/test" = "true"
+  }
 }
 `
 	testAccRancher2CatalogGlobalUpdate = `
@@ -25,6 +31,12 @@ resource "` + testAccRancher2CatalogType + `" "foo-global" {
   url = "http://foo.updated.com:8080"
   description= "Terraform catalog acceptance test - updated"
   version = "helm_v3"
+  annotations = {
+    "testacc.terraform.io/test" = "false"
+  }
+  labels = {
+    "testacc.terraform.io/test" = "false"
+  }
 }
  `
 )
@@ -104,6 +116,8 @@ func TestAccRancher2Catalog_basic_Global(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "url", "http://foo.com:8080"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "scope", "global"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "version", "helm_v3"),
+					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "annotations.testacc.terraform.io/test", "true"),
+					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "labels.testacc.terraform.io/test", "true"),
 				),
 			},
 			{
@@ -115,6 +129,8 @@ func TestAccRancher2Catalog_basic_Global(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "url", "http://foo.updated.com:8080"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "scope", "global"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "version", "helm_v3"),
+					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "annotations.testacc.terraform.io/test", "false"),
+					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "labels.testacc.terraform.io/test", "false"),
 				),
 			},
 			{
@@ -126,6 +142,8 @@ func TestAccRancher2Catalog_basic_Global(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "url", "http://foo.com:8080"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "scope", "global"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "version", "helm_v3"),
+					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "annotations.testacc.terraform.io/test", "true"),
+					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "labels.testacc.terraform.io/test", "true"),
 				),
 			},
 		},

--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -31,17 +31,17 @@ func resourceRancher2Cluster() *schema.Resource {
 }
 
 func resourceRancher2ClusterCreate(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return err
+	}
+
 	cluster, err := expandCluster(d)
 	if err != nil {
 		return err
 	}
 
 	log.Printf("[INFO] Creating Cluster %s", cluster.Name)
-
-	client, err := meta.(*Config).ManagementClient()
-	if err != nil {
-		return err
-	}
 
 	expectedState := "active"
 

--- a/rancher2/resource_rancher2_cluster_test.go
+++ b/rancher2/resource_rancher2_cluster_test.go
@@ -63,6 +63,12 @@ resource "` + testAccRancher2ClusterType + `" "foo" {
       retention = 5
     }
   }
+  annotations = {
+    "testacc.terraform.io/test" = "true"
+  }
+  labels = {
+    "testacc.terraform.io/test" = "true"
+  }
 }
 `
 	testAccRancher2ClusterUpdateConfigRKE = `
@@ -109,6 +115,12 @@ resource "` + testAccRancher2ClusterType + `" "foo" {
       cron_schedule = "30 10 * * *"
       retention = 5
     }
+  }
+  annotations = {
+    "testacc.terraform.io/test" = "false"
+  }
+  labels = {
+    "testacc.terraform.io/test" = "false"
   }
 }
  `
@@ -176,6 +188,8 @@ func TestAccRancher2Cluster_basic_RKE(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "rke_config.0.upgrade_strategy.0.max_unavailable_worker", "20%"),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "scheduled_cluster_scan.0.scan_config.0.cis_scan_config.0.debug_worker", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "scheduled_cluster_scan.0.schedule_config.0.cron_schedule", "30 * * * *"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "annotations.testacc.terraform.io/test", "true"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "labels.testacc.terraform.io/test", "true"),
 				),
 			},
 			{
@@ -191,6 +205,8 @@ func TestAccRancher2Cluster_basic_RKE(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "rke_config.0.upgrade_strategy.0.max_unavailable_worker", "10%"),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "scheduled_cluster_scan.0.scan_config.0.cis_scan_config.0.debug_worker", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "scheduled_cluster_scan.0.schedule_config.0.cron_schedule", "30 10 * * *"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "annotations.testacc.terraform.io/test", "false"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "labels.testacc.terraform.io/test", "false"),
 				),
 			},
 			{
@@ -206,6 +222,8 @@ func TestAccRancher2Cluster_basic_RKE(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "rke_config.0.upgrade_strategy.0.max_unavailable_worker", "20%"),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "scheduled_cluster_scan.0.scan_config.0.cis_scan_config.0.debug_worker", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "scheduled_cluster_scan.0.schedule_config.0.cron_schedule", "30 * * * *"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "annotations.testacc.terraform.io/test", "true"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "labels.testacc.terraform.io/test", "true"),
 				),
 			},
 		},

--- a/rancher2/schema_alert_group.go
+++ b/rancher2/schema_alert_group.go
@@ -44,16 +44,11 @@ func alertGroupFields() map[string]*schema.Schema {
 			Default:     3600,
 			Description: "Alert group repeat interval seconds",
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
 	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
+	}
+
 	return s
 }

--- a/rancher2/schema_alert_rule.go
+++ b/rancher2/schema_alert_rule.go
@@ -115,17 +115,12 @@ func alertRuleFields() map[string]*schema.Schema {
 			Description:  "Alert rule severity",
 			ValidateFunc: validation.StringInSlice(alertRuleSeverityTypes, true),
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
 	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
+	}
+
 	return s
 }
 

--- a/rancher2/schema_app.go
+++ b/rancher2/schema_app.go
@@ -80,18 +80,10 @@ func appFields() map[string]*schema.Schema {
 				return Base64Encode(TrimSpace(s))
 			},
 		},
-		"annotations": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Annotations of the app",
-		},
-		"labels": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Labels of the app",
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_auth_config.go
+++ b/rancher2/schema_auth_config.go
@@ -41,16 +41,10 @@ func authConfigFields() map[string]*schema.Schema {
 			Optional: true,
 			Default:  true,
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 	return s
 }

--- a/rancher2/schema_auth_config_activedirectory.go
+++ b/rancher2/schema_auth_config_activedirectory.go
@@ -9,7 +9,6 @@ const AuthConfigActiveDirectoryName = "activedirectory"
 //Schemas
 
 func authConfigActiveDirectoryFields() map[string]*schema.Schema {
-	r := authConfigFields()
 	s := map[string]*schema.Schema{
 		"servers": {
 			Type:     schema.TypeList,
@@ -139,7 +138,7 @@ func authConfigActiveDirectoryFields() map[string]*schema.Schema {
 		},
 	}
 
-	for k, v := range r {
+	for k, v := range authConfigFields() {
 		s[k] = v
 	}
 

--- a/rancher2/schema_auth_config_adfs.go
+++ b/rancher2/schema_auth_config_adfs.go
@@ -9,7 +9,6 @@ const AuthConfigADFSName = "adfs"
 //Schemas
 
 func authConfigADFSFields() map[string]*schema.Schema {
-	r := authConfigFields()
 	s := map[string]*schema.Schema{
 		"display_name_field": {
 			Type:     schema.TypeString,
@@ -51,7 +50,7 @@ func authConfigADFSFields() map[string]*schema.Schema {
 		},
 	}
 
-	for k, v := range r {
+	for k, v := range authConfigFields() {
 		s[k] = v
 	}
 

--- a/rancher2/schema_auth_config_azuread.go
+++ b/rancher2/schema_auth_config_azuread.go
@@ -9,7 +9,6 @@ const AuthConfigAzureADName = "azuread"
 //Schemas
 
 func authConfigAzureADFields() map[string]*schema.Schema {
-	r := authConfigFields()
 	s := map[string]*schema.Schema{
 		"application_id": {
 			Type:      schema.TypeString,
@@ -48,7 +47,7 @@ func authConfigAzureADFields() map[string]*schema.Schema {
 		},
 	}
 
-	for k, v := range r {
+	for k, v := range authConfigFields() {
 		s[k] = v
 	}
 

--- a/rancher2/schema_auth_config_github.go
+++ b/rancher2/schema_auth_config_github.go
@@ -9,7 +9,6 @@ const AuthConfigGithubName = "github"
 //Schemas
 
 func authConfigGithubFields() map[string]*schema.Schema {
-	r := authConfigFields()
 	s := map[string]*schema.Schema{
 		"client_id": {
 			Type:      schema.TypeString,
@@ -33,7 +32,7 @@ func authConfigGithubFields() map[string]*schema.Schema {
 		},
 	}
 
-	for k, v := range r {
+	for k, v := range authConfigFields() {
 		s[k] = v
 	}
 

--- a/rancher2/schema_auth_config_keycloak.go
+++ b/rancher2/schema_auth_config_keycloak.go
@@ -9,7 +9,6 @@ const AuthConfigKeyCloakName = "keycloak"
 //Schemas
 
 func authConfigKeyCloakFields() map[string]*schema.Schema {
-	r := authConfigFields()
 	s := map[string]*schema.Schema{
 		"display_name_field": {
 			Type:     schema.TypeString,
@@ -51,7 +50,7 @@ func authConfigKeyCloakFields() map[string]*schema.Schema {
 		},
 	}
 
-	for k, v := range r {
+	for k, v := range authConfigFields() {
 		s[k] = v
 	}
 

--- a/rancher2/schema_auth_config_ldap.go
+++ b/rancher2/schema_auth_config_ldap.go
@@ -8,7 +8,6 @@ import (
 //Schemas
 
 func authConfigLdapFields() map[string]*schema.Schema {
-	r := authConfigFields()
 	s := map[string]*schema.Schema{
 		"servers": {
 			Type:     schema.TypeList,
@@ -133,7 +132,7 @@ func authConfigLdapFields() map[string]*schema.Schema {
 		},
 	}
 
-	for k, v := range r {
+	for k, v := range authConfigFields() {
 		s[k] = v
 	}
 

--- a/rancher2/schema_auth_config_okta.go
+++ b/rancher2/schema_auth_config_okta.go
@@ -9,7 +9,6 @@ const AuthConfigOKTAName = "okta"
 //Schemas
 
 func authConfigOKTAFields() map[string]*schema.Schema {
-	r := authConfigFields()
 	s := map[string]*schema.Schema{
 		"display_name_field": {
 			Type:     schema.TypeString,
@@ -51,7 +50,7 @@ func authConfigOKTAFields() map[string]*schema.Schema {
 		},
 	}
 
-	for k, v := range r {
+	for k, v := range authConfigFields() {
 		s[k] = v
 	}
 

--- a/rancher2/schema_auth_config_ping.go
+++ b/rancher2/schema_auth_config_ping.go
@@ -9,7 +9,6 @@ const AuthConfigPingName = "ping"
 //Schemas
 
 func authConfigPingFields() map[string]*schema.Schema {
-	r := authConfigFields()
 	s := map[string]*schema.Schema{
 		"display_name_field": {
 			Type:     schema.TypeString,
@@ -51,7 +50,7 @@ func authConfigPingFields() map[string]*schema.Schema {
 		},
 	}
 
-	for k, v := range r {
+	for k, v := range authConfigFields() {
 		s[k] = v
 	}
 

--- a/rancher2/schema_catalog.go
+++ b/rancher2/schema_catalog.go
@@ -86,16 +86,10 @@ func catalogFields() map[string]*schema.Schema {
 			Computed:     true,
 			ValidateFunc: validation.StringInSlice(catalogHelmVersions, true),
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_certificate.go
+++ b/rancher2/schema_certificate.go
@@ -53,18 +53,10 @@ func certificateFields() map[string]*schema.Schema {
 			ForceNew:    true,
 			Description: "Namespace ID to add certificate",
 		},
-		"annotations": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Annotations of the certificate",
-		},
-		"labels": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Labels of the certificate",
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_cloud_credential.go
+++ b/rancher2/schema_cloud_credential.go
@@ -87,15 +87,10 @@ func cloudCredentialFields() map[string]*schema.Schema {
 				Schema: cloudCredentialVsphereFields(),
 			},
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -65,16 +65,10 @@ func clusterRegistationTokenFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s
@@ -286,16 +280,6 @@ func clusterFields() map[string]*schema.Schema {
 				Schema: scheduledClusterScanFields(),
 			},
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
 		"windows_prefered_cluster": {
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -303,6 +287,10 @@ func clusterFields() map[string]*schema.Schema {
 			Description: "Windows preferred cluster",
 			ForceNew:    true,
 		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_cluster_alert_group.go
+++ b/rancher2/schema_cluster_alert_group.go
@@ -7,7 +7,6 @@ import (
 //Schemas
 
 func clusterAlertGroupFields() map[string]*schema.Schema {
-	r := alertGroupFields()
 	s := map[string]*schema.Schema{
 		"cluster_id": {
 			Type:        schema.TypeString,
@@ -16,7 +15,7 @@ func clusterAlertGroupFields() map[string]*schema.Schema {
 		},
 	}
 
-	for k, v := range r {
+	for k, v := range alertGroupFields() {
 		s[k] = v
 	}
 

--- a/rancher2/schema_cluster_alert_rule.go
+++ b/rancher2/schema_cluster_alert_rule.go
@@ -7,7 +7,6 @@ import (
 //Schemas
 
 func clusterAlertRuleFields() map[string]*schema.Schema {
-	r := alertRuleFields()
 	s := map[string]*schema.Schema{
 		"cluster_id": {
 			Type:        schema.TypeString,
@@ -56,7 +55,7 @@ func clusterAlertRuleFields() map[string]*schema.Schema {
 		},
 	}
 
-	for k, v := range r {
+	for k, v := range alertRuleFields() {
 		s[k] = v
 	}
 

--- a/rancher2/schema_cluster_driver.go
+++ b/rancher2/schema_cluster_driver.go
@@ -43,16 +43,10 @@ func clusterDriverFields() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_cluster_logging.go
+++ b/rancher2/schema_cluster_logging.go
@@ -102,16 +102,10 @@ func clusterLoggingFields() map[string]*schema.Schema {
 				Schema: loggingSyslogConfigFields(),
 			},
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_cluster_role_template_binding.go
+++ b/rancher2/schema_cluster_role_template_binding.go
@@ -40,16 +40,10 @@ func clusterRoleTemplateBindingFields() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_cluster_scan.go
+++ b/rancher2/schema_cluster_scan.go
@@ -110,16 +110,10 @@ func clusterScanFields() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "The cluster scan status",
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_cluster_template.go
+++ b/rancher2/schema_cluster_template.go
@@ -182,16 +182,10 @@ func clusterTemplateRevisionFields() map[string]*schema.Schema {
 				Schema: questionFields(),
 			},
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s
@@ -231,16 +225,10 @@ func clusterTemplateFields() map[string]*schema.Schema {
 				Schema: clusterTemplateRevisionFields(),
 			},
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_common.go
+++ b/rancher2/schema_common.go
@@ -1,0 +1,46 @@
+package rancher2
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+const (
+	commonAnnotationLabelCattle  = "cattle.io/"
+	commonAnnotationLabelRancher = "rancher.io/"
+)
+
+//Schemas
+
+func commonAnnotationLabelFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"annotations": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Description: "Annotations of the resource",
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				// Supressing diff for annotations containing cattle.io/
+				if (strings.Contains(k, commonAnnotationLabelCattle) || strings.Contains(k, commonAnnotationLabelRancher)) && old != "" && new == "" {
+					return true
+				}
+				return false
+			},
+		},
+		"labels": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Description: "Labels of the resource",
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				// Supressing diff for labels containing cattle.io/
+				if (strings.Contains(k, commonAnnotationLabelCattle) || strings.Contains(k, commonAnnotationLabelRancher)) && old != "" && new == "" {
+					return true
+				}
+				return false
+			},
+		},
+	}
+	return s
+}

--- a/rancher2/schema_etcd_backup.go
+++ b/rancher2/schema_etcd_backup.go
@@ -44,18 +44,10 @@ func etcdBackupFields() map[string]*schema.Schema {
 			Computed: true,
 			ForceNew: true,
 		},
-		"annotations": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: descriptions["annotations"],
-		},
-		"labels": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: descriptions["labels"],
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_global_role_binding.go
+++ b/rancher2/schema_global_role_binding.go
@@ -31,16 +31,10 @@ func globalRoleBindingFields() map[string]*schema.Schema {
 			Computed: true,
 			ForceNew: true,
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_multi_cluster_app.go
+++ b/rancher2/schema_multi_cluster_app.go
@@ -96,16 +96,10 @@ func multiClusterAppFields() map[string]*schema.Schema {
 			Default:     true,
 			Description: "Wait until multi cluster app is active",
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_namespace.go
+++ b/rancher2/schema_namespace.go
@@ -132,18 +132,10 @@ func namespaceFields() map[string]*schema.Schema {
 			Default:     false,
 			Description: "Wait for cluster becomes active",
 		},
-		"annotations": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Annotations of the k8s namespace managed by rancher v2",
-		},
-		"labels": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Labels of the k8s namespace managed by rancher v2",
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_node_driver.go
+++ b/rancher2/schema_node_driver.go
@@ -47,16 +47,10 @@ func nodeDriverFields() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_node_pool.go
+++ b/rancher2/schema_node_pool.go
@@ -56,16 +56,10 @@ func nodePoolFields() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Optional: true,
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_node_template.go
+++ b/rancher2/schema_node_template.go
@@ -156,16 +156,10 @@ func nodeTemplateFields() map[string]*schema.Schema {
 				Schema: opennebulaConfigFields(),
 			},
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_notifier.go
+++ b/rancher2/schema_notifier.go
@@ -75,16 +75,10 @@ func notifierFields() map[string]*schema.Schema {
 				Schema: notifierWechatConfigFields(),
 			},
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_pod_security_policy_template.go
+++ b/rancher2/schema_pod_security_policy_template.go
@@ -20,18 +20,6 @@ func podSecurityPolicyTemplateFields() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Pod Security Policy template policy description",
 		},
-		"annotations": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Annotations of the Pod Security Policy template",
-		},
-		"labels": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Labels of the Pod Security Policy template",
-		},
 		"allow_privilege_escalation": {
 			Type:        schema.TypeBool,
 			Description: "allowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.",
@@ -207,6 +195,10 @@ func podSecurityPolicyTemplateFields() map[string]*schema.Schema {
 			Computed:    true,
 			Elem:        podSecurityPolicyVolumesFields(),
 		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_project.go
+++ b/rancher2/schema_project.go
@@ -150,18 +150,10 @@ func projectFields() map[string]*schema.Schema {
 			Default:     false,
 			Description: "Wait for cluster becomes active",
 		},
-		"annotations": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: descriptions["annotations"],
-		},
-		"labels": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: descriptions["labels"],
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_project_alert_group.go
+++ b/rancher2/schema_project_alert_group.go
@@ -7,7 +7,6 @@ import (
 //Schemas
 
 func projectAlertGroupFields() map[string]*schema.Schema {
-	r := alertGroupFields()
 	s := map[string]*schema.Schema{
 		"project_id": {
 			Type:        schema.TypeString,
@@ -16,7 +15,7 @@ func projectAlertGroupFields() map[string]*schema.Schema {
 		},
 	}
 
-	for k, v := range r {
+	for k, v := range alertGroupFields() {
 		s[k] = v
 	}
 

--- a/rancher2/schema_project_alert_rule.go
+++ b/rancher2/schema_project_alert_rule.go
@@ -7,7 +7,6 @@ import (
 //Schemas
 
 func projectAlertRuleFields() map[string]*schema.Schema {
-	r := alertRuleFields()
 	s := map[string]*schema.Schema{
 		"project_id": {
 			Type:        schema.TypeString,
@@ -46,7 +45,7 @@ func projectAlertRuleFields() map[string]*schema.Schema {
 		},
 	}
 
-	for k, v := range r {
+	for k, v := range alertRuleFields() {
 		s[k] = v
 	}
 

--- a/rancher2/schema_project_logging.go
+++ b/rancher2/schema_project_logging.go
@@ -102,16 +102,10 @@ func projectLoggingFields() map[string]*schema.Schema {
 				Schema: loggingSyslogConfigFields(),
 			},
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_project_role_template_binding.go
+++ b/rancher2/schema_project_role_template_binding.go
@@ -40,16 +40,10 @@ func projectRoleTemplateBindingFields() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_registry.go
+++ b/rancher2/schema_registry.go
@@ -58,18 +58,10 @@ func registryFields() map[string]*schema.Schema {
 			ForceNew:    true,
 			Description: "Namespace ID to add docker registry",
 		},
-		"annotations": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Annotations of the docker registry",
-		},
-		"labels": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Labels of the docker registry",
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_role_template.go
+++ b/rancher2/schema_role_template.go
@@ -89,18 +89,10 @@ func roleTemplateFields() map[string]*schema.Schema {
 				Schema: policyRuleFields(),
 			},
 		},
-		"annotations": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Annotations of the role template",
-		},
-		"labels": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Labels of the role template",
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_secret.go
+++ b/rancher2/schema_secret.go
@@ -37,18 +37,10 @@ func secretFields() map[string]*schema.Schema {
 			ForceNew:    true,
 			Description: "Namespace ID to add secret",
 		},
-		"annotations": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Annotations of the secret",
-		},
-		"labels": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Labels of the secret",
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_setting.go
+++ b/rancher2/schema_setting.go
@@ -17,16 +17,10 @@ func settingFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Required: true,
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_token.go
+++ b/rancher2/schema_token.go
@@ -76,18 +76,10 @@ func tokenFields() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Token user ID",
 		},
-		"annotations": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Annotations of the token",
-		},
-		"labels": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Labels of the token",
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/schema_user.go
+++ b/rancher2/schema_user.go
@@ -34,16 +34,10 @@ func userFields() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
-		"annotations": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
-		"labels": {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Computed: true,
-		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
 	}
 
 	return s

--- a/rancher2/structure_cloud_credential.go
+++ b/rancher2/structure_cloud_credential.go
@@ -79,7 +79,7 @@ func flattenCloudCredential(d *schema.ResourceData, in *CloudCredential) error {
 		return fmt.Errorf("[ERROR] Unsupported driver on cloud credential: %s", driver)
 	}
 
-	if len(in.Annotations) > 0 {
+	if in.Annotations != nil {
 		err := d.Set("annotations", toMapInterface(in.Annotations))
 		if err != nil {
 			return err

--- a/scripts/start_rancher.sh
+++ b/scripts/start_rancher.sh
@@ -20,7 +20,7 @@ CERTMANAGER_CRD=${CERTMANAGER_CRD:-"https://github.com/jetstack/cert-manager/rel
 CERTMANAGER_NS=${CERTMANAGER_NS:-"cert-manager"}
 
 ## rancher
-RANCHER_VERSION=${RANCHER_VERSION:-"v2.4.2"}
+RANCHER_VERSION=${RANCHER_VERSION:-"v2.4.5"}
 RANCHER_NS=${RANCHER_NS:-"cattle-system"}
 RANCHER_HOSTNAME="rancher.${K3S_SERVER_IP}.xip.io"
 

--- a/vendor/github.com/rancher/types/client/management/v3/zz_generated_docker_info.go
+++ b/vendor/github.com/rancher/types/client/management/v3/zz_generated_docker_info.go
@@ -11,6 +11,7 @@ const (
 	DockerInfoFieldHTTPProxy          = "httpProxy"
 	DockerInfoFieldHTTPSProxy         = "httpsProxy"
 	DockerInfoFieldIndexServerAddress = "indexServerAddress"
+	DockerInfoFieldInitBinary         = "initBinary"
 	DockerInfoFieldKernelVersion      = "kernelVersion"
 	DockerInfoFieldLabels             = "labels"
 	DockerInfoFieldLoggingDriver      = "loggingDriver"
@@ -18,6 +19,7 @@ const (
 	DockerInfoFieldNoProxy            = "noProxy"
 	DockerInfoFieldOSType             = "osType"
 	DockerInfoFieldOperatingSystem    = "operatingSystem"
+	DockerInfoFieldSecurityOptions    = "securityOptions"
 	DockerInfoFieldServerVersion      = "serverVersion"
 )
 
@@ -31,6 +33,7 @@ type DockerInfo struct {
 	HTTPProxy          string   `json:"httpProxy,omitempty" yaml:"httpProxy,omitempty"`
 	HTTPSProxy         string   `json:"httpsProxy,omitempty" yaml:"httpsProxy,omitempty"`
 	IndexServerAddress string   `json:"indexServerAddress,omitempty" yaml:"indexServerAddress,omitempty"`
+	InitBinary         string   `json:"initBinary,omitempty" yaml:"initBinary,omitempty"`
 	KernelVersion      string   `json:"kernelVersion,omitempty" yaml:"kernelVersion,omitempty"`
 	Labels             []string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	LoggingDriver      string   `json:"loggingDriver,omitempty" yaml:"loggingDriver,omitempty"`
@@ -38,5 +41,6 @@ type DockerInfo struct {
 	NoProxy            string   `json:"noProxy,omitempty" yaml:"noProxy,omitempty"`
 	OSType             string   `json:"osType,omitempty" yaml:"osType,omitempty"`
 	OperatingSystem    string   `json:"operatingSystem,omitempty" yaml:"operatingSystem,omitempty"`
+	SecurityOptions    []string `json:"securityOptions,omitempty" yaml:"securityOptions,omitempty"`
 	ServerVersion      string   `json:"serverVersion,omitempty" yaml:"serverVersion,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -237,7 +237,7 @@ github.com/posener/complete
 github.com/posener/complete/cmd
 github.com/posener/complete/cmd/install
 github.com/posener/complete/match
-# github.com/rancher/norman v0.0.0-20200520181341-ab75acb55410
+# github.com/rancher/norman v0.0.0-20200609224801-7afd2e9bf37f
 github.com/rancher/norman/clientbase
 github.com/rancher/norman/httperror
 github.com/rancher/norman/types
@@ -245,7 +245,7 @@ github.com/rancher/norman/types/convert
 github.com/rancher/norman/types/definition
 github.com/rancher/norman/types/slice
 github.com/rancher/norman/types/values
-# github.com/rancher/types v0.0.0-20200529180016-a8a73960f6b9
+# github.com/rancher/types v0.0.0-20200609171948-b18f4c194419
 github.com/rancher/types/client/cluster/v3
 github.com/rancher/types/client/management/v3
 github.com/rancher/types/client/project/v3


### PR DESCRIPTION
This PR contains:
* Updated `annotations` and `labels` arguments to supress diff when name contains `cattle.io/` or `rancher.io/`. Fix issue #27 
* Updated Rancher support to v2.4.5
