### PR TITLE
Fixed rancher2_cluster docs, adding missed gke_config.enable_master_authorized_network argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ BUG FIXES:
 * Fixed doc examples for activedirectory, freeipa and openldap auth providers
 * Fixed `rancher2_app_v2` resource to properly pass global values to sub charts. https://github.com/rancher/terraform-provider-rancher2/issues/545
 * Fixed `rancher2_app_v2` resource to don't override name nor namespace on App v2 not certified by rancher
+* Fixed `rancher2_cluster` docs, adding missed `gke_config.enable_master_authorized_network` argument
 
 ## 1.10.6 (November 11, 2020)
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1159,6 +1159,7 @@ The following arguments are supported:
 * `enable_http_load_balancing` - (Optional) Enable HTTP load balancing on GKE cluster. Default `true` (bool)
 * `enable_kubernetes_dashboard` - (Optional) Whether to enable the Kubernetes dashboard. Default `false` (bool)
 * `enable_legacy_abac` - (Optional) Whether to enable legacy abac on the cluster. Default `false` (bool)
+* `enable_master_authorized_network` - (Optional) Enable master authorized network. Set to `true` if `master_authorized_network_cidr_blocks` is set. Default `false` (bool)
 * `enable_network_policy_config` - (Optional) Enable network policy config for the cluster. Default `true` (bool)
 * `enable_nodepool_autoscaling` - (Optional) Enable nodepool autoscaling. Default `false` (bool)
 * `enable_private_endpoint` - (Optional) Whether the master's internal IP address is used as the cluster endpoint. Default `false` (bool)


### PR DESCRIPTION
Closes #548 