### PR TITLE
Add support for OKE cluster driver (oke_config) to rancher2_cluster

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -351,11 +351,12 @@ resource "rancher2_cluster" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Cluster (string)
-* `rke_config` - (Optional/Computed) The RKE configuration for `rke` Clusters. Conflicts with `aks_config`, `eks_config`, `gke_config` and `k3s_config` (list maxitems:1)
-* `k3s_config` - (Optional/Computed) The K3S configuration for `k3s` imported Clusters. Conflicts with `aks_config`, `eks_config`, `gke_config` and `rke_config` (list maxitems:1)
-* `aks_config` - (Optional) The Azure AKS configuration for `aks` Clusters. Conflicts with `eks_config`, `gke_config`, `k3s_config` and `rke_config` (list maxitems:1)
-* `eks_config` - (Optional) The Amazon EKS configuration for `eks` Clusters. Conflicts with `aks_config`, `gke_config`, `k3s_config` and `rke_config` (list maxitems:1)
-* `gke_config` - (Optional) The Google GKE configuration for `gke` Clusters. Conflicts with `aks_config`, `eks_config`, `k3s_config` and `rke_config` (list maxitems:1)
+* `rke_config` - (Optional/Computed) The RKE configuration for `rke` Clusters. Conflicts with `aks_config`, `eks_config`, `gke_config`, `oke_config` and `k3s_config` (list maxitems:1)
+* `k3s_config` - (Optional/Computed) The K3S configuration for `k3s` imported Clusters. Conflicts with `aks_config`, `eks_config`, `gke_config`, `oke_config` and `rke_config` (list maxitems:1)
+* `aks_config` - (Optional) The Azure AKS configuration for `aks` Clusters. Conflicts with `eks_config`, `gke_config`, `oke_config` `k3s_config` and `rke_config` (list maxitems:1)
+* `eks_config` - (Optional) The Amazon EKS configuration for `eks` Clusters. Conflicts with `aks_config`, `gke_config`, `oke_config` `k3s_config` and `rke_config` (list maxitems:1)
+* `gke_config` - (Optional) The Google GKE configuration for `gke` Clusters. Conflicts with `aks_config`, `eks_config`, `oke_config` `k3s_config` and `rke_config` (list maxitems:1)
+* `oke_config` - (Optional) The Oracle OKE configuration for `oke` Clusters. Conflicts with `aks_config`, `eks_config`, `gke_config` `k3s_config` and `rke_config` (list maxitems:1)
 * `description` - (Optional) The description for Cluster (string)
 * `cluster_auth_endpoint` - (Optional/Computed) Enabling the [local cluster authorized endpoint](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#local-cluster-auth-endpoint) allows direct communication with the cluster, bypassing the Rancher API proxy. (list maxitems:1)
 * `cluster_monitoring_input` - (Optional) Cluster monitoring config. Any parameter defined in [rancher-monitoring charts](https://github.com/rancher/system-charts/tree/dev/charts/rancher-monitoring) could be configured  (list maxitems:1)
@@ -1066,6 +1067,37 @@ The following arguments are supported:
 * `use_ip_aliases` - (Optional) Whether alias IPs will be used for pod IPs in the cluster. Default `false` (bool)
 * `taints` - (Required) List of Kubernetes taints to be applied to each node (list)
 * `zone` - (Optional) GKE cluster zone. Conflicts with `region` (string)
+
+### `oke_config`
+
+#### Arguments
+
+The following arguments are supported:
+
+* `compartment_id` - (Required) The OCID of the compartment in which to create resources OKE cluster and related resources (string)
+* `description` - (Optional) An optional description of this cluster (string)
+* `enable_kubernetes_dashboard` - (Optional) Specifies whether to enable the Kubernetes dashboard. Default `false` (bool)
+* `enable_private_nodes` - (Optional) Specifies whether worker nodes will be deployed into a new, private, subnet. Default `false` (bool)
+* `fingerprint` - (Required) The fingerprint corresponding to the specified user's private API Key (string)
+* `kubernetes_version` - (Required) The Kubernetes version that will be used for your master *and* OKE worker nodes (string)
+* `load_balancer_subnet_name_1` - (Optional) The name of the first existing subnet to use for Kubernetes services / LB. `vcn_name` is also required when specifying an existing subnet. (string)
+* `load_balancer_subnet_name_2` - (Optional) The name of a second existing subnet to use for Kubernetes services / LB. A second subnet is only required when it is AD-specific (non-regional) (string)
+* `node_image` - (Required) The Oracle Linux OS image name to use for the OKE node(s). See [here](https://docs.cloud.oracle.com/en-us/iaas/images/) for a list of images. (string)
+* `node_pool_dns_domain_name` - (Optional) Name for DNS domain of node pool subnet. Default `nodedns` (string)
+* `node_pool_subnet_name` - (Optional) Name for node pool subnet. Default `nodedns` (string)
+* `node_public_key_contents` - (Optional) The contents of the SSH public key file to use for the nodes (string)
+* `node_shape` - (Required) The shape of the node (determines number of CPUs and  amount of memory on each OKE node) (string)
+* `private_key_contents` - (Required/Sensitive) The private API key file contents for the specified user, in PEM format (string)
+* `private_key_passphrase` - (Optional/Sensitive) The passphrase (if any) of the private key for the OKE cluster (string)
+* `quantity_of_node_subnets` - (Optional) Number of node subnets. Default `1` (int)
+* `quantity_per_subnet` - (Optional) Number of OKE worker nodes in each subnet / availability domain. Default `1` (int)
+* `region` - (Required) The availability domain within the region to host the cluster. See [here](https://docs.cloud.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm) for a list of region names. (string)
+* `service_dns_domain_name` - (Optional) Name for DNS domain of service subnet. Default `svcdns` (string)
+* `skip_vcn_delete` - (Optional) Specifies whether to skip deleting the virtual cloud network (VCN) on destroy. Default `false` (bool)
+* `tenancy_id` - (Required) The OCID of the tenancy in which to create resources (string)
+* `user_ocid` - (Required) The OCID of a user who has access to the tenancy/compartment (string)
+* `vcn_name` - (Optional) The name of an existing virtual network to use for the cluster creation. If set, you must also set `load_balancer_subnet_name_1`. A VCN and subnets will be created if none are specified. (string)
+* `worker_node_ingress_cidr` - (Optional) Additional CIDR from which to allow ingress to worker nodes (string)
 
 ### `cluster_auth_endpoint`
 

--- a/rancher2/data_source_rancher2_cluster.go
+++ b/rancher2/data_source_rancher2_cluster.go
@@ -63,6 +63,14 @@ func dataSourceRancher2Cluster() *schema.Resource {
 					Schema: clusterGKEConfigFields(),
 				},
 			},
+			"oke_config": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: clusterOKEConfigFields(),
+				},
+			},
 			"default_project_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -286,6 +286,12 @@ func resourceRancher2ClusterUpdate(d *schema.ResourceData, meta interface{}) err
 			return err
 		}
 		update["googleKubernetesEngineConfig"] = gkeConfig
+	case clusterOKEKind:
+		okeConfig, err := expandClusterOKEConfig(d.Get("oke_config").([]interface{}), d.Get("name").(string))
+		if err != nil {
+			return err
+		}
+		update["okeEngineConfig"] = okeConfig
 	case ToLower(clusterDriverRKE):
 		rkeConfig, err := expandClusterRKEConfig(d.Get("rke_config").([]interface{}), d.Get("name").(string))
 		if err != nil {

--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -12,7 +12,7 @@ const (
 )
 
 var (
-	clusterDrivers = []string{clusterDriverImported, clusterDriverAKS, clusterDriverEKS, clusterDriverGKE, clusterDriverK3S, clusterDriverRKE}
+	clusterDrivers = []string{clusterDriverImported, clusterDriverAKS, clusterDriverEKS, clusterDriverGKE, clusterDriverK3S, clusterDriverOKE, clusterDriverRKE}
 )
 
 //Types
@@ -22,6 +22,7 @@ type Cluster struct {
 	AmazonElasticContainerServiceConfig *AmazonElasticContainerServiceConfig `json:"amazonElasticContainerServiceConfig,omitempty" yaml:"amazonElasticContainerServiceConfig,omitempty"`
 	AzureKubernetesServiceConfig        *AzureKubernetesServiceConfig        `json:"azureKubernetesServiceConfig,omitempty" yaml:"azureKubernetesServiceConfig,omitempty"`
 	GoogleKubernetesEngineConfig        *GoogleKubernetesEngineConfig        `json:"googleKubernetesEngineConfig,omitempty" yaml:"googleKubernetesEngineConfig,omitempty"`
+	OracleKubernetesEngineConfig        *OracleKubernetesEngineConfig        `json:"okeEngineConfig,omitempty" yaml:"okeEngineConfig,omitempty"`
 }
 
 // Schemas
@@ -481,7 +482,7 @@ func clusterFields() map[string]*schema.Schema {
 			MaxItems:      1,
 			Optional:      true,
 			Computed:      true,
-			ConflictsWith: []string{"aks_config", "eks_config", "gke_config", "k3s_config"},
+			ConflictsWith: []string{"aks_config", "eks_config", "gke_config", "k3s_config", "oke_config"},
 			Elem: &schema.Resource{
 				Schema: clusterRKEConfigFields(),
 			},
@@ -491,7 +492,7 @@ func clusterFields() map[string]*schema.Schema {
 			MaxItems:      1,
 			Optional:      true,
 			Computed:      true,
-			ConflictsWith: []string{"aks_config", "eks_config", "gke_config", "rke_config"},
+			ConflictsWith: []string{"aks_config", "eks_config", "gke_config", "oke_config", "rke_config"},
 			Elem: &schema.Resource{
 				Schema: clusterK3SConfigFields(),
 			},
@@ -500,7 +501,7 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"aks_config", "gke_config", "k3s_config", "rke_config"},
+			ConflictsWith: []string{"aks_config", "gke_config", "k3s_config", "oke_config", "rke_config"},
 			Elem: &schema.Resource{
 				Schema: clusterEKSConfigFields(),
 			},
@@ -509,7 +510,7 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"eks_config", "gke_config", "k3s_config", "rke_config"},
+			ConflictsWith: []string{"eks_config", "gke_config", "k3s_config", "oke_config", "rke_config"},
 			Elem: &schema.Resource{
 				Schema: clusterAKSConfigFields(),
 			},
@@ -518,9 +519,18 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"aks_config", "eks_config", "k3s_config", "rke_config"},
+			ConflictsWith: []string{"aks_config", "eks_config", "k3s_config", "oke_config", "rke_config"},
 			Elem: &schema.Resource{
 				Schema: clusterGKEConfigFields(),
+			},
+		},
+		"oke_config": {
+			Type:          schema.TypeList,
+			MaxItems:      1,
+			Optional:      true,
+			ConflictsWith: []string{"aks_config", "eks_config", "gke_config", "k3s_config", "rke_config"},
+			Elem: &schema.Resource{
+				Schema: clusterOKEConfigFields(),
 			},
 		},
 		"default_project_id": {

--- a/rancher2/schema_cluster_oke_config.go
+++ b/rancher2/schema_cluster_oke_config.go
@@ -1,0 +1,184 @@
+// Copyright 2020 Oracle and/or its affiliates.
+
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+const (
+	clusterOKEKind   = "oke"
+	clusterDriverOKE = "oraclecontainerengine"
+)
+
+//Types
+
+type OracleKubernetesEngineConfig struct {
+	CompartmentID               string `json:"compartmentId,omitempty" yaml:"compartmentId,omitempty"`
+	Description                 string `json:"description,omitempty" yaml:"description,omitempty"`
+	DisplayName                 string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
+	EnableKubernetesDashboard   bool   `json:"enableKubernetesDashboard,omitempty" yaml:"enableKubernetesDashboard,omitempty"`
+	Fingerprint                 string `json:"fingerprint,omitempty" yaml:"fingerprint,omitempty"`
+	KubernetesVersion           string `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
+	DriverName                  string `json:"driverName,omitempty" yaml:"driverName,omitempty"`
+	Name                        string `json:"name,omitempty" yaml:"name,omitempty"`
+	NodeImage                   string `json:"nodeImage,omitempty" yaml:"nodeImage,omitempty"`
+	NodePoolSubnetDNSDomainName string `json:"nodePoolDnsDomainName,omitempty" yaml:"nodePoolDnsDomainName,omitempty"`
+	NodePoolSubnetName          string `json:"nodePoolSubnetName,omitempty" yaml:"nodePoolSubnetName,omitempty"`
+	NodePublicSSHKeyContents    string `json:"nodePublicKeyContents,omitempty" yaml:"nodePublicKeyContents,omitempty"`
+	NodeShape                   string `json:"nodeShape,omitempty" yaml:"nodeShape,omitempty"`
+	PrivateKeyContents          string `json:"privateKeyContents,omitempty" yaml:"privateKeyContents,omitempty"`
+	PrivateKeyPassphrase        string `json:"privateKeyPassphrase,omitempty" yaml:"privateKeyPassphrase,omitempty"`
+	PrivateNodes                bool   `json:"enablePrivateNodes,omitempty" yaml:"enablePrivateNodes,omitempty"`
+	QuantityOfSubnets           int64  `json:"quantityOfNodeSubnets,omitempty" yaml:"quantityOfNodeSubnets,omitempty"`
+	QuantityPerSubnet           int64  `json:"quantityPerSubnet,omitempty" yaml:"quantityPerSubnet,omitempty"`
+	Region                      string `json:"region,omitempty" yaml:"region,omitempty"`
+	ServiceLBSubnet1Name        string `json:"loadBalancerSubnetName1,omitempty" yaml:"loadBalancerSubnetName1,omitempty"`
+	ServiceLBSubnet2Name        string `json:"loadBalancerSubnetName2,omitempty" yaml:"loadBalancerSubnetName2,omitempty"`
+	ServiceSubnetDNSDomainName  string `json:"serviceDnsDomainName,omitempty" yaml:"serviceDnsDomainName,omitempty"`
+	SkipVCNDelete               bool   `json:"skipVcnDelete,omitempty" yaml:"skipVcnDelete,omitempty"`
+	TenancyID                   string `json:"tenancyId,omitempty" yaml:"tenancyId,omitempty"`
+	UserOCID                    string `json:"userOcid,omitempty" yaml:"userOcid,omitempty"`
+	VCNName                     string `json:"vcnName,omitempty" yaml:"vcnName,omitempty"`
+	VcnCompartmentID            string `json:"vcnCompartmentId,omitempty" yaml:"vcnCompartmentId,omitempty"`
+	WorkerNodeIngressCidr       string `json:"workerNodeIngressCidr,omitempty" yaml:"workerNodeIngressCidr,omitempty"`
+}
+
+//Schemas
+
+func clusterOKEConfigFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+
+		"compartment_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The OCID of the compartment in which to create resources (VCN, worker nodes, etc.)",
+		},
+		"fingerprint": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The fingerprint corresponding to the specified user's private API Key",
+		},
+		"kubernetes_version": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The Kubernetes version that will be used for your master *and* worker nodes e.g. v1.17.9",
+		},
+		"node_image": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The OS for the node image",
+		},
+		"node_shape": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The shape of the node (determines number of CPUs and  amount of memory on each node)",
+		},
+		"private_key_contents": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "The private API key file contents for the specified user, in PEM format",
+		},
+		"region": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The availability domain within the region to host the OKE cluster",
+		},
+		"tenancy_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The OCID of the tenancy in which to create resources",
+		},
+		"user_ocid": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The OCID of a user who has access to the tenancy/compartment",
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "An optional description of this cluster",
+		},
+		"enable_kubernetes_dashboard": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Enable the kubernetes dashboard",
+		},
+		"enable_private_nodes": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Whether worker nodes are deployed into a new private subnet",
+		},
+		"load_balancer_subnet_name_1": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The name of the first existing subnet to use for Kubernetes services / LB",
+		},
+		"load_balancer_subnet_name_2": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The (optional) name of a second existing subnet to use for Kubernetes services / LB",
+		},
+		"node_pool_dns_domain_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "nodedns",
+			Description: "Optional name for DNS domain of node pool subnet",
+		},
+		"node_pool_subnet_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "nodedns",
+			Description: "Optional name for node pool subnet",
+		},
+		"node_public_key_contents": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The contents of the SSH public key file to use for the nodes",
+		},
+		"private_key_passphrase": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
+			Description: "The passphrase of the private key for the OKE cluster",
+		},
+		"quantity_of_node_subnets": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Number of node subnets (defaults to creating 1 regional subnet)",
+		},
+		"quantity_per_subnet": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Default:     1,
+			Description: "Number of worker nodes in each subnet / availability domain",
+		},
+		"service_dns_domain_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "svcdns",
+			Description: "Optional name for DNS domain of service subnet",
+		},
+		"skip_vcn_delete": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Whether to skip deleting VCN",
+		},
+		"vcn_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The optional name of an existing virtual network to use for the cluster creation. A new VCN will be created if not specified.",
+		},
+		"worker_node_ingress_cidr": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Additional CIDR from which to allow ingress to worker nodes",
+		},
+	}
+
+	return s
+}

--- a/rancher2/structure_cluster.go
+++ b/rancher2/structure_cluster.go
@@ -171,6 +171,20 @@ func flattenCluster(d *schema.ResourceData, in *Cluster, clusterRegToken *manage
 		if err != nil {
 			return err
 		}
+	case clusterOKEKind, clusterDriverOKE:
+		v, ok := d.Get("oke_config").([]interface{})
+		if !ok {
+			v = []interface{}{}
+		}
+
+		okeConfig, err := flattenClusterOKEConfig(in.OracleKubernetesEngineConfig, v)
+		if err != nil {
+			return err
+		}
+		err = d.Set("oke_config", okeConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Setting k3s_config and rke_config always as computed
@@ -338,6 +352,15 @@ func expandCluster(in *schema.ResourceData) (*Cluster, error) {
 		}
 		obj.GoogleKubernetesEngineConfig = gkeConfig
 		obj.Driver = clusterDriverGKE
+	}
+
+	if v, ok := in.Get("oke_config").([]interface{}); ok && len(v) > 0 {
+		okeConfig, err := expandClusterOKEConfig(v, obj.Name)
+		if err != nil {
+			return nil, err
+		}
+		obj.OracleKubernetesEngineConfig = okeConfig
+		obj.Driver = clusterOKEKind
 	}
 
 	if v, ok := in.Get("k3s_config").([]interface{}); ok && len(v) > 0 {

--- a/rancher2/structure_cluster_oke_config.go
+++ b/rancher2/structure_cluster_oke_config.go
@@ -1,0 +1,225 @@
+// Copyright 2020 Oracle and/or its affiliates.
+
+package rancher2
+
+// Flatteners
+
+func flattenClusterOKEConfig(in *OracleKubernetesEngineConfig, p []interface{}) ([]interface{}, error) {
+	var obj map[string]interface{}
+	if len(p) == 0 || p[0] == nil {
+		obj = make(map[string]interface{})
+	} else {
+		obj = p[0].(map[string]interface{})
+	}
+
+	if in == nil {
+		return []interface{}{}, nil
+	}
+
+	if len(in.CompartmentID) > 0 {
+		obj["compartment_id"] = in.CompartmentID
+	}
+
+	if len(in.Description) > 0 {
+		obj["description"] = in.Description
+	}
+
+	obj["enable_kubernetes_dashboard"] = in.EnableKubernetesDashboard
+	obj["enable_private_nodes"] = in.PrivateNodes
+
+	if len(in.Fingerprint) > 0 {
+		obj["fingerprint"] = in.Fingerprint
+	}
+
+	if len(in.KubernetesVersion) > 0 {
+		obj["kubernetes_version"] = in.KubernetesVersion
+	}
+
+	if len(in.ServiceLBSubnet1Name) > 0 {
+		obj["load_balancer_subnet_name_1"] = in.ServiceLBSubnet1Name
+	}
+
+	if len(in.ServiceLBSubnet2Name) > 0 {
+		obj["load_balancer_subnet_name_2"] = in.ServiceLBSubnet2Name
+	}
+
+	if len(in.NodeImage) > 0 {
+		obj["node_image"] = in.NodeImage
+	}
+
+	if len(in.NodePoolSubnetDNSDomainName) > 0 {
+		obj["node_pool_dns_domain_name"] = in.NodePoolSubnetDNSDomainName
+	}
+
+	if len(in.NodePoolSubnetName) > 0 {
+		obj["node_pool_subnet_name"] = in.NodePoolSubnetName
+	}
+
+	if len(in.NodePublicSSHKeyContents) > 0 {
+		obj["node_public_key_contents"] = in.NodePublicSSHKeyContents
+	}
+
+	if len(in.NodeShape) > 0 {
+		obj["node_shape"] = in.NodeShape
+	}
+
+	if len(in.PrivateKeyContents) > 0 {
+		obj["private_key_contents"] = in.PrivateKeyContents
+	}
+
+	if len(in.PrivateKeyPassphrase) > 0 {
+		obj["private_key_passphrase"] = in.PrivateKeyPassphrase
+	}
+
+	if in.QuantityOfSubnets > 0 {
+		obj["quantity_of_node_subnets"] = int(in.QuantityOfSubnets)
+	}
+
+	if in.QuantityPerSubnet > 0 {
+		obj["quantity_per_subnet"] = int(in.QuantityPerSubnet)
+	}
+
+	if len(in.Region) > 0 {
+		obj["region"] = in.Region
+	}
+
+	if len(in.ServiceSubnetDNSDomainName) > 0 {
+		obj["service_dns_domain_name"] = in.ServiceSubnetDNSDomainName
+	}
+
+	obj["skip_vcn_delete"] = in.SkipVCNDelete
+
+	if len(in.TenancyID) > 0 {
+		obj["tenancy_id"] = in.TenancyID
+	}
+
+	if len(in.UserOCID) > 0 {
+		obj["user_ocid"] = in.UserOCID
+	}
+
+	if len(in.VCNName) > 0 {
+		obj["vcn_name"] = in.VCNName
+	}
+
+	if len(in.WorkerNodeIngressCidr) > 0 {
+		obj["worker_node_ingress_cidr"] = in.WorkerNodeIngressCidr
+	}
+
+	return []interface{}{obj}, nil
+}
+
+// Expanders
+
+func expandClusterOKEConfig(p []interface{}, name string) (*OracleKubernetesEngineConfig, error) {
+	obj := &OracleKubernetesEngineConfig{}
+	if len(p) == 0 || p[0] == nil {
+		return obj, nil
+	}
+	in := p[0].(map[string]interface{})
+
+	obj.DisplayName = name
+	obj.Name = name
+	obj.DriverName = clusterDriverOKE
+
+	if v, ok := in["compartment_id"].(string); ok && len(v) > 0 {
+		obj.CompartmentID = v
+	}
+
+	if v, ok := in["description"].(string); ok && len(v) > 0 {
+		obj.Description = v
+	}
+
+	if v, ok := in["enable_kubernetes_dashboard"].(bool); ok {
+		obj.EnableKubernetesDashboard = v
+	}
+
+	if v, ok := in["enable_private_nodes"].(bool); ok {
+		obj.PrivateNodes = v
+	}
+
+	if v, ok := in["fingerprint"].(string); ok && len(v) > 0 {
+		obj.Fingerprint = v
+	}
+
+	if v, ok := in["kubernetes_version"].(string); ok && len(v) > 0 {
+		obj.KubernetesVersion = v
+	}
+
+	if v, ok := in["load_balancer_subnet_name_1"].(string); ok && len(v) > 0 {
+		obj.ServiceLBSubnet1Name = v
+	}
+
+	if v, ok := in["load_balancer_subnet_name_2"].(string); ok && len(v) > 0 {
+		obj.ServiceLBSubnet2Name = v
+	}
+
+	if v, ok := in["name"].(string); ok && len(v) > 0 {
+		obj.Name = v
+	}
+
+	if v, ok := in["node_image"].(string); ok && len(v) > 0 {
+		obj.NodeImage = v
+	}
+
+	if v, ok := in["node_pool_dns_domain_name"].(string); ok && len(v) > 0 {
+		obj.NodePoolSubnetDNSDomainName = v
+	}
+
+	if v, ok := in["node_pool_subnet_name"].(string); ok && len(v) > 0 {
+		obj.NodePoolSubnetName = v
+	}
+
+	if v, ok := in["node_public_key_contents"].(string); ok && len(v) > 0 {
+		obj.NodePublicSSHKeyContents = v
+	}
+
+	if v, ok := in["node_shape"].(string); ok && len(v) > 0 {
+		obj.NodeShape = v
+	}
+
+	if v, ok := in["private_key_contents"].(string); ok && len(v) > 0 {
+		obj.PrivateKeyContents = v
+	}
+
+	if v, ok := in["private_key_passphrase"].(string); ok && len(v) > 0 {
+		obj.PrivateKeyPassphrase = v
+	}
+
+	if v, ok := in["quantity_of_node_subnets"].(int); ok && v > 0 {
+		obj.QuantityOfSubnets = int64(v)
+	}
+
+	if v, ok := in["quantity_per_subnet"].(int); ok && v > 0 {
+		obj.QuantityPerSubnet = int64(v)
+	}
+
+	if v, ok := in["region"].(string); ok && len(v) > 0 {
+		obj.Region = v
+	}
+
+	if v, ok := in["service_dns_domain_name"].(string); ok && len(v) > 0 {
+		obj.ServiceSubnetDNSDomainName = v
+	}
+
+	if v, ok := in["skip_vcn_delete"].(bool); ok {
+		obj.SkipVCNDelete = v
+	}
+
+	if v, ok := in["tenancy_id"].(string); ok && len(v) > 0 {
+		obj.TenancyID = v
+	}
+
+	if v, ok := in["user_ocid"].(string); ok && len(v) > 0 {
+		obj.UserOCID = v
+	}
+
+	if v, ok := in["vcn_name"].(string); ok && len(v) > 0 {
+		obj.VCNName = v
+	}
+
+	if v, ok := in["worker_node_ingress_cidr"].(string); ok && len(v) > 0 {
+		obj.WorkerNodeIngressCidr = v
+	}
+
+	return obj, nil
+}

--- a/rancher2/structure_cluster_oke_config_test.go
+++ b/rancher2/structure_cluster_oke_config_test.go
@@ -1,0 +1,122 @@
+// Copyright 2020 Oracle and/or its affiliates.
+
+package rancher2
+
+import (
+	"reflect"
+	"testing"
+)
+
+var (
+	testClusterOKEConfigConf      *OracleKubernetesEngineConfig
+	testClusterOKEConfigInterface []interface{}
+)
+
+func init() {
+	testClusterOKEConfigConf = &OracleKubernetesEngineConfig{
+		CompartmentID:               "compartment",
+		Description:                 "description",
+		DisplayName:                 "test",
+		DriverName:                  clusterDriverOKE,
+		EnableKubernetesDashboard:   true,
+		Fingerprint:                 "fingerprint",
+		KubernetesVersion:           "version",
+		Name:                        "test",
+		NodeImage:                   "image",
+		NodePoolSubnetDNSDomainName: "nodedns",
+		NodePoolSubnetName:          "nodedns",
+		NodePublicSSHKeyContents:    "public_key",
+		NodeShape:                   "shape",
+		PrivateKeyContents:          "private_key_contents",
+		PrivateKeyPassphrase:        "",
+		PrivateNodes:                false,
+		QuantityOfSubnets:           2,
+		QuantityPerSubnet:           1,
+		Region:                      "region",
+		ServiceLBSubnet1Name:        "",
+		ServiceLBSubnet2Name:        "",
+		ServiceSubnetDNSDomainName:  "svcdns",
+		SkipVCNDelete:               false,
+		TenancyID:                   "tenancy",
+		UserOCID:                    "user",
+		VCNName:                     "",
+		VcnCompartmentID:            "",
+		WorkerNodeIngressCidr:       "",
+	}
+	testClusterOKEConfigInterface = []interface{}{
+		map[string]interface{}{
+			"compartment_id":              "compartment",
+			"description":                 "description",
+			"enable_kubernetes_dashboard": true,
+			"enable_private_nodes":        false,
+			"fingerprint":                 "fingerprint",
+			"kubernetes_version":          "version",
+			"node_image":                  "image",
+			"node_pool_dns_domain_name":   "nodedns",
+			"node_pool_subnet_name":       "nodedns",
+			"node_public_key_contents":    "public_key",
+			"node_shape":                  "shape",
+			"private_key_contents":        "private_key_contents",
+			"private_key_passphrase":      "",
+			"quantity_of_node_subnets":    2,
+			"quantity_per_subnet":         1,
+			"region":                      "region",
+			"load_balancer_subnet_name_1": "",
+			"load_balancer_subnet_name_2": "",
+			"service_dns_domain_name":     "svcdns",
+			"skip_vcn_delete":             false,
+			"tenancy_id":                  "tenancy",
+			"user_ocid":                   "user",
+			"vcn_name":                    "",
+			"worker_node_ingress_cidr":    "",
+		},
+	}
+}
+
+func TestFlattenClusterOKEConfig(t *testing.T) {
+
+	cases := []struct {
+		Input          *OracleKubernetesEngineConfig
+		ExpectedOutput []interface{}
+	}{
+		{
+			testClusterOKEConfigConf,
+			testClusterOKEConfigInterface,
+		},
+	}
+
+	for _, tc := range cases {
+		output, err := flattenClusterOKEConfig(tc.Input, testClusterOKEConfigInterface)
+		if err != nil {
+			t.Fatalf("[ERROR] on flattener: %#v", err)
+		}
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestExpandClusterOKEConfig(t *testing.T) {
+
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *OracleKubernetesEngineConfig
+	}{
+		{
+			testClusterOKEConfigInterface,
+			testClusterOKEConfigConf,
+		},
+	}
+
+	for _, tc := range cases {
+		output, err := expandClusterOKEConfig(tc.Input, "test")
+		if err != nil {
+			t.Fatalf("[ERROR] on expander: %#v", err)
+		}
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}

--- a/rancher2/structure_cluster_test.go
+++ b/rancher2/structure_cluster_test.go
@@ -29,6 +29,8 @@ var (
 	testClusterInterfaceEKS                        map[string]interface{}
 	testClusterConfGKE                             *Cluster
 	testClusterInterfaceGKE                        map[string]interface{}
+	testClusterConfOKE                             *Cluster
+	testClusterInterfaceOKE                        map[string]interface{}
 	testClusterConfRKE                             *Cluster
 	testClusterInterfaceRKE                        map[string]interface{}
 	testClusterConfTemplate                        *Cluster
@@ -233,6 +235,31 @@ func testCluster() {
 		"gke_config":                              testClusterGKEConfigInterface,
 		"system_project_id":                       "system_project_id",
 	}
+	testClusterConfOKE = &Cluster{
+		OracleKubernetesEngineConfig: testClusterOKEConfigConf,
+	}
+	testClusterConfOKE.Name = "test"
+	testClusterConfOKE.Description = "description"
+	testClusterConfOKE.Driver = clusterOKEKind
+	testClusterConfOKE.DefaultPodSecurityPolicyTemplateID = "restricted"
+	testClusterConfOKE.EnableClusterMonitoring = true
+	testClusterConfOKE.EnableNetworkPolicy = newTrue()
+	testClusterConfOKE.LocalClusterAuthEndpoint = testLocalClusterAuthEndpointConf
+	testClusterInterfaceOKE = map[string]interface{}{
+		"id":                         "id",
+		"name":                       "test",
+		"default_project_id":         "default_project_id",
+		"description":                "description",
+		"cluster_auth_endpoint":      testLocalClusterAuthEndpointInterface,
+		"cluster_registration_token": testClusterRegistrationTokenInterface,
+		"default_pod_security_policy_template_id": "restricted",
+		"enable_cluster_monitoring":               true,
+		"enable_network_policy":                   true,
+		"kube_config":                             "kube_config",
+		"driver":                                  clusterOKEKind,
+		"oke_config":                              testClusterOKEConfigInterface,
+		"system_project_id":                       "system_project_id",
+	}
 	testClusterConfRKE = &Cluster{}
 	testClusterConfRKE.Name = "test"
 	testClusterConfRKE.Description = "description"
@@ -350,6 +377,12 @@ func TestFlattenCluster(t *testing.T) {
 			testClusterInterfaceGKE,
 		},
 		{
+			testClusterConfOKE,
+			testClusterRegistrationTokenConf,
+			testClusterGenerateKubeConfigOutput,
+			testClusterInterfaceOKE,
+		},
+		{
 			testClusterConfRKE,
 			testClusterRegistrationTokenConf,
 			testClusterGenerateKubeConfigOutput,
@@ -428,6 +461,10 @@ func TestExpandCluster(t *testing.T) {
 		{
 			testClusterInterfaceGKE,
 			testClusterConfGKE,
+		},
+		{
+			testClusterInterfaceOKE,
+			testClusterConfOKE,
 		},
 		{
 			testClusterInterfaceRKE,


### PR DESCRIPTION
This PR adds support Oracle Cloud Infrastructure Container Engine for Kubernetes (also known as OKE) to the `rancher2_clusters` resource via a `oke_config` argument. It also adds the corresponding data-source as well as the documentation and unit tests. The [OKE driver](https://github.com/rancher-plugins/kontainer-engine-driver-oke) is a builtin cluster-driver as of 2.4+.

See also issue #462

Below is a minimal example of a `oke_config` in `rancher2_cluster`:

```hcl
resource "rancher2_cluster" "dev" {
  name        = "dev-oke"
  description = "oke dev-cluster"
  oke_config {
    compartment_id       = "ocid1.compartment.oc1..aaaaaaaaaaaaaaaaaaaaaaaa"
    tenancy_id           = "ocid1.tenancy.oc1..aaaaaaaaaaaaaaaaaaaaaaaa"
    user_ocid            = "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaa"
    region               = "us-phoenix-1"
    fingerprint          = "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
    node_shape           = "VM.Standard2.4"
    node_image           = "Oracle-Linux-7.8-2020.08.26-0"
    private_key_contents = "-----BEGIN RSA PRIVATE KEY-----\n....\n-----END RSA PRIVATE KEY-----"
  quantity_per_subnet = 1
  kubernetes_version = "v1.17.9"
  enable_private_nodes = "false"
  skip_vcn_delete = false
  }
}
```

![oke_tf](https://user-images.githubusercontent.com/13613687/93834274-1f2e9e00-fc30-11ea-8234-a65bbbfe67b5.png)

