### PR TITLE
Revert rancher2_cluster_sync ID format change

### DIFF
--- a/rancher2/resource_rancher2_cluster_sync.go
+++ b/rancher2/resource_rancher2_cluster_sync.go
@@ -76,7 +76,7 @@ func resourceRancher2ClusterSyncCreate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	d.SetId(clusterSyncPrefixID + clusterID)
+	d.SetId(clusterID)
 
 	return resourceRancher2ClusterSyncRead(d, meta)
 }

--- a/rancher2/schema_cluster_sync.go
+++ b/rancher2/schema_cluster_sync.go
@@ -4,8 +4,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-const clusterSyncPrefixID = "sync:"
-
 //Schemas
 
 func clusterSyncFields() map[string]*schema.Schema {


### PR DESCRIPTION
This reverts a [recent unreleased change](https://github.com/rancher/terraform-provider-rancher2/commit/5d652277e405504308a84f39efe9afaef16bc9fe#diff-64cfe614b85a1d9a4b7f52aeb31a308eR79) to the `rancher2_cluster_sync` resource ID format, which Hashicorp lists as a potentially breaking change their [versioning best practices](https://www.terraform.io/docs/extend/best-practices/versioning.html#example-major-number-increments).

Closes #419 