### PR TITLE
Fix rancher2_project resource applying pod_security_policy_template_id argument on creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ BUG FIXES:
 * Fix `rancher2_cluster` and `rancher2_project` resources error if created with monitoring enabled by not global admin user
 * Fix `rancher2_token` to set annotations and labels as computed attibutes
 * Fix `rke_config.secrets_encryption_config.custom_config` argument to work properly
+* Fix `rancher2_project` resource applying `pod_security_policy_template_id` argument on creation
 
 ## 1.10.0 (July 29, 2020)
 

--- a/rancher2/resource_rancher2_project.go
+++ b/rancher2/resource_rancher2_project.go
@@ -102,6 +102,19 @@ func resourceRancher2ProjectCreate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
+	if pspID, ok := d.Get("pod_security_policy_template_id").(string); ok && len(pspID) > 0 {
+		pspInput := &managementClient.SetPodSecurityPolicyTemplateInput{
+			PodSecurityPolicyTemplateName: pspID,
+		}
+		_, err = client.Project.ActionSetpodsecuritypolicytemplate(newProject, pspInput)
+		if err != nil {
+			// Checking error due to ActionSetpodsecuritypolicytemplate() issue
+			if error.Error(err) != "unexpected end of JSON input" {
+				return err
+			}
+		}
+	}
+
 	return resourceRancher2ProjectRead(d, meta)
 }
 


### PR DESCRIPTION
closes #167 , #431 