### PR TITLE
Rancher v2.5.2 support and Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.10.5 (Unreleased)
+## 1.10.5 (November 6, 2020)
 
 FEATURES:
 
@@ -7,11 +7,20 @@ FEATURES:
 
 ENHANCEMENTS:
 
-
+* Updated go mod to support Rancher `v2.5.2-rc2`
+* Updated acceptance tests to use Rancher `v2.5.2-rc2`
+* Improved `rancher2_bootstrap` on resource creation. Number of retires on `bootstrapDoLogin` function can be configured with `retries` provider argument
+* Updated `rancher2_catalog_v2` contextualized resource id with `cluster_id` prefix
+* Updated `rancher2_app_v2` contextualized resource id with `cluster_id` prefix
+* Updated `rancher2_app_v2` to show helm operation log if fail
+* Updated `rancher2_app_v2.values` argument as sensitive
 
 BUG FIXES:
 
-
+* Fixed `rancher2_cluster.rke_config.upgrade_strategy.drain` argument to set false value properly
+* Fixed `Apps & marketplace` guide for Rancher v2.5.0 format
+* Fixed `rancher2_app_v2.values` argument to avoid false diff
+* Fixed `rancher2_cluster_role_template_binding` and  `rancher2_cluster_role_template_binding` arguments to forceNew on update  
 
 ## 1.10.4 (October 29, 2020)
 
@@ -45,6 +54,7 @@ BUG FIXES:
 
 * Fix `rke_config.monitoring.replicas` argument to set default value to 1 if monitoring enabled
 * Fix Rancher auth config apply on activedirectory, freeipa and openldap providers
+* Fix `rancher2_cluster.rke_config.upgrade_strategy.drain` argument to set false value properly
 
 
 ## 1.10.3 (September 14, 2020)

--- a/docs/guides/apps_marketplace.md
+++ b/docs/guides/apps_marketplace.md
@@ -127,7 +127,8 @@ EOF
 }
 ```
 
-** tip ** If you are reinstalling `rancher-monitoring` and the deployment is failing, try adding this values to app v2
+**Tip:** If you are reinstalling `rancher-monitoring` and the deployment is failing, try adding this values to app v2
+
 ```
 alertmanager:
   alertmanagerSpec:
@@ -147,6 +148,11 @@ resource "rancher2_app_v2" "rancher-monitoring" {
   chart_name = "rancher-monitoring"
   chart_version = "9.4.200"
   values = <<EOF
+alertmanager:
+  alertmanagerSpec:
+    enabled: false
+    useExistingSecret: true
+    configSecret: alertmanager-rancher-monitoring-alertmanager
 prometheus:
   prometheusSpec:
     requests:

--- a/docs/resources/app_v2.md
+++ b/docs/resources/app_v2.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `chart_name` - (Required) The app v2 chart name (string)
 * `chart_version` - (Optional) The app v2 chart version (string)
 * `project_id` - (Optional) Deploy the app v2 within project ID (string)
-* `values` - (Optional) The app v2 values yaml. Yaml format is required (string)
+* `values` - (Optional/Sensitive) The app v2 values yaml. Yaml format is required (string)
 * `cleanup_on_fail` - (Optional) Cleanup app v2 on failed chart upgrade. Default: `false` (bool)
 * `disable_hooks` - (Optional) Disable app v2 chart hooks. Default: `false` (bool)
 * `disable_open_api_validation` - (Optional) Disable app V2 Open API Validation. Default: `false` (bool)

--- a/go.mod
+++ b/go.mod
@@ -7,25 +7,24 @@ require (
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/terraform-plugin-sdk v1.14.0
 	github.com/rancher/client-go v11.0.0+incompatible // indirect
-	github.com/rancher/eks-operator v1.0.1 // indirect
 	github.com/rancher/lasso v0.0.0-20200905045615-7fcb07d6a20b // indirect
 	github.com/rancher/norman v0.0.0-20200930000340-693d65aaffe3
-	github.com/rancher/rancher v0.0.0-20201007163458-eb990af66be1
+	github.com/rancher/rancher v0.0.0-20201109223515-3205bc1e82e5
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/rancher/pkg/client v0.0.0
-	github.com/rancher/wrangler v0.7.2
+	github.com/rancher/wrangler v0.7.3-0.20201023210123-9b7d265b90ec // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	gopkg.in/yaml.v2 v2.3.0
-	k8s.io/api v0.19.0
+	k8s.io/api v0.19.0 // indirect
 	k8s.io/apimachinery v0.19.0
 	k8s.io/apiserver v0.19.0
-	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/client-go v12.0.0+incompatible // indirect
 )
 
 replace (
 	github.com/crewjam/saml => github.com/crewjam/saml v0.4.1
-	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20201007163458-eb990af66be1
-	github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20201007163458-eb990af66be1
+	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20201109223515-3205bc1e82e5
+	github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20201109223515-3205bc1e82e5
 	k8s.io/api => k8s.io/api v0.19.0
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.19.0
 	k8s.io/apimachinery => github.com/rancher/apimachinery v0.19.0-rancher1

--- a/go.sum
+++ b/go.sum
@@ -1042,6 +1042,7 @@ github.com/rancher/apiserver v0.0.0-20200730050206-780f0e4c5f48 h1:XmhN3O0azgyrM
 github.com/rancher/apiserver v0.0.0-20200730050206-780f0e4c5f48/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
 github.com/rancher/apiserver v0.0.0-20200930005138-e90b0a39d0c0 h1:8B+JgDR/4SoY3Z5Z1E0iMGDmnVg9prqM2HuZmOs4ft8=
 github.com/rancher/apiserver v0.0.0-20200930005138-e90b0a39d0c0/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
+github.com/rancher/apiserver v0.0.0-20201023000256-1a0a904f9197/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=
 github.com/rancher/client-go v1.17.2-rancher.3/go.mod h1:QAzRgsa0C2xl4/eVpeVAZMvikCn8Nm81yqVx3Kk9XYI=
 github.com/rancher/client-go v1.18.8-rancher.1 h1:TtrjNtTzwOsWbSKVo2iRzDE3adb6dgkl+/y4HlaLNMY=
 github.com/rancher/client-go v1.18.8-rancher.1/go.mod h1:HqFqMllQ5NnQJNwjro9k5zMyfhZlOwpuTLVrxjkYSxU=
@@ -1058,6 +1059,8 @@ github.com/rancher/eks-operator v0.1.0-rc30 h1:5Q/TWFRzHX7O4ZsNAdaSMSSHVHoxYxB5G
 github.com/rancher/eks-operator v0.1.0-rc30/go.mod h1:Q9J5NGpq/y1qdog+6YzYmvhPDKgJ7F/8vOgza9+HF6M=
 github.com/rancher/eks-operator v1.0.1 h1:U2b7kJSOm4oKiEVfMdXqNpo2RlFOh+VSvsqtjZBQxKk=
 github.com/rancher/eks-operator v1.0.1/go.mod h1:Q9J5NGpq/y1qdog+6YzYmvhPDKgJ7F/8vOgza9+HF6M=
+github.com/rancher/eks-operator v1.0.4 h1:yFEdfutbRoDUV5aHw2cQkQBBO14x4wypmk1VNHhKCTU=
+github.com/rancher/eks-operator v1.0.4/go.mod h1:Bbm03sRUFEfMiP9xA6rCLHB1RiKbifvvs0Egl8+XdOA=
 github.com/rancher/kubernetes-provider-detector v0.0.0-20200807181951-690274ab1fb3/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
 github.com/rancher/kubernetes-provider-detector v0.1.0/go.mod h1:ypuJS7kP7rUiAn330xG46mj+Nhvym05GM8NqMVekpH0=
 github.com/rancher/lasso v0.0.0-20200427171700-e0509f89f319/go.mod h1:6Dw19z1lDIpL887eelVjyqH/mna1hfR61ddCFOG78lw=
@@ -1096,6 +1099,12 @@ github.com/rancher/rancher v0.0.0-20201006004413-65f3525cdc11 h1:rswGHFUGMjvWpx9
 github.com/rancher/rancher v0.0.0-20201006004413-65f3525cdc11/go.mod h1:9SAouAL0Ju4MislIyIvDMlZzWY1baecQ7AQleW+EQ0A=
 github.com/rancher/rancher v0.0.0-20201007163458-eb990af66be1 h1:TMvX3oa6Uo7QTeJPwc5WryPY9NGre99Hdol91ROMr8E=
 github.com/rancher/rancher v0.0.0-20201007163458-eb990af66be1/go.mod h1:9SAouAL0Ju4MislIyIvDMlZzWY1baecQ7AQleW+EQ0A=
+github.com/rancher/rancher v0.0.0-20201030190240-e80ea39ccc79 h1:nYLXcK7zmlkkHTwJSWoyOYFMZUuflp8tV15JBV6smk4=
+github.com/rancher/rancher v0.0.0-20201030190240-e80ea39ccc79/go.mod h1:cKmc3M+0CbJxpg70LkglLJ5s0qj1dM7PaSnlVOm7XHg=
+github.com/rancher/rancher v0.0.0-20201031154808-22e997aa268a h1:IhnfCoq+2sQOyoFvX32Mg7FqSznPhWsFR+3nWAh1AiA=
+github.com/rancher/rancher v0.0.0-20201031154808-22e997aa268a/go.mod h1:cKmc3M+0CbJxpg70LkglLJ5s0qj1dM7PaSnlVOm7XHg=
+github.com/rancher/rancher v0.0.0-20201109223515-3205bc1e82e5 h1:DSKAoV6JNuf+wK07Z5NVLpIZBGjgasLnfEr/TV5JAL4=
+github.com/rancher/rancher v0.0.0-20201109223515-3205bc1e82e5/go.mod h1:8GVPnrjfMPp0yHO+QofjN5uG4giu1BkrezQ+HKYyabc=
 github.com/rancher/rancher v2.2.13+incompatible h1:LzIBmtbHxMl9gpwcwWYPl8Qdl9+bzY2JeSiTAGtochY=
 github.com/rancher/rancher/pkg/apis v0.0.0-20200827144819-5e1b21b931ac/go.mod h1:IRGNKTYcyi3lg/IwYpxvc0f+B71WdFeEz58Nb/7+6GA=
 github.com/rancher/rancher/pkg/apis v0.0.0-20200828154848-941896ed704f h1:8sR6QrTy0iM/5pFiO9UJB411ev5b3Wm5sly+QtuDK2U=
@@ -1110,6 +1119,10 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20201006004413-65f3525cdc11 h1:71sUAv
 github.com/rancher/rancher/pkg/apis v0.0.0-20201006004413-65f3525cdc11/go.mod h1:DfKhLz+l9O7g+4sly/7/8PnJrfi4mVJRFG3SMDf/nJ4=
 github.com/rancher/rancher/pkg/apis v0.0.0-20201007163458-eb990af66be1 h1:uOFvBP1v70EgyoVQ56tIxlAlK+6OatPJMY5un4xellQ=
 github.com/rancher/rancher/pkg/apis v0.0.0-20201007163458-eb990af66be1/go.mod h1:DfKhLz+l9O7g+4sly/7/8PnJrfi4mVJRFG3SMDf/nJ4=
+github.com/rancher/rancher/pkg/apis v0.0.0-20201031154808-22e997aa268a h1:/2d34L5nkX9xXjaE/S1oy9I6ScKekHVMEft0DPn8Ehw=
+github.com/rancher/rancher/pkg/apis v0.0.0-20201031154808-22e997aa268a/go.mod h1:UM8C6yuNwGrJZ3Gb1bs5XPY321Pb9FP218YJkTf+pWg=
+github.com/rancher/rancher/pkg/apis v0.0.0-20201109223515-3205bc1e82e5 h1:B/uiT3bu1hx2kpfNIyvRPCL+5ZvUwGeQfs8j7a68ZSg=
+github.com/rancher/rancher/pkg/apis v0.0.0-20201109223515-3205bc1e82e5/go.mod h1:bi73dwViquKSFkgTc8wmTeXARZFyy4C5WGA22qSdnro=
 github.com/rancher/rancher/pkg/client v0.0.0-20200827144819-5e1b21b931ac h1:3EgTrvGwtyeMlBJl/9vqBjdf6W3MPQpvMHnRBkK8F0E=
 github.com/rancher/rancher/pkg/client v0.0.0-20200827144819-5e1b21b931ac/go.mod h1:iUy4JIYYA0BBQ7nFxueLJYDCYg7Hhoo+VY5t9HQXmlc=
 github.com/rancher/rancher/pkg/client v0.0.0-20200828154848-941896ed704f h1:AAXDQWGx7wVlcJGU6V4ACd6hdGW/ZYoCBOQu1VomAAk=
@@ -1124,6 +1137,10 @@ github.com/rancher/rancher/pkg/client v0.0.0-20201006004413-65f3525cdc11 h1:ifnm
 github.com/rancher/rancher/pkg/client v0.0.0-20201006004413-65f3525cdc11/go.mod h1:iUy4JIYYA0BBQ7nFxueLJYDCYg7Hhoo+VY5t9HQXmlc=
 github.com/rancher/rancher/pkg/client v0.0.0-20201007163458-eb990af66be1 h1:MA+CjgLceR4ytl/KyTd6wUPFHm3dy16fNklZ7IoGEz8=
 github.com/rancher/rancher/pkg/client v0.0.0-20201007163458-eb990af66be1/go.mod h1:iUy4JIYYA0BBQ7nFxueLJYDCYg7Hhoo+VY5t9HQXmlc=
+github.com/rancher/rancher/pkg/client v0.0.0-20201031154808-22e997aa268a h1:01t3KT4Lgs+9DwOiHcx9YIPM7mjegTiWRJ9DF3CpLU4=
+github.com/rancher/rancher/pkg/client v0.0.0-20201031154808-22e997aa268a/go.mod h1:iUy4JIYYA0BBQ7nFxueLJYDCYg7Hhoo+VY5t9HQXmlc=
+github.com/rancher/rancher/pkg/client v0.0.0-20201109223515-3205bc1e82e5 h1:Vl5BknCQSrtFVA+9eKiG571u2afkog0ifmqwjJtNkac=
+github.com/rancher/rancher/pkg/client v0.0.0-20201109223515-3205bc1e82e5/go.mod h1:iUy4JIYYA0BBQ7nFxueLJYDCYg7Hhoo+VY5t9HQXmlc=
 github.com/rancher/rdns-server v0.0.0-20180802070304-bf662911db6a/go.mod h1:YW8wJ/coee2n9ed937uPBWQArBaVlxs+5wkkS9KiyDc=
 github.com/rancher/remotedialer v0.2.6-0.20200820180140-e5448aaba7ee/go.mod h1:dbzn9NF1JWbGEHL6Q/1KG4KFROILiY/j6wmfF1Np3fk=
 github.com/rancher/rke v1.2.0-rc15 h1:s8kPVj16/+yppC08mvNUQ6S6sA2mxfUrO/KgaM4I0w4=
@@ -1134,6 +1151,10 @@ github.com/rancher/rke v1.2.0-rc8 h1:WrEE/NVUyBHk1ueIIwUiKu4Qt6Tefemq8qpjLVT5SqE
 github.com/rancher/rke v1.2.0-rc8/go.mod h1:aPSc14Hp8UGLscL/wB9ZZQHPX/kjDiPXLcoMTCY2NS4=
 github.com/rancher/rke v1.2.0 h1:IxnUfQKyiQ1F16xERd9JSboS8g43JHtjpmtcfgssHQE=
 github.com/rancher/rke v1.2.0/go.mod h1:aPSc14Hp8UGLscL/wB9ZZQHPX/kjDiPXLcoMTCY2NS4=
+github.com/rancher/rke v1.2.2-rc4 h1:2lt7KJM82l2W8C4HBWFOWPeQORnuXMABv3gS+gFwEDo=
+github.com/rancher/rke v1.2.2-rc4/go.mod h1:aPSc14Hp8UGLscL/wB9ZZQHPX/kjDiPXLcoMTCY2NS4=
+github.com/rancher/rke v1.2.2 h1:E5Vqs+vO+M0iN/0b5EsS0vc9Bg5BtQtXOQVXVakxr4s=
+github.com/rancher/rke v1.2.2/go.mod h1:aPSc14Hp8UGLscL/wB9ZZQHPX/kjDiPXLcoMTCY2NS4=
 github.com/rancher/security-scan v0.1.7-0.20200222041501-f7377f127168/go.mod h1:WlLAocVyVQs5J8r0IiQXsp0ajVZO6hYi/Vo6zxjo73s=
 github.com/rancher/steve v0.0.0-20200810194305-6ebfa39af82c h1:GyN1uaOC5XU0m3Yn40gb6CLl8r094cG10GMBsfs0YQE=
 github.com/rancher/steve v0.0.0-20200810194305-6ebfa39af82c/go.mod h1:OzaEqY4YLLtoxJ9Qozo6+PcmDnzzJ/VN8l3o48d8mR0=
@@ -1143,6 +1164,7 @@ github.com/rancher/steve v0.0.0-20200930182348-e7858849e90c h1:uu7ZgUMc/DeTT72R0
 github.com/rancher/steve v0.0.0-20200930182348-e7858849e90c/go.mod h1:BwtPwkGv6vayWxQXWaJazMEbt/NM0kb/+qbGVSCfrCg=
 github.com/rancher/steve v0.0.0-20201001183606-e0e2eddcb1b2 h1:D0kqOYXm1mTLwmckKajkTU9630Io+FZyqNH372FnjYg=
 github.com/rancher/steve v0.0.0-20201001183606-e0e2eddcb1b2/go.mod h1:ejhy2JaZWwl/FWvuR566aizHG4XvBLHCWyRXVozCa6s=
+github.com/rancher/steve v0.0.0-20201023210011-92638937dffd/go.mod h1:X57vY9bp/Jla+9ZS0kIxXybCsBns8axTAjmQc7iu40k=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20200825145542-a04e2061be24/go.mod h1:f8UA6yw5xPtSspqXUQZNfs7bTyG0UOfzJz7zOkegir4=
 github.com/rancher/types v0.0.0-20200609171948-b18f4c194419 h1:UdhVgG4irjMaNVoZlJygXv1AD7eDYeS4srnLHjMezbg=
 github.com/rancher/types v0.0.0-20200609171948-b18f4c194419/go.mod h1:J6XqSEmTbADDyC4Dp6LLiceNtnlYvyHEcV4o7zG/0hg=
@@ -1170,6 +1192,9 @@ github.com/rancher/wrangler v0.6.2-0.20200922204249-68dfef44d080/go.mod h1:I7qe4
 github.com/rancher/wrangler v0.7.1/go.mod h1:goezjesEKwMxHLfltdjg9DW0xWV7txQee6vOuSDqXAI=
 github.com/rancher/wrangler v0.7.2 h1:GlUIFKO26qq1ICMf1CjAGBr2uP52GQX3E0E69zkW88Q=
 github.com/rancher/wrangler v0.7.2/go.mod h1:goezjesEKwMxHLfltdjg9DW0xWV7txQee6vOuSDqXAI=
+github.com/rancher/wrangler v0.7.3-0.20201020003736-e86bc912dfac/go.mod h1:goezjesEKwMxHLfltdjg9DW0xWV7txQee6vOuSDqXAI=
+github.com/rancher/wrangler v0.7.3-0.20201023210123-9b7d265b90ec h1:FSHitOD9wDscz28bH5b9UPmFA9ZMe50Mu4GFWZqUfHg=
+github.com/rancher/wrangler v0.7.3-0.20201023210123-9b7d265b90ec/go.mod h1:goezjesEKwMxHLfltdjg9DW0xWV7txQee6vOuSDqXAI=
 github.com/rancher/wrangler-api v0.5.1-0.20200326194427-c13310506d04/go.mod h1:R3nemXoECcrDqXDSHdY7yJay4j42TeEkU79Hep0rdJ8=
 github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e/go.mod h1:2lcWR98q8HU3U4mVETnXc8quNG0uXxrt8vKd6cAa/30=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/rancher2/0_provider_upgrade_test.go
+++ b/rancher2/0_provider_upgrade_test.go
@@ -38,7 +38,7 @@ resource "rancher2_namespace" "testacc" {
   project_id = rancher2_cluster_sync.testacc.default_project_id
 }
 `
-	testAccCheckRancher2UpgradeVersion = []string{"v2.3.6", "v2.4.8", "v2.5.1"}
+	testAccCheckRancher2UpgradeVersion = []string{"v2.3.6", "v2.4.8", "v2.5.2"}
 	testAccCheckRancher2RunningVersionIndex = 0
 	testAccCheckRancher2UpgradeCluster = os.Getenv("RANCHER_ACC_CLUSTER_NAME")
 	testAccCheckRancher2UpgradeCatalogV24 = testAccRancher2CatalogGlobal + testAccRancher2CatalogCluster + testAccRancher2CatalogProject

--- a/rancher2/resource_rancher2_app_v2.go
+++ b/rancher2/resource_rancher2_app_v2.go
@@ -60,7 +60,7 @@ func resourceRancher2AppV2Create(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		return fmt.Errorf("[ERROR] installing App V2: %s", err)
 	}
-	d.SetId(chartInstallAction.Namespace + "/" + name)
+	d.SetId(clusterID + appV2ClusterIDsep + chartInstallAction.Namespace + "/" + name)
 
 	return resourceRancher2AppV2Read(d, meta)
 }
@@ -77,8 +77,8 @@ func resourceRancher2AppV2Read(d *schema.ResourceData, meta interface{}) error {
 		}
 		d.Set("cluster_name", cluster.Name)
 	}
-
-	app, err := meta.(*Config).GetAppV2ByID(clusterID, d.Id())
+	_, rancherID := splitID(d.Id())
+	app, err := meta.(*Config).GetAppV2ByID(clusterID, rancherID)
 	if err != nil {
 		if IsNotFound(err) || IsForbidden(err) {
 			log.Printf("[INFO] App V2 %s not found at %s", name, clusterID)
@@ -123,7 +123,8 @@ func resourceRancher2AppV2Delete(d *schema.ResourceData, meta interface{}) error
 	name := d.Get("name").(string)
 	log.Printf("[INFO] Deleting App V2 %s at %s", name, clusterID)
 
-	app, err := meta.(*Config).GetAppV2ByID(clusterID, d.Id())
+	_, rancherID := splitID(d.Id())
+	app, err := meta.(*Config).GetAppV2ByID(clusterID, rancherID)
 	if err != nil {
 		if IsNotFound(err) || IsForbidden(err) {
 			log.Printf("[INFO] App V2 %s not found at %s", name, clusterID)
@@ -148,20 +149,16 @@ func resourceRancher2AppV2Delete(d *schema.ResourceData, meta interface{}) error
 	if waitErr != nil {
 		return fmt.Errorf("[ERROR] waiting for app (%s) to be deleted: %s", app.ID, waitErr)
 	}
-	if app.Spec.Chart.Metadata != nil && app.Spec.Chart.Metadata.Annotations != nil && len(app.Spec.Chart.Metadata.Annotations) > 0 {
+	if app.Spec.Chart.Metadata != nil && app.Spec.Chart.Metadata.Annotations != nil && len(app.Spec.Chart.Metadata.Annotations) > 0 && len(app.Spec.Chart.Metadata.Annotations["catalog.cattle.io/auto-install"]) > 0 {
 		namespace := d.Get("namespace").(string)
-		name := ""
 		if len(app.Spec.Chart.Metadata.Annotations["catalog.cattle.io/namespace"]) > 0 {
 			namespace = app.Spec.Chart.Metadata.Annotations["catalog.cattle.io/namespace"]
 		}
-		if len(app.Spec.Chart.Metadata.Annotations["catalog.cattle.io/auto-install"]) > 0 {
-			chartAuto := splitBySep(app.Spec.Chart.Metadata.Annotations["catalog.cattle.io/auto-install"], "=")
-			if len(chartAuto) != 2 {
-				return fmt.Errorf("bad format on chart annotation catalog.cattle.io/auto-install: %s", app.Spec.Chart.Metadata.Annotations["catalog.cattle.io/auto-install"])
-			}
-			name = chartAuto[0]
+		chartAuto := splitBySep(app.Spec.Chart.Metadata.Annotations["catalog.cattle.io/auto-install"], "=")
+		if len(chartAuto) != 2 {
+			return fmt.Errorf("bad format on chart annotation catalog.cattle.io/auto-install: %s", app.Spec.Chart.Metadata.Annotations["catalog.cattle.io/auto-install"])
 		}
-
+		name := chartAuto[0]
 		app, err = meta.(*Config).GetAppV2ByID(clusterID, namespace+"/"+name)
 		if err != nil {
 			if IsNotFound(err) || IsForbidden(err) {
@@ -185,6 +182,7 @@ func resourceRancher2AppV2Delete(d *schema.ResourceData, meta interface{}) error
 		if waitErr != nil {
 			return fmt.Errorf("[ERROR] waiting for app (%s) to be deleted: %s", app.ID, waitErr)
 		}
+
 	}
 	return nil
 }

--- a/rancher2/resource_rancher2_app_v2.go
+++ b/rancher2/resource_rancher2_app_v2.go
@@ -213,7 +213,11 @@ func appV2OperationWait(meta interface{}, clusterID, opID string) error {
 			if state, ok := metadata["state"].(map[string]interface{}); ok && len(state) > 0 {
 				if transitioning, ok := state["transitioning"].(bool); ok && !transitioning {
 					if opError, ok := state["error"].(bool); ok && opError {
-						return fmt.Errorf("%s", state["message"])
+						message, err := meta.(*Config).GetAppV2OperationLogs(clusterID, obj)
+						if err != nil {
+							return fmt.Errorf("%s: %s", state["message"], err)
+						}
+						return fmt.Errorf("%s", message)
 					}
 					return nil
 				}

--- a/rancher2/resource_rancher2_app_v2_test.go
+++ b/rancher2/resource_rancher2_app_v2_test.go
@@ -164,7 +164,8 @@ func testAccRancher2AppV2Disappears(cat *AppV2) resource.TestCheckFunc {
 
 			clusterID := rs.Primary.Attributes["cluster_id"]
 			name := rs.Primary.Attributes["name"]
-			app, err := testAccProvider.Meta().(*Config).GetAppV2ByID(clusterID, rs.Primary.ID)
+			_, rancherID := splitID(rs.Primary.ID)
+			app, err := testAccProvider.Meta().(*Config).GetAppV2ByID(clusterID, rancherID)
 			if err != nil {
 				if IsNotFound(err) || IsForbidden(err) {
 					return nil
@@ -206,7 +207,8 @@ func testAccCheckRancher2AppV2Exists(n string, cat *AppV2) resource.TestCheckFun
 		}
 
 		clusterID := rs.Primary.Attributes["cluster_id"]
-		foundReg, err := testAccProvider.Meta().(*Config).GetAppV2ByID(clusterID, rs.Primary.ID)
+		_, rancherID := splitID(rs.Primary.ID)
+		foundReg, err := testAccProvider.Meta().(*Config).GetAppV2ByID(clusterID, rancherID)
 		if err != nil {
 			if IsNotFound(err) || IsForbidden(err) {
 				return nil
@@ -226,7 +228,8 @@ func testAccCheckRancher2AppV2Destroy(s *terraform.State) error {
 			continue
 		}
 		clusterID := rs.Primary.Attributes["cluster_id"]
-		_, err := testAccProvider.Meta().(*Config).GetAppV2ByID(clusterID, rs.Primary.ID)
+		_, rancherID := splitID(rs.Primary.ID)
+		_, err := testAccProvider.Meta().(*Config).GetAppV2ByID(clusterID, rancherID)
 		if err != nil {
 			if IsNotFound(err) {
 				return nil

--- a/rancher2/resource_rancher2_bootstrap.go
+++ b/rancher2/resource_rancher2_bootstrap.go
@@ -259,8 +259,8 @@ func bootstrapDoLogin(d *schema.ResourceData, meta interface{}) error {
 	}
 	tokenID, token, err := DoUserLogin(meta.(*Config).URL, bootstrapDefaultUser, currentPass, bootstrapDefaultTTL, bootstrapDefaultSessionDesc, meta.(*Config).CACerts, meta.(*Config).Insecure)
 	if err != nil {
-		// 3 login retries waiting 5 seconds if user/pass login fails
-		for i := 0; i < 3; i++ {
+		// login retries waiting 5 seconds if user/pass login fails
+		for i := 0; i < meta.(*Config).Retries; i++ {
 			time.Sleep(5 * time.Second)
 			tokenID, token, err = DoUserLogin(meta.(*Config).URL, bootstrapDefaultUser, currentPass, bootstrapDefaultTTL, bootstrapDefaultSessionDesc, meta.(*Config).CACerts, meta.(*Config).Insecure)
 			if err == nil {

--- a/rancher2/resource_rancher2_catalog_v2_test.go
+++ b/rancher2/resource_rancher2_catalog_v2_test.go
@@ -105,7 +105,8 @@ func testAccRancher2CatalogV2Disappears(cat *ClusterRepo) resource.TestCheckFunc
 				continue
 			}
 			clusterID := rs.Primary.Attributes["cluster_id"]
-			catalog, err := testAccProvider.Meta().(*Config).GetCatalogV2ByID(clusterID, rs.Primary.ID)
+			_, rancherID := splitID(rs.Primary.ID)
+			catalog, err := testAccProvider.Meta().(*Config).GetCatalogV2ByID(clusterID, rancherID)
 			if err != nil {
 				if IsNotFound(err) || IsForbidden(err) {
 					return nil
@@ -147,7 +148,8 @@ func testAccCheckRancher2CatalogV2Exists(n string, cat *ClusterRepo) resource.Te
 		}
 
 		clusterID := rs.Primary.Attributes["cluster_id"]
-		foundReg, err := testAccProvider.Meta().(*Config).GetCatalogV2ByID(clusterID, rs.Primary.ID)
+		_, rancherID := splitID(rs.Primary.ID)
+		foundReg, err := testAccProvider.Meta().(*Config).GetCatalogV2ByID(clusterID, rancherID)
 		if err != nil {
 			if IsNotFound(err) || IsForbidden(err) {
 				return nil
@@ -167,7 +169,8 @@ func testAccCheckRancher2CatalogV2Destroy(s *terraform.State) error {
 			continue
 		}
 		clusterID := rs.Primary.Attributes["cluster_id"]
-		_, err := testAccProvider.Meta().(*Config).GetCatalogV2ByID(clusterID, rs.Primary.ID)
+		_, rancherID := splitID(rs.Primary.ID)
+		_, err := testAccProvider.Meta().(*Config).GetCatalogV2ByID(clusterID, rancherID)
 		if err != nil {
 			if IsNotFound(err) {
 				return nil

--- a/rancher2/resource_rancher2_cluster_test.go
+++ b/rancher2/resource_rancher2_cluster_test.go
@@ -107,7 +107,7 @@ resource "` + testAccRancher2ClusterType + `" "foo" {
       }
     }
     upgrade_strategy {
-      drain = true
+      drain = false
       max_unavailable_worker = "10%"
     }
   }
@@ -209,7 +209,7 @@ func TestAccRancher2Cluster_basic_RKE(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "rke_config.0.services.0.etcd.0.creation", "12h"),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "rke_config.0.services.0.etcd.0.retention", "72h"),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "rke_config.0.services.0.kube_api.0.audit_log.0.configuration.0.max_age", "7"),
-					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "rke_config.0.upgrade_strategy.0.drain", "true"),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "rke_config.0.upgrade_strategy.0.drain", "false"),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "rke_config.0.upgrade_strategy.0.max_unavailable_worker", "10%"),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "scheduled_cluster_scan.0.scan_config.0.cis_scan_config.0.debug_worker", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2ClusterType+".foo", "scheduled_cluster_scan.0.schedule_config.0.cron_schedule", "30 10 * * *"),

--- a/rancher2/schema_app_v2.go
+++ b/rancher2/schema_app_v2.go
@@ -79,6 +79,7 @@ func appV2Fields() map[string]*schema.Schema {
 		"values": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			Sensitive:   false,
 			Description: "App v2 custom values yaml",
 			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 				v, ok := val.(string)
@@ -102,7 +103,7 @@ func appV2Fields() map[string]*schema.Schema {
 				globalInfo := map[string]interface{}{
 					"cattle": map[string]interface{}{
 						"clusterId":   d.Get("cluster_id").(string),
-						"clusterName": d.Get("cluster_id").(string),
+						"clusterName": d.Get("cluster_name").(string),
 					},
 				}
 				if newGlobal, ok := newMap["global"].(map[string]interface{}); ok && len(newGlobal) > 0 {

--- a/rancher2/schema_app_v2.go
+++ b/rancher2/schema_app_v2.go
@@ -16,6 +16,7 @@ const (
 	appV2APIType          = rancher2CatalogTypePrefix + ".app"
 	appV2OperationAPIType = rancher2CatalogTypePrefix + ".operation"
 	appV2ValueGlobal      = "global."
+	appV2ClusterIDsep     = "."
 )
 
 //Types

--- a/rancher2/schema_catalog_v2.go
+++ b/rancher2/schema_catalog_v2.go
@@ -7,10 +7,11 @@ import (
 )
 
 const (
-	catalogV2Kind       = "ClusterRepo"
-	catalogV2APIGroup   = "catalog.cattle.io"
-	catalogV2APIVersion = "v1"
-	catalogV2APIType    = rancher2CatalogTypePrefix + ".clusterrepo"
+	catalogV2Kind         = "ClusterRepo"
+	catalogV2APIGroup     = "catalog.cattle.io"
+	catalogV2APIVersion   = "v1"
+	catalogV2APIType      = rancher2CatalogTypePrefix + ".clusterrepo"
+	catalogV2ClusterIDsep = "."
 )
 
 //Types

--- a/rancher2/structure_app_v2.go
+++ b/rancher2/structure_app_v2.go
@@ -16,9 +16,6 @@ func flattenAppV2(d *schema.ResourceData, in *AppV2) error {
 		return nil
 	}
 
-	if len(in.ID) > 0 {
-		d.SetId(in.ID)
-	}
 	d.Set("name", in.ObjectMeta.Name)
 	d.Set("namespace", in.ObjectMeta.Namespace)
 	err := d.Set("annotations", toMapInterface(in.ObjectMeta.Annotations))
@@ -46,8 +43,14 @@ func flattenAppV2(d *schema.ResourceData, in *AppV2) error {
 				if clusterID, ok := cattle["clusterId"].(string); ok && len(clusterID) > 0 {
 					d.Set("cluster_id", clusterID)
 				}
+				if clusterName, ok := cattle["clusterName"].(string); ok && len(clusterName) > 0 {
+					d.Set("cluster_name", clusterName)
+				}
 			}
 		}
+	}
+	if len(in.ID) > 0 {
+		d.SetId(d.Get("cluster_id").(string) + appV2ClusterIDsep + in.ID)
 	}
 
 	return nil

--- a/rancher2/structure_catalog_v2.go
+++ b/rancher2/structure_catalog_v2.go
@@ -13,7 +13,7 @@ func flattenCatalogV2(d *schema.ResourceData, in *ClusterRepo) error {
 	}
 
 	if len(in.ID) > 0 {
-		d.SetId(in.ID)
+		d.SetId(d.Get("cluster_id").(string) + catalogV2ClusterIDsep + in.ID)
 	}
 	d.Set("name", in.ObjectMeta.Name)
 	err := d.Set("annotations", toMapInterface(in.ObjectMeta.Annotations))
@@ -53,7 +53,7 @@ func expandCatalogV2(in *schema.ResourceData) *ClusterRepo {
 	obj := &ClusterRepo{}
 
 	if len(in.Id()) > 0 {
-		obj.ID = in.Id()
+		_, obj.ID = splitID(in.Id())
 	}
 	obj.TypeMeta.Kind = catalogV2Kind
 	obj.TypeMeta.APIVersion = catalogV2APIGroup + "/" + catalogV2APIVersion

--- a/rancher2/structure_cluster_rke_config_nodes.go
+++ b/rancher2/structure_cluster_rke_config_nodes.go
@@ -29,7 +29,9 @@ func flattenClusterRKEConfigNodeUpgradeStrategy(in *managementClient.NodeUpgrade
 		return []interface{}{}
 	}
 
-	obj["drain"] = in.Drain
+	if in.Drain != nil {
+		obj["drain"] = *in.Drain
+	}
 
 	if in.DrainInput != nil {
 		obj["drain_input"] = flattenClusterRKEConfigNodeDrainInput(in.DrainInput)
@@ -144,7 +146,7 @@ func expandClusterRKEConfigNodeUpgradeStrategy(p []interface{}) *managementClien
 	in := p[0].(map[string]interface{})
 
 	if v, ok := in["drain"].(bool); ok {
-		obj.Drain = v
+		obj.Drain = &v
 	}
 
 	if v, ok := in["drain_input"].([]interface{}); ok {

--- a/rancher2/structure_cluster_rke_config_nodes_test.go
+++ b/rancher2/structure_cluster_rke_config_nodes_test.go
@@ -34,7 +34,7 @@ func init() {
 		},
 	}
 	testClusterRKEConfigNodeUpgradeStrategyConf = &managementClient.NodeUpgradeStrategy{
-		Drain:                      false,
+		Drain:                      newFalse(),
 		DrainInput:                 testClusterRKEConfigNodeDrainInputConf,
 		MaxUnavailableControlplane: "2",
 		MaxUnavailableWorker:       "20%",

--- a/scripts/start_rancher.sh
+++ b/scripts/start_rancher.sh
@@ -20,7 +20,7 @@ CERTMANAGER_CRD=${CERTMANAGER_CRD:-"https://github.com/jetstack/cert-manager/rel
 CERTMANAGER_NS=${CERTMANAGER_NS:-"cert-manager"}
 
 ## rancher
-RANCHER_VERSION=${RANCHER_VERSION:-"v2.5.1"}
+RANCHER_VERSION=${RANCHER_VERSION:-"v2.5.2"}
 RANCHER_NS=${RANCHER_NS:-"cattle-system"}
 export RANCHER_HOSTNAME="rancher.${K3S_SERVER_IP}.xip.io"
 export RANCHER_IP=${K3S_SERVER_IP}


### PR DESCRIPTION
This PR contains: 
* Updated go mod and test to use rancher v2.5.2-rc5
* Fix `rancher2_cluster.rke_config.upgrade_strategy.drain` to set false value properly. Closes #440, Closes #494 
* Fix apps & marketplace guide format. Closes #492 
* Improved `rancher2_bootstrap` on resource creation. Number of retires on `bootstrapDoLogin` function can be configured with retries provider argument. Closes #493 
* Updated `rancher2_catalog_v2` contextualized resource id with `cluster_id` prefix
* Updated `rancher2_app_v2` contextualized resource id with `cluster_id` prefix
* Updated `rancher2_app_v2` to show helm operation log if fail. Closes #503 Closes #508 
* Updated `rancher2_app_v2.values` argument as sensitive. Closes #499 
* Fixed `rancher2_app_v2.values` argument to avoid false diff. Closes #500 

Once rancher v2.5.2 is released, this PR should be updated to set proper rancher go mod: DONE