### PR TITLE
Add configurable retry logic when Rancher responds with 405 method not allowed for node templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 ENHANCEMENTS:
 
 * Added `wait` argument to rancher2_app
+* Added configurable retry logic when Rancher responds with "405 method not allowed" for `rancher2_node_template` resource
 
 BUG FIXES:
 

--- a/rancher2/provider.go
+++ b/rancher2/provider.go
@@ -83,7 +83,7 @@ func Provider() terraform.ResourceProvider {
 			"retries": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      5,
+				Default:      10,
 				Description:  descriptions["retries"],
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},

--- a/rancher2/resource_rancher2_node_template.go
+++ b/rancher2/resource_rancher2_node_template.go
@@ -199,6 +199,10 @@ func resourceRancher2NodeTemplateDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	err = client.APIBaseClient.Delete(nodeTemplate)
+	for i := 0; i <= meta.(*Config).Retries && IsNotAllowed(err); err = client.APIBaseClient.Delete(nodeTemplate) {
+		time.Sleep(30 * time.Second)
+		i++
+	}
 	if err != nil {
 		return fmt.Errorf("Error removing Node Template: %s", err)
 	}

--- a/rancher2/util.go
+++ b/rancher2/util.go
@@ -266,6 +266,16 @@ func IsForbidden(err error) bool {
 	return apiError.StatusCode == http.StatusForbidden
 }
 
+// IsNotAllowed checks if the given APIError is a Method Not Allowed HTTP statuscode
+func IsNotAllowed(err error) bool {
+	apiError, ok := err.(*clientbase.APIError)
+	if !ok {
+		return false
+	}
+
+	return apiError.StatusCode == http.StatusMethodNotAllowed
+}
+
 func splitTokenID(token string) string {
 	separator := ":"
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -81,6 +81,4 @@ The following arguments are supported:
 * `ca_certs` - CA certificates used to sign Rancher server tls certificates. Mandatory if self signed tls and insecure option false. It can also be sourced from the `RANCHER_CA_CERTS` environment variable.
 * `insecure` - (Optional) Allow insecure connection to Rancher. Mandatory if self signed tls and not ca_certs provided. It can also be sourced from the `RANCHER_INSECURE` environment variable.
 * `bootstrap` - (Optional) Enable bootstrap mode to manage `rancher2_bootstrap` resource. It can also be sourced from the `RANCHER_BOOTSTRAP` environment variable. Default: `false`
-* `retries` - (Optional) Number of retries to connect to Rancher. Default: `5`
-
-
+* `retries` - (Optional) Number of retries to check Rancher connectivity and `rancher2_node_template` resource deletion. Default: `10`


### PR DESCRIPTION
Related to https://github.com/rancher/rancher/issues/26456 and https://github.com/rancherlabs/eio/issues/126
Requires https://github.com/rancher/rancher/pull/27804