### PR TITLE
fix rancher url property doc for auth resources

### DIFF
--- a/docs/resources/auth_config_adfs.md
+++ b/docs/resources/auth_config_adfs.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `display_name_field` - (Required) ADFS display name field (string)
 * `groups_field` - (Required) ADFS group field (string)
 * `idp_metadata_content` - (Required/Sensitive) ADFS IDP metadata content (string)
-* `rancher_api_host` - (Required) Rancher url. Schema needs to be specified, `https://<RANCHER_API_HOST>` (string)
+* `rancher_api_host` - (Required) Rancher URL. URL scheme needs to be specified, `https://<RANCHER_API_HOST>` (string)
 * `sp_cert` - (Required/Sensitive) ADFS SP cert (string)
 * `sp_key` - (Required/Sensitive) ADFS SP key (string)
 * `uid_field` - (Required) ADFS UID field (string)

--- a/docs/resources/auth_config_keycloak.md
+++ b/docs/resources/auth_config_keycloak.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `display_name_field` - (Required) KeyCloak display name field (string)
 * `groups_field` - (Required) KeyCloak group field (string)
 * `idp_metadata_content` - (Required/Sensitive) KeyCloak IDP metadata content (string)
-* `rancher_api_host` - (Required) Rancher url. Schema needs to be specified, `https://<RANCHER_API_HOST>` (string)
+* `rancher_api_host` - (Required) Rancher URL. URL scheme needs to be specified, `https://<RANCHER_API_HOST>` (string)
 * `sp_cert` - (Required/Sensitive) KeyCloak SP cert (string)
 * `sp_key` - (Required/Sensitive) KeyCloak SP key (string)
 * `uid_field` - (Required) KeyCloak UID field (string)

--- a/docs/resources/auth_config_okta.md
+++ b/docs/resources/auth_config_okta.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `display_name_field` - (Required) OKTA display name field (string)
 * `groups_field` - (Required) OKTA group field (string)
 * `idp_metadata_content` - (Required/Sensitive) OKTA IDP metadata content (string)
-* `rancher_api_host` - (Required) Rancher url. Schema needs to be specified, `https://<RANCHER_API_HOST>` (string)
+* `rancher_api_host` - (Required) Rancher URL. URL scheme needs to be specified, `https://<RANCHER_API_HOST>` (string)
 * `sp_cert` - (Required/Sensitive) OKTA SP cert (string)
 * `sp_key` - (Required/Sensitive) OKTA SP key (string)
 * `uid_field` - (Required) OKTA UID field (string)

--- a/docs/resources/auth_config_ping.md
+++ b/docs/resources/auth_config_ping.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `display_name_field` - (Required) Ping display name field (string)
 * `groups_field` - (Required) Ping group field (string)
 * `idp_metadata_content` - (Required/Sensitive) Ping IDP metadata content (string)
-* `rancher_api_host` - (Required) Rancher url. Schema needs to be specified, `https://<RANCHER_API_HOST>` (string)
+* `rancher_api_host` - (Required) Rancher URL. URL scheme needs to be specified, `https://<RANCHER_API_HOST>` (string)
 * `sp_cert` - (Required/Sensitive) Ping SP cert (string)
 * `sp_key` - (Required/Sensitive) Ping SP key (string)
 * `uid_field` - (Required) Ping UID field (string)


### PR DESCRIPTION
Updates documentation for various auth resources to correct a typo in the `rancher_api_host` property. Per [RFC 1738](https://tools.ietf.org/html/rfc1738#section-2.1) the "https" portion of a URL is the `scheme`, not the `schema` as described in the docs.