### PR TITLE
Adding node template support for Hetzner

### DIFF
--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -6,7 +6,7 @@ page_title: "rancher2_node_template Resource"
 
 Provides a Rancher v2 Node Template resource. This can be used to create Node Template for Rancher v2 and retrieve their information.
 
-amazonec2, azure, digitalocean, linode, opennebula, openstack, and vsphere drivers are supported for node templates.
+amazonec2, azure, digitalocean, linode, opennebula, openstack, hetzner, and vsphere drivers are supported for node templates.
 
 **Note** If you are upgrading to Rancher v2.3.3, please take a look to [final section](#Upgrading-to-Rancher-v2.3.3)
 
@@ -51,6 +51,31 @@ resource "rancher2_node_template" "foo" {
     subnet_id = "<SUBNET_ID>"
     vpc_id = "<VPC_ID>"
     zone = "<ZONE>"
+  }
+}
+```
+
+### Using the Hetzner Node Driver
+
+```hcl
+# Create a new rancher2 Node Template using hetzner node_driver
+resource "rancher2_node_driver" "hetzner_node_driver" {
+  active   = true
+  builtin  = false
+  name     = "Hetzner"
+  ui_url   = "https://storage.googleapis.com/hcloud-rancher-v2-ui-driver/component.js"
+  url      = "https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases/download/3.0.0/docker-machine-driver-hetzner_3.0.0_linux_amd64.tar.gz"
+  whitelist_domains = ["storage.googleapis.com"]
+}
+
+resource "rancher2_node_template" "my_hetzner_node_template" {
+  name = "my-hetzner-node-template"
+  driver_id = rancher2_node_driver.hetzner_node_driver.id
+  hetzner_config {
+    api_token = "XXXXXXXXXX"
+    image = "ubuntu-18.04"
+    server_location = "nbg1"
+    server_type = "cx11"
   }
 }
 ```
@@ -180,6 +205,21 @@ The following attributes are exported:
 * `ssh_user` - (Optional) SSH username. Default `root` (string)
 * `tags` - (Optional) Comma-separated list of tags to apply to the Droplet (string)
 * `userdata` - (Optional) Path to file with cloud-init user-data (string)
+
+### `hetzner_config`
+
+#### Arguments
+
+* `api_token` - (Required/Sensitive) Hetzner Cloud project API token (string)
+* `image` - (Optional) Hetzner Cloud server image. Default `ubuntu-18.04` (string)
+* `server_location` - (Optional) Hetzner Cloud datacenter. Default `nbg1` (string) 
+* `server_type` - (Optional) Hetzner Cloud server type. Default `cx11` (string)
+* `networks` - (Optional) Comma-separated list of network IDs or names which should be attached to the server private network interface (string)
+* `use_private_networks` - (Optional) Use private network. Default `false` (bool)
+* `volumes` - (Optional) Comma-separated list of volume IDs or names which should be attached to the server (string)
+* `userdata` - (Optional) Path to file with cloud-init user-data (string)
+
+> **Note**: You need to install the Hetzner Docker Machine Driver first as shown as in the [examples section](#using-the-hetzner-node-driver).
 
 ### `linode_config`
 

--- a/rancher2/resource_rancher2_node_template.go
+++ b/rancher2/resource_rancher2_node_template.go
@@ -152,6 +152,8 @@ func resourceRancher2NodeTemplateUpdate(d *schema.ResourceData, meta interface{}
 		update["openstackConfig"] = expandOpenstackConfig(d.Get("openstack_config").([]interface{}))
 	case opennebulaConfigDriver:
 		update["opennebulaConfig"] = expandOpennebulaConfig(d.Get("opennebula_config").([]interface{}))
+	case hetznerConfigDriver:
+		update["hetznerConfig"] = expandHetznercloudConfig(d.Get("hetzner_config").([]interface{}))
 	case vmwarevsphereConfigDriver:
 		update["vmwarevsphereConfig"] = expandVsphereConfig(d.Get("vsphere_config").([]interface{}))
 	}

--- a/rancher2/schema_node_template.go
+++ b/rancher2/schema_node_template.go
@@ -16,6 +16,7 @@ type NodeTemplate struct {
 	OpenstackConfig     *openstackConfig     `json:"openstackConfig,omitempty" yaml:"openstackConfig,omitempty"`
 	VmwarevsphereConfig *vmwarevsphereConfig `json:"vmwarevsphereConfig,omitempty" yaml:"vmwarevsphereConfig,omitempty"`
 	OpennebulaConfig    *opennebulaConfig    `json:"opennebulaConfig,omitempty" yaml:"opennebulaConfig,omitempty"`
+	HetznerConfig       *hetznerConfig       `json:"hetznerConfig,omitempty" yaml:"hetznerConfig,omitempty"`
 }
 
 //Schemas
@@ -30,7 +31,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"azure_config", "digitalocean_config", "opennebula_config", "openstack_config", "vsphere_config"},
+			ConflictsWith: []string{"azure_config", "digitalocean_config", "opennebula_config", "openstack_config", "hetzner_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: amazonec2ConfigFields(),
 			},
@@ -49,7 +50,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "digitalocean_config", "opennebula_config", "openstack_config", "vsphere_config"},
+			ConflictsWith: []string{"amazonec2_config", "digitalocean_config", "opennebula_config", "openstack_config", "hetzner_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: azureConfigFields(),
 			},
@@ -66,7 +67,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "opennebula_config", "openstack_config", "vsphere_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "opennebula_config", "openstack_config", "hetzner_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: digitaloceanConfigFields(),
 			},
@@ -119,7 +120,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "opennebula_config", "openstack_config", "vsphere_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "opennebula_config", "openstack_config", "hetzner_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: linodeConfigFields(),
 			},
@@ -128,9 +129,18 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "opennebula_config", "vsphere_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "opennebula_config", "hetzner_config", "vsphere_config"},
 			Elem: &schema.Resource{
 				Schema: openstackConfigFields(),
+			},
+		},
+		"hetzner_config": {
+			Type:          schema.TypeList,
+			MaxItems:      1,
+			Optional:      true,
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "opennebula_config", "openstack_config", "vsphere_config"},
+			Elem: &schema.Resource{
+				Schema: hetznerConfigFields(),
 			},
 		},
 		"use_internal_ip_address": {
@@ -142,7 +152,7 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "opennebula_config", "openstack_config"},
+			ConflictsWith: []string{"amazonec2_config", "azure_config", "digitalocean_config", "opennebula_config", "hetzner_config", "openstack_config"},
 			Elem: &schema.Resource{
 				Schema: vsphereConfigFields(),
 			},

--- a/rancher2/schema_node_template_hetzner.go
+++ b/rancher2/schema_node_template_hetzner.go
@@ -1,0 +1,76 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+const (
+	hetznerConfigDriver = "hetzner"
+)
+
+//Types
+
+type hetznerConfig struct {
+	APIToken          string `json:"apiToken,omitempty" yaml:"apiToken,omitempty"`
+	Image             string `json:"image,omitempty" yaml:"image,omitempty"`
+	ServerLocation    string `json:"serverLocation,omitempty" yaml:"serverLocation,omitempty"`
+	ServerType        string `json:"serverType,omitempty" yaml:"serverType,omitempty"`
+	Networks          string `json:"networks,omitempty" yaml:"networks,omitempty"`
+	UsePrivateNetwork bool   `json:"usePrivateNetworks,omitempty" yaml:"usePrivateNetworks,omitempty"`
+	UserData          string `json:"userData,omitempty" yaml:"userData,omitempty"`
+	Volumes           string `json:"volumes,omitempty" yaml:"volumes,omitempty"`
+}
+
+//Schemas
+
+func hetznerConfigFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"api_token": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Hetzner Cloud project API token",
+		},
+		"image": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "ubuntu-18.04",
+			Description: "Hetzner Cloud server image",
+		},
+		"server_location": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "nbg1",
+			Description: "Hetzner Cloud datacenter",
+		},
+		"server_type": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "cx11",
+			Description: "Hetzner Cloud server type",
+		},
+		"networks": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Comma-separated list of network IDs or names which should be attached to the server private network interface",
+		},
+		"use_private_networks": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Use private network",
+		},
+		"userdata": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Path to file with cloud-init user-data",
+		},
+		"volumes": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Comma-separated list of volume IDs or names which should be attached to the server",
+		},
+	}
+
+	return s
+}

--- a/rancher2/structure_node_template.go
+++ b/rancher2/structure_node_template.go
@@ -38,6 +38,10 @@ func flattenNodeTemplate(d *schema.ResourceData, in *NodeTemplate) error {
 		if in.OpenstackConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires openstack_config", in.Driver)
 		}
+	case hetznerConfigDriver:
+		if in.HetznerConfig == nil {
+			return fmt.Errorf("[ERROR] Node template driver %s requires hetzner_config", in.Driver)
+		}
 	case vmwarevsphereConfigDriver:
 		if in.VmwarevsphereConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires vsphere_config", in.Driver)
@@ -209,6 +213,11 @@ func expandNodeTemplate(in *schema.ResourceData) *NodeTemplate {
 	if v, ok := in.Get("opennebula_config").([]interface{}); ok && len(v) > 0 {
 		obj.OpennebulaConfig = expandOpennebulaConfig(v)
 		obj.Driver = opennebulaConfigDriver
+	}
+
+	if v, ok := in.Get("hetzner_config").([]interface{}); ok && len(v) > 0 {
+		obj.HetznerConfig = expandHetznercloudConfig(v)
+		obj.Driver = hetznerConfigDriver
 	}
 
 	if v, ok := in.Get("use_internal_ip_address").(bool); ok {

--- a/rancher2/structure_node_template_hetzner.go
+++ b/rancher2/structure_node_template_hetzner.go
@@ -1,0 +1,86 @@
+package rancher2
+
+// Flatteners
+
+func flattenHetznerConfig(in *hetznerConfig) []interface{} {
+	obj := make(map[string]interface{})
+	if in == nil {
+		return []interface{}{}
+	}
+
+	if len(in.APIToken) > 0 {
+		obj["api_token"] = in.APIToken
+	}
+
+	if len(in.Image) > 0 {
+		obj["image"] = in.Image
+	}
+
+	if len(in.ServerLocation) > 0 {
+		obj["server_location"] = in.ServerLocation
+	}
+
+	if len(in.ServerType) > 0 {
+		obj["server_type"] = in.ServerType
+	}
+
+	if len(in.Networks) > 0 {
+		obj["networks"] = in.Networks
+	}
+
+	obj["use_private_network"] = in.UsePrivateNetwork
+
+	if len(in.UserData) > 0 {
+		obj["userdata"] = in.UserData
+	}
+
+	if len(in.Volumes) > 0 {
+		obj["volumes"] = in.Volumes
+	}
+
+	return []interface{}{obj}
+}
+
+// Expanders
+
+func expandHetznercloudConfig(p []interface{}) *hetznerConfig {
+	obj := &hetznerConfig{}
+	if len(p) == 0 || p[0] == nil {
+		return obj
+	}
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["api_token"].(string); ok && len(v) > 0 {
+		obj.APIToken = v
+	}
+
+	if v, ok := in["image"].(string); ok && len(v) > 0 {
+		obj.Image = v
+	}
+
+	if v, ok := in["server_location"].(string); ok && len(v) > 0 {
+		obj.ServerLocation = v
+	}
+
+	if v, ok := in["server_type"].(string); ok && len(v) > 0 {
+		obj.ServerType = v
+	}
+
+	if v, ok := in["networks"].(string); ok && len(v) > 0 {
+		obj.Networks = v
+	}
+
+	if v, ok := in["use_private_network"].(bool); ok {
+		obj.UsePrivateNetwork = v
+	}
+
+	if v, ok := in["userdata"].(string); ok && len(v) > 0 {
+		obj.UserData = v
+	}
+
+	if v, ok := in["volumes"].(string); ok && len(v) > 0 {
+		obj.Volumes = v
+	}
+
+	return obj
+}


### PR DESCRIPTION
This PR adds support for adding node templates for Hetzner Cloud using the machine driver API. My work so far is based on @ntoljic's in PR #216.

Compiling works fine so far but i need to test it against a running rancher installation. But i have trouble forcing Terraform to use my local binary as provider instead of downloading one from the registry. Maybe someone can give me a hint here?

When i've verified that this works, i'll open the request for review.