### PR TITLE
Expose app timeout

### DIFF
--- a/rancher2/structure_app.go
+++ b/rancher2/structure_app.go
@@ -158,5 +158,7 @@ func expandApp(in *schema.ResourceData) (*projectClient.App, error) {
 		obj.Labels = toMapString(v)
 	}
 
+	obj.Timeout = int64(in.Timeout(schema.TimeoutCreate).Seconds())
+
 	return obj, nil
 }

--- a/rancher2/structure_app_test.go
+++ b/rancher2/structure_app_test.go
@@ -40,6 +40,7 @@ func init() {
 			"option1": "value1",
 			"option2": "value2",
 		},
+		Timeout: 1200,
 	}
 	testAppInterfaceGlobal = map[string]interface{}{
 		"catalog_name": "test",
@@ -85,6 +86,7 @@ func init() {
 			"option1": "value1",
 			"option2": "value2",
 		},
+		Timeout: 1200,
 	}
 	testAppInterfaceClusterLocal = map[string]interface{}{
 		"catalog_name":     "local:test",
@@ -129,6 +131,7 @@ func init() {
 			"option1": "value1",
 			"option2": "value2",
 		},
+		Timeout: 1200,
 	}
 	testAppInterfaceCluster = map[string]interface{}{
 		"catalog_name":     "c-XXXXX:test",
@@ -173,6 +176,7 @@ func init() {
 			"option1": "value1",
 			"option2": "value2",
 		},
+		Timeout: 1200,
 	}
 	testAppInterfaceProject = map[string]interface{}{
 		"catalog_name":     "p-XXXXX:test",


### PR DESCRIPTION
Expose the application timeout, as the default value of 300 seconds, 5
minutes is sometimes insufficient.

Signed-off-by: Gary Lockyer <gary@catalyst.net.nz>