### PR TITLE
add openstack application credentials to node template

### DIFF
--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -235,12 +235,12 @@ The following attributes are exported:
 * `auth_url` - (Required) OpenStack authentication URL (string)
 * `availability_zone` - (Required) OpenStack availability zone (string)
 * `region` - (Required) OpenStack region name (string)
-* `username` - (Required) OpenStack username (string)
+* `username` - (Required**) OpenStack username (string)
 * `active_timeout`- (Optional) OpenStack active timeout Default `200` (string)
 * `cacert` - (Optional) CA certificate bundle to verify against (string)
 * `config_drive` - (Optional) Enables the OpenStack config drive for the instance. Default `false` (bool)
-* `domain_id` - (Required*) OpenStack domain ID. Identity v3 only. Conflicts with `domain_name` (string)
-* `domain_name` - (Required*) OpenStack domain name. Identity v3 only. Conflicts with `domain_id` (string)
+* `domain_id` - (Required**) OpenStack domain ID. Identity v3 only. Conflicts with `domain_name` (string)
+* `domain_name` - (Required**) OpenStack domain name. Identity v3 only. Conflicts with `domain_id` (string)
 * `endpoint_type` - (Optional) OpenStack endpoint type. adminURL, internalURL or publicURL (string)
 * `flavor_id` - (Required*) OpenStack flavor id to use for the instance. Conflicts with `flavor_name` (string)
 * `flavor_name` - (Required*) OpenStack flavor name to use for the instance. Conflicts with `flavor_id` (string)
@@ -258,11 +258,16 @@ The following attributes are exported:
 * `sec_groups` - (Optional) OpenStack comma separated security groups for the machine (string)
 * `ssh_port` - (Optional) OpenStack SSH port * Default `22` (string)
 * `ssh_user` - (Optional) OpenStack SSH user * Default: `root` (string)
-* `tenant_id` - (Required*) OpenStack tenant id. Conflicts with `tenant_name` (string)
-* `tenant_name` - (Required*) OpenStack tenant name. Conflicts with `tenant_id` (string)
+* `tenant_id` - (Required**) OpenStack tenant id. Conflicts with `tenant_name` (string)
+* `tenant_name` - (Required**) OpenStack tenant name. Conflicts with `tenant_id` (string)
 * `user_data_file` - (Optional) File containing an openstack userdata script (string)
+* `application_credential_id` - (Optional) OpenStack application credential id. Conflicts with `application_credential_name` (string)
+* `application_credential_name` - (Optional) OpenStack application credential name. Conflicts with `application_credential_id` (string)
+* `application_credential_secret` - (Optional) OpenStack application credential secret (string)
 
 > **Note**: `Required*` denotes that either the _name or _id is required but you cannot use both.
+
+> **Note**: `Required**` denotes that either the _name or _id is required unless `application_credential_id` is defined.
 
 ### `vsphere_config`
 

--- a/rancher2/schema_node_template_openstack.go
+++ b/rancher2/schema_node_template_openstack.go
@@ -11,35 +11,38 @@ const (
 //Types
 
 type openstackConfig struct {
-	ActiveTimeout    string `json:"activeTimeout,omitempty" yaml:"activeTimeout,omitempty"`
-	AuthURL          string `json:"authUrl,omitempty" yaml:"authUrl,omitempty"`
-	AvailabilityZone string `json:"availabilityZone,omitempty" yaml:"availabilityZone,omitempty"`
-	CaCert           string `json:"cacert,omitempty" yaml:"cacert,omitempty"`
-	ConfigDrive      bool   `json:"configDrive,omitempty" yaml:"configDrive,omitempty"`
-	DomainID         string `json:"domainId,omitempty" yaml:"domainId,omitempty"`
-	DomainName       string `json:"domainName,omitempty" yaml:"domainName,omitempty"`
-	EndpointType     string `json:"endpointType,omitempty" yaml:"endpointType,omitempty"`
-	FlavorID         string `json:"flavorId,omitempty" yaml:"flavorId,omitempty"`
-	FlavorName       string `json:"flavorName,omitempty" yaml:"flavorName,omitempty"`
-	FloatingIPPool   string `json:"floatingipPool,omitempty" yaml:"floatingipPool,omitempty"`
-	ImageID          string `json:"imageId,omitempty" yaml:"imageId,omitempty"`
-	ImageName        string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
-	Insecure         bool   `json:"insecure,omitempty" yaml:"insecure,omitempty"`
-	IPVersion        string `json:"ipVersion,omitempty" yaml:"ipVersion,omitempty"`
-	KeypairName      string `json:"keypairName,omitempty" yaml:"keypairName,omitempty"`
-	NetID            string `json:"netId,omitempty" yaml:"netId,omitempty"`
-	NetName          string `json:"netName,omitempty" yaml:"netName,omitempty"`
-	NovaNetwork      bool   `json:"novaNetwork,omitempty" yaml:"novaNetwork,omitempty"`
-	Password         string `json:"password,omitempty" yaml:"password,omitempty"`
-	PrivateKeyFile   string `json:"privateKeyFile,omitempty" yaml:"privateKeyFile,omitempty"`
-	Region           string `json:"region,omitempty" yaml:"region,omitempty"`
-	SecGroups        string `json:"secGroups,omitempty" yaml:"secGroups,omitempty"`
-	SSHPort          string `json:"sshPort,omitempty" yaml:"sshPort,omitempty"`
-	SSHUser          string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
-	TenantID         string `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
-	TenantName       string `json:"tenantName,omitempty" yaml:"tenantName,omitempty"`
-	UserDataFile     string `json:"userDataFile,omitempty" yaml:"userDataFile,omitempty"`
-	Username         string `json:"username,omitempty" yaml:"username,omitempty"`
+	ActiveTimeout               string `json:"activeTimeout,omitempty" yaml:"activeTimeout,omitempty"`
+	AuthURL                     string `json:"authUrl,omitempty" yaml:"authUrl,omitempty"`
+	AvailabilityZone            string `json:"availabilityZone,omitempty" yaml:"availabilityZone,omitempty"`
+	CaCert                      string `json:"cacert,omitempty" yaml:"cacert,omitempty"`
+	ConfigDrive                 bool   `json:"configDrive,omitempty" yaml:"configDrive,omitempty"`
+	DomainID                    string `json:"domainId,omitempty" yaml:"domainId,omitempty"`
+	DomainName                  string `json:"domainName,omitempty" yaml:"domainName,omitempty"`
+	EndpointType                string `json:"endpointType,omitempty" yaml:"endpointType,omitempty"`
+	FlavorID                    string `json:"flavorId,omitempty" yaml:"flavorId,omitempty"`
+	FlavorName                  string `json:"flavorName,omitempty" yaml:"flavorName,omitempty"`
+	FloatingIPPool              string `json:"floatingipPool,omitempty" yaml:"floatingipPool,omitempty"`
+	ImageID                     string `json:"imageId,omitempty" yaml:"imageId,omitempty"`
+	ImageName                   string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
+	Insecure                    bool   `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	IPVersion                   string `json:"ipVersion,omitempty" yaml:"ipVersion,omitempty"`
+	KeypairName                 string `json:"keypairName,omitempty" yaml:"keypairName,omitempty"`
+	NetID                       string `json:"netId,omitempty" yaml:"netId,omitempty"`
+	NetName                     string `json:"netName,omitempty" yaml:"netName,omitempty"`
+	NovaNetwork                 bool   `json:"novaNetwork,omitempty" yaml:"novaNetwork,omitempty"`
+	Password                    string `json:"password,omitempty" yaml:"password,omitempty"`
+	PrivateKeyFile              string `json:"privateKeyFile,omitempty" yaml:"privateKeyFile,omitempty"`
+	Region                      string `json:"region,omitempty" yaml:"region,omitempty"`
+	SecGroups                   string `json:"secGroups,omitempty" yaml:"secGroups,omitempty"`
+	SSHPort                     string `json:"sshPort,omitempty" yaml:"sshPort,omitempty"`
+	SSHUser                     string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	TenantID                    string `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
+	TenantName                  string `json:"tenantName,omitempty" yaml:"tenantName,omitempty"`
+	UserDataFile                string `json:"userDataFile,omitempty" yaml:"userDataFile,omitempty"`
+	Username                    string `json:"username,omitempty" yaml:"username,omitempty"`
+	ApplicationCredentialID     string `json:"applicationCredentialId,omitempty" yaml:"applicationCredentialId,omitempty"`
+	ApplicationCredentialName   string `json:"applicationCredentialName,omitempty" yaml:"applicationCredentialName,omitempty"`
+	ApplicationCredentialSecret string `json:"applicationCredentialSecret,omitempty" yaml:"applicationCredentialSecret,omitempty"`
 }
 
 //Schemas
@@ -60,7 +63,7 @@ func openstackConfigFields() map[string]*schema.Schema {
 		},
 		"username": {
 			Type:     schema.TypeString,
-			Required: true,
+			Optional: true,
 		},
 		"active_timeout": {
 			Type:     schema.TypeString,
@@ -170,6 +173,19 @@ func openstackConfigFields() map[string]*schema.Schema {
 		"user_data_file": {
 			Type:     schema.TypeString,
 			Optional: true,
+		},
+		"application_credential_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"application_credential_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"application_credential_secret": {
+			Type:      schema.TypeString,
+			Optional:  true,
+			Sensitive: true,
 		},
 	}
 	return s

--- a/rancher2/structure_node_template_openstack.go
+++ b/rancher2/structure_node_template_openstack.go
@@ -37,6 +37,9 @@ func flattenOpenstackConfig(in *openstackConfig) []interface{} {
 	obj["tenant_name"] = in.TenantName
 	obj["user_data_file"] = in.UserDataFile
 	obj["username"] = in.Username
+	obj["application_credential_id"] = in.ApplicationCredentialID
+	obj["application_credential_name"] = in.ApplicationCredentialName
+	obj["application_credential_secret"] = in.ApplicationCredentialSecret
 
 	return []interface{}{obj}
 }
@@ -139,6 +142,15 @@ func expandOpenstackConfig(p []interface{}) *openstackConfig {
 	}
 	if v, ok := in["username"].(string); ok && len(v) > 0 {
 		obj.Username = v
+	}
+	if v, ok := in["application_credential_id"].(string); ok && len(v) > 0 {
+		obj.ApplicationCredentialID = v
+	}
+	if v, ok := in["application_credential_name"].(string); ok && len(v) > 0 {
+		obj.ApplicationCredentialName = v
+	}
+	if v, ok := in["application_credential_secret"].(string); ok && len(v) > 0 {
+		obj.ApplicationCredentialSecret = v
 	}
 	return obj
 }


### PR DESCRIPTION
Adds the ability to specify OpenStack application credentials in a node template instead of using username and password.

Fixes #418 