### PR TITLE
Fixed issue with hetzner variable naming

### DIFF
--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -216,7 +216,7 @@ The following attributes are exported:
 * `server_location` - (Optional) Hetzner Cloud datacenter. Default `nbg1` (string)
 * `server_type` - (Optional) Hetzner Cloud server type. Default `cx11` (string)
 * `networks` - (Optional) Comma-separated list of network IDs or names which should be attached to the server private network interface (string)
-* `use_private_networks` - (Optional) Use private network. Default `false` (bool)
+* `use_private_network` - (Optional) Use private network. Default `false` (bool)
 * `volumes` - (Optional) Comma-separated list of volume IDs or names which should be attached to the server (string)
 * `userdata` - (Optional) Path to file with cloud-init user-data (string)
 

--- a/rancher2/schema_node_template_hetzner.go
+++ b/rancher2/schema_node_template_hetzner.go
@@ -54,7 +54,7 @@ func hetznerConfigFields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Comma-separated list of network IDs or names which should be attached to the server private network interface",
 		},
-		"use_private_networks": {
+		"use_private_network": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     false,

--- a/rancher2/schema_node_template_hetzner.go
+++ b/rancher2/schema_node_template_hetzner.go
@@ -11,14 +11,14 @@ const (
 //Types
 
 type hetznerConfig struct {
-	APIToken          string `json:"apiToken,omitempty" yaml:"apiToken,omitempty"`
-	Image             string `json:"image,omitempty" yaml:"image,omitempty"`
-	ServerLocation    string `json:"serverLocation,omitempty" yaml:"serverLocation,omitempty"`
-	ServerType        string `json:"serverType,omitempty" yaml:"serverType,omitempty"`
-	Networks          string `json:"networks,omitempty" yaml:"networks,omitempty"`
-	UsePrivateNetwork bool   `json:"usePrivateNetworks,omitempty" yaml:"usePrivateNetworks,omitempty"`
-	UserData          string `json:"userData,omitempty" yaml:"userData,omitempty"`
-	Volumes           string `json:"volumes,omitempty" yaml:"volumes,omitempty"`
+	APIToken          string   `json:"apiToken,omitempty" yaml:"apiToken,omitempty"`
+	Image             string   `json:"image,omitempty" yaml:"image,omitempty"`
+	ServerLocation    string   `json:"serverLocation,omitempty" yaml:"serverLocation,omitempty"`
+	ServerType        string   `json:"serverType,omitempty" yaml:"serverType,omitempty"`
+	Networks          []string `json:"networks,omitempty" yaml:"networks,omitempty"`
+	UsePrivateNetwork bool     `json:"usePrivateNetworks,omitempty" yaml:"usePrivateNetworks,omitempty"`
+	UserData          string   `json:"userData,omitempty" yaml:"userData,omitempty"`
+	Volumes           []string `json:"volumes,omitempty" yaml:"volumes,omitempty"`
 }
 
 //Schemas

--- a/rancher2/structure_node_template_hetzner.go
+++ b/rancher2/structure_node_template_hetzner.go
@@ -1,5 +1,7 @@
 package rancher2
 
+import "strings"
+
 // Flatteners
 
 func flattenHetznerConfig(in *hetznerConfig) []interface{} {
@@ -25,7 +27,7 @@ func flattenHetznerConfig(in *hetznerConfig) []interface{} {
 	}
 
 	if len(in.Networks) > 0 {
-		obj["networks"] = in.Networks
+		obj["networks"] = strings.Join(in.Networks, ",")
 	}
 
 	obj["use_private_network"] = in.UsePrivateNetwork
@@ -35,7 +37,7 @@ func flattenHetznerConfig(in *hetznerConfig) []interface{} {
 	}
 
 	if len(in.Volumes) > 0 {
-		obj["volumes"] = in.Volumes
+		obj["volumes"] = strings.Join(in.Volumes, ",")
 	}
 
 	return []interface{}{obj}
@@ -67,7 +69,7 @@ func expandHetznercloudConfig(p []interface{}) *hetznerConfig {
 	}
 
 	if v, ok := in["networks"].(string); ok && len(v) > 0 {
-		obj.Networks = v
+		obj.Networks = strings.Split(v, ",")
 	}
 
 	if v, ok := in["use_private_network"].(bool); ok {
@@ -79,7 +81,7 @@ func expandHetznercloudConfig(p []interface{}) *hetznerConfig {
 	}
 
 	if v, ok := in["volumes"].(string); ok && len(v) > 0 {
-		obj.Volumes = v
+		obj.Volumes = strings.Split(v, ",")
 	}
 
 	return obj


### PR DESCRIPTION
This PR removes corrects a wrong named variable in the Hetzner-Cloud node template. Instead of `use_private_network` the variable was named `use_private_networks`.

I decided to introduce a new variable with the correct name and mark the old one as deprecated. I have also fixed the mapping, so that the wrong named variable will be mapped right. However, the new variable will win over a the wrong named one, if its set.

Fixes rancher/terraform-provider-rancher2#567 