### PR TITLE
Add missing OCI config argument vcn_compartment_id

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1212,6 +1212,7 @@ The following arguments are supported:
 * `skip_vcn_delete` - (Optional) Specifies whether to skip deleting the virtual cloud network (VCN) on destroy. Default `false` (bool)
 * `tenancy_id` - (Required) The OCID of the tenancy in which to create resources (string)
 * `user_ocid` - (Required) The OCID of a user who has access to the tenancy/compartment (string)
+* `vcn_compartment_id` - (Optional) The OCID of the compartment (if different from `compartment_id`) in which to find the pre-existing virtual network set with `vcn_name`. (string)
 * `vcn_name` - (Optional) The name of an existing virtual network to use for the cluster creation. If set, you must also set `load_balancer_subnet_name_1`. A VCN and subnets will be created if none are specified. (string)
 * `worker_node_ingress_cidr` - (Optional) Additional CIDR from which to allow ingress to worker nodes (string)
 

--- a/rancher2/schema_cluster_oke_config.go
+++ b/rancher2/schema_cluster_oke_config.go
@@ -168,6 +168,11 @@ func clusterOKEConfigFields() map[string]*schema.Schema {
 			Default:     false,
 			Description: "Whether to skip deleting VCN",
 		},
+		"vcn_compartment_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The OCID of the compartment (if different from compartment_id) in which to find the pre-existing virtual network set with vcn_name.",
+		},
 		"vcn_name": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/rancher2/structure_cluster_oke_config.go
+++ b/rancher2/structure_cluster_oke_config.go
@@ -97,6 +97,10 @@ func flattenClusterOKEConfig(in *OracleKubernetesEngineConfig, p []interface{}) 
 		obj["user_ocid"] = in.UserOCID
 	}
 
+	if len(in.VcnCompartmentID) > 0 {
+		obj["vcn_compartment_id"] = in.VcnCompartmentID
+	}
+
 	if len(in.VCNName) > 0 {
 		obj["vcn_name"] = in.VCNName
 	}
@@ -211,6 +215,10 @@ func expandClusterOKEConfig(p []interface{}, name string) (*OracleKubernetesEngi
 
 	if v, ok := in["user_ocid"].(string); ok && len(v) > 0 {
 		obj.UserOCID = v
+	}
+
+	if v, ok := in["vcn_compartment_id"].(string); ok && len(v) > 0 {
+		obj.VcnCompartmentID = v
 	}
 
 	if v, ok := in["vcn_name"].(string); ok && len(v) > 0 {

--- a/rancher2/structure_cluster_oke_config_test.go
+++ b/rancher2/structure_cluster_oke_config_test.go
@@ -67,6 +67,7 @@ func init() {
 			"skip_vcn_delete":             false,
 			"tenancy_id":                  "tenancy",
 			"user_ocid":                   "user",
+			"vcn_compartment_id":          "",
 			"vcn_name":                    "",
 			"worker_node_ingress_cidr":    "",
 		},


### PR DESCRIPTION
This PR adds an _existing driver_ argument `vcn_compartment_id`, which was previously supported by the [OKE driver](https://github.com/rancher-plugins/kontainer-engine-driver-oke). This argument was inadvertently forgotten when the provider was [initially added](https://github.com/rancher/terraform-provider-rancher2/pull/463/files).