### PR TITLE
Add linear_autoscaler_params to rke dns config

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -710,10 +710,12 @@ The following attributes are exported:
 ##### Arguments
 
 * `nodelocal` - (Optional) Nodelocal dns config  (list Maxitem: 1)
+* `linear_autoscaler_params` - (Optional) LinearAutoScalerParams dns config (list Maxitem: 1)
 * `node_selector` - (Optional/Computed) DNS add-on node selector (map)
 * `provider` - (Optional) DNS add-on provider. `kube-dns`, `coredns` (default), and `none` are supported (string)
 * `reverse_cidrs` - (Optional/Computed) DNS add-on reverse cidr  (list)
 * `upstream_nameservers` - (Optional/Computed) DNS add-on upstream nameservers  (list)
+* `update_strategy` - (Optional) DNS update strategy (list Maxitems: 1)
 
 ##### `nodelocal`
 
@@ -721,6 +723,16 @@ The following attributes are exported:
 
 * `ip_address` - (required) Nodelocal dns ip address (string)
 * `node_selector` - (Optional) Node selector key pair (map)
+
+##### `linear_autoscaler_params`
+
+###### Arguments
+
+* `cores_per_replica` - (Optional) number of replicas per cluster cores (float64)
+* `nodes_per_replica` - (Optional) number of replica per cluster nodes (float64)
+* `max` - (Optional) maximum number of replicas (int64)
+* `min` - (Optional) minimum number of replicas (int64)
+* `prevent_single_point_failure` - (Optional) prevent single point of failure
 
 #### `ingress`
 

--- a/rancher2/schema_cluster_rke_config_dns.go
+++ b/rancher2/schema_cluster_rke_config_dns.go
@@ -32,6 +32,32 @@ func clusterRKEConfigDNSNodelocalFields() map[string]*schema.Schema {
 	return s
 }
 
+func clusterRKEConfigDNSLinearAutoscalerParamsFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"cores_per_replica": {
+			Type:     schema.TypeFloat,
+			Optional: true,
+		},
+		"nodes_per_replica": {
+			Type:     schema.TypeFloat,
+			Optional: true,
+		},
+		"prevent_single_point_failure": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"min": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		"max": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+	}
+	return s
+}
+
 func clusterRKEConfigDNSFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"node_selector": {
@@ -46,6 +72,15 @@ func clusterRKEConfigDNSFields() map[string]*schema.Schema {
 			Description: "Nodelocal dns",
 			Elem: &schema.Resource{
 				Schema: clusterRKEConfigDNSNodelocalFields(),
+			},
+		},
+		"linear_autoscaler_params": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Linear Autoscaler Params",
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigDNSLinearAutoscalerParamsFields(),
 			},
 		},
 		"provider": {
@@ -68,6 +103,15 @@ func clusterRKEConfigDNSFields() map[string]*schema.Schema {
 			Computed: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
+			},
+		},
+		"update_strategy": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Update deployment strategy",
+			Elem: &schema.Resource{
+				Schema: deploymentStrategyFields(),
 			},
 		},
 	}

--- a/rancher2/structure_cluster_rke_config_dns.go
+++ b/rancher2/structure_cluster_rke_config_dns.go
@@ -23,6 +23,33 @@ func flattenClusterRKEConfigDNSNodelocal(in *managementClient.Nodelocal) []inter
 	return []interface{}{obj}
 }
 
+func flattenClusterRKEConfigDNSLinearAutoscalerParams(in *managementClient.LinearAutoscalerParams) []interface{} {
+	obj := make(map[string]interface{})
+	if in == nil {
+		return nil
+	}
+
+	if in.CoresPerReplica > 0 {
+		obj["cores_per_replica"] = in.CoresPerReplica
+	}
+
+	if in.NodesPerReplica > 0 {
+		obj["nodes_per_replica"] = in.NodesPerReplica
+	}
+
+	if in.Max >= 0 {
+		obj["max"] = int(in.Max)
+	}
+
+	if in.Min > 0 {
+		obj["min"] = int(in.Min)
+	}
+
+	obj["prevent_single_point_failure"] = in.PreventSinglePointFailure
+
+	return []interface{}{obj}
+}
+
 func flattenClusterRKEConfigDNS(in *managementClient.DNSConfig) ([]interface{}, error) {
 	obj := make(map[string]interface{})
 	if in == nil {
@@ -37,6 +64,10 @@ func flattenClusterRKEConfigDNS(in *managementClient.DNSConfig) ([]interface{}, 
 		obj["nodelocal"] = flattenClusterRKEConfigDNSNodelocal(in.Nodelocal)
 	}
 
+	if in.LinearAutoscalerParams != nil {
+		obj["linear_autoscaler_params"] = flattenClusterRKEConfigDNSLinearAutoscalerParams(in.LinearAutoscalerParams)
+	}
+
 	if len(in.Provider) > 0 {
 		obj["provider"] = in.Provider
 	}
@@ -47,6 +78,10 @@ func flattenClusterRKEConfigDNS(in *managementClient.DNSConfig) ([]interface{}, 
 
 	if len(in.UpstreamNameservers) > 0 {
 		obj["upstream_nameservers"] = toArrayInterface(in.UpstreamNameservers)
+	}
+
+	if in.UpdateStrategy != nil {
+		obj["update_strategy"] = flattenDeploymentStrategy(in.UpdateStrategy)
 	}
 
 	return []interface{}{obj}, nil
@@ -72,6 +107,36 @@ func expandClusterRKEConfigDNSNodelocal(p []interface{}) *managementClient.Nodel
 	return obj
 }
 
+func expandClusterRKEConfigDNSLinearAutoscalerParams(p []interface{}) *managementClient.LinearAutoscalerParams {
+	obj := &managementClient.LinearAutoscalerParams{}
+	if len(p) == 0 || p[0] == nil {
+		return nil
+	}
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["cores_per_replica"].(float64); ok && v > 0 {
+		obj.CoresPerReplica = v
+	}
+
+	if v, ok := in["nodes_per_replica"].(float64); ok && v > 0 {
+		obj.NodesPerReplica = v
+	}
+
+	if v, ok := in["max"].(int); ok && v >= 0 {
+		obj.Max = int64(v)
+	}
+
+	if v, ok := in["min"].(int); ok && v > 0 {
+		obj.Min = int64(v)
+	}
+
+	if v, ok := in["prevent_single_point_failure"].(bool); ok {
+		obj.PreventSinglePointFailure = v
+	}
+
+	return obj
+}
+
 func expandClusterRKEConfigDNS(p []interface{}) (*managementClient.DNSConfig, error) {
 	obj := &managementClient.DNSConfig{}
 	if len(p) == 0 || p[0] == nil {
@@ -87,6 +152,10 @@ func expandClusterRKEConfigDNS(p []interface{}) (*managementClient.DNSConfig, er
 		obj.Nodelocal = expandClusterRKEConfigDNSNodelocal(v)
 	}
 
+	if v, ok := in["linear_autoscaler_params"].([]interface{}); ok && len(v) > 0 {
+		obj.LinearAutoscalerParams = expandClusterRKEConfigDNSLinearAutoscalerParams(v)
+	}
+
 	if v, ok := in["provider"].(string); ok && len(v) > 0 {
 		obj.Provider = v
 	}
@@ -97,6 +166,10 @@ func expandClusterRKEConfigDNS(p []interface{}) (*managementClient.DNSConfig, er
 
 	if v, ok := in["upstream_nameservers"].([]interface{}); ok && len(v) > 0 {
 		obj.UpstreamNameservers = toArrayString(v)
+	}
+
+	if v, ok := in["update_strategy"].([]interface{}); ok && v != nil {
+		obj.UpdateStrategy = expandDeploymentStrategy(v)
 	}
 
 	return obj, nil

--- a/rancher2/structure_cluster_rke_config_dns_test.go
+++ b/rancher2/structure_cluster_rke_config_dns_test.go
@@ -8,10 +8,14 @@ import (
 )
 
 var (
-	testClusterRKEConfigDNSNodelocalConf      *managementClient.Nodelocal
-	testClusterRKEConfigDNSNodelocalInterface []interface{}
-	testClusterRKEConfigDNSConf               *managementClient.DNSConfig
-	testClusterRKEConfigDNSInterface          []interface{}
+	testClusterRKEConfigDNSNodelocalConf                        *managementClient.Nodelocal
+	testClusterRKEConfigDNSLinearAutoscalerParamsConf           *managementClient.LinearAutoscalerParams
+	testClusterRKEConfigDNSLinearAutoscalerParamsConfFalse      *managementClient.LinearAutoscalerParams
+	testClusterRKEConfigDNSNodelocalInterface                   []interface{}
+	testClusterRKEConfigDNSLinearAutoscalerParamsInterface      []interface{}
+	testClusterRKEConfigDNSLinearAutoscalerParamsInterfaceFalse []interface{}
+	testClusterRKEConfigDNSConf                                 *managementClient.DNSConfig
+	testClusterRKEConfigDNSInterface                            []interface{}
 )
 
 func init() {
@@ -22,6 +26,20 @@ func init() {
 		},
 		IPAddress: "ip_address",
 	}
+	testClusterRKEConfigDNSLinearAutoscalerParamsConf = &managementClient.LinearAutoscalerParams{
+		CoresPerReplica:           float64(128),
+		Max:                       int64(0),
+		Min:                       int64(1),
+		NodesPerReplica:           float64(4),
+		PreventSinglePointFailure: true,
+	}
+	testClusterRKEConfigDNSLinearAutoscalerParamsConfFalse = &managementClient.LinearAutoscalerParams{
+		CoresPerReplica:           float64(64),
+		Max:                       int64(10),
+		Min:                       int64(1),
+		NodesPerReplica:           float64(8),
+		PreventSinglePointFailure: false,
+	}
 	testClusterRKEConfigDNSNodelocalInterface = []interface{}{
 		map[string]interface{}{
 			"node_selector": map[string]interface{}{
@@ -31,15 +49,34 @@ func init() {
 			"ip_address": "ip_address",
 		},
 	}
+	testClusterRKEConfigDNSLinearAutoscalerParamsInterface = []interface{}{
+		map[string]interface{}{
+			"cores_per_replica":            float64(128),
+			"max":                          0,
+			"min":                          1,
+			"nodes_per_replica":            float64(4),
+			"prevent_single_point_failure": true,
+		},
+	}
+	testClusterRKEConfigDNSLinearAutoscalerParamsInterfaceFalse = []interface{}{
+		map[string]interface{}{
+			"cores_per_replica":            float64(64),
+			"max":                          10,
+			"min":                          1,
+			"nodes_per_replica":            float64(8),
+			"prevent_single_point_failure": false,
+		},
+	}
 	testClusterRKEConfigDNSConf = &managementClient.DNSConfig{
 		NodeSelector: map[string]string{
 			"sel1": "value1",
 			"sel2": "value2",
 		},
-		Nodelocal:           testClusterRKEConfigDNSNodelocalConf,
-		Provider:            "kube-dns",
-		ReverseCIDRs:        []string{"rev1", "rev2"},
-		UpstreamNameservers: []string{"up1", "up2"},
+		Nodelocal:              testClusterRKEConfigDNSNodelocalConf,
+		LinearAutoscalerParams: testClusterRKEConfigDNSLinearAutoscalerParamsConf,
+		Provider:               "kube-dns",
+		ReverseCIDRs:           []string{"rev1", "rev2"},
+		UpstreamNameservers:    []string{"up1", "up2"},
 	}
 	testClusterRKEConfigDNSInterface = []interface{}{
 		map[string]interface{}{
@@ -47,10 +84,11 @@ func init() {
 				"sel1": "value1",
 				"sel2": "value2",
 			},
-			"nodelocal":            testClusterRKEConfigDNSNodelocalInterface,
-			"provider":             "kube-dns",
-			"reverse_cidrs":        []interface{}{"rev1", "rev2"},
-			"upstream_nameservers": []interface{}{"up1", "up2"},
+			"nodelocal":                testClusterRKEConfigDNSNodelocalInterface,
+			"linear_autoscaler_params": testClusterRKEConfigDNSLinearAutoscalerParamsInterface,
+			"provider":                 "kube-dns",
+			"reverse_cidrs":            []interface{}{"rev1", "rev2"},
+			"upstream_nameservers":     []interface{}{"up1", "up2"},
 		},
 	}
 }
@@ -69,6 +107,31 @@ func TestFlattenClusterRKEConfigDNSNodelocal(t *testing.T) {
 
 	for _, tc := range cases {
 		output := flattenClusterRKEConfigDNSNodelocal(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestFlattenClusterRKEConfigDNSLinearAutoscalerParams(t *testing.T) {
+
+	cases := []struct {
+		Input          *managementClient.LinearAutoscalerParams
+		ExpectedOutput []interface{}
+	}{
+		{
+			testClusterRKEConfigDNSLinearAutoscalerParamsConf,
+			testClusterRKEConfigDNSLinearAutoscalerParamsInterface,
+		},
+		{
+			testClusterRKEConfigDNSLinearAutoscalerParamsConfFalse,
+			testClusterRKEConfigDNSLinearAutoscalerParamsInterfaceFalse,
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenClusterRKEConfigDNSLinearAutoscalerParams(tc.Input)
 		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
 			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
 				tc.ExpectedOutput, output)
@@ -114,6 +177,31 @@ func TestExpandClusterRKEConfigDNSNodelocal(t *testing.T) {
 
 	for _, tc := range cases {
 		output := expandClusterRKEConfigDNSNodelocal(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestExpandClusterRKEConfigDNSLinearAutoscalerParams(t *testing.T) {
+
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *managementClient.LinearAutoscalerParams
+	}{
+		{
+			testClusterRKEConfigDNSLinearAutoscalerParamsInterface,
+			testClusterRKEConfigDNSLinearAutoscalerParamsConf,
+		},
+		{
+			testClusterRKEConfigDNSLinearAutoscalerParamsInterfaceFalse,
+			testClusterRKEConfigDNSLinearAutoscalerParamsConfFalse,
+		},
+	}
+
+	for _, tc := range cases {
+		output := expandClusterRKEConfigDNSLinearAutoscalerParams(tc.Input)
 		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
 			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
 				tc.ExpectedOutput, output)

--- a/rancher2/structure_cluster_rke_config_dns_test.go
+++ b/rancher2/structure_cluster_rke_config_dns_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var (
@@ -67,6 +68,26 @@ func init() {
 			"prevent_single_point_failure": false,
 		},
 	}
+	testRollingUpdateDeploymentConf = &managementClient.RollingUpdateDeployment{
+		MaxSurge:       intstr.FromInt(10),
+		MaxUnavailable: intstr.FromInt(10),
+	}
+	testRollingUpdateDeploymentInterface = []interface{}{
+		map[string]interface{}{
+			"max_surge":       10,
+			"max_unavailable": 10,
+		},
+	}
+	testDeploymentStrategyConf = &managementClient.DeploymentStrategy{
+		RollingUpdate: testRollingUpdateDeploymentConf,
+		Strategy:      "strategy",
+	}
+	testDeploymentStrategyInterface = []interface{}{
+		map[string]interface{}{
+			"rolling_update": testRollingUpdateDeploymentInterface,
+			"strategy":       "strategy",
+		},
+	}
 	testClusterRKEConfigDNSConf = &managementClient.DNSConfig{
 		NodeSelector: map[string]string{
 			"sel1": "value1",
@@ -77,6 +98,7 @@ func init() {
 		Provider:               "kube-dns",
 		ReverseCIDRs:           []string{"rev1", "rev2"},
 		UpstreamNameservers:    []string{"up1", "up2"},
+		UpdateStrategy:         testDeploymentStrategyConf,
 	}
 	testClusterRKEConfigDNSInterface = []interface{}{
 		map[string]interface{}{
@@ -89,6 +111,7 @@ func init() {
 			"provider":                 "kube-dns",
 			"reverse_cidrs":            []interface{}{"rev1", "rev2"},
 			"upstream_nameservers":     []interface{}{"up1", "up2"},
+			"update_strategy":          testDeploymentStrategyInterface,
 		},
 	}
 }


### PR DESCRIPTION
Work to add the linear_autoscaler_params option to the DNS configuration for RKE as we have a need to adjust the replicas per node.  Fixes #527

Appreciate any guidance if this was submitted incorrectly or code issues. 