### PR TITLE
Add custom_boot_volume_size and flex_ocpus to OCI config.

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1191,10 +1191,12 @@ The following arguments are supported:
 The following arguments are supported:
 
 * `compartment_id` - (Required) The OCID of the compartment in which to create resources OKE cluster and related resources (string)
+* `custom_boot_volume_size` - (Optional) Optional custom boot volume size (GB) for all nodes. If you specify 0, it will apply the default according to the `node_image` specified. Default `0` (int)
 * `description` - (Optional) An optional description of this cluster (string)
 * `enable_kubernetes_dashboard` - (Optional) Specifies whether to enable the Kubernetes dashboard. Default `false` (bool)
 * `enable_private_nodes` - (Optional) Specifies whether worker nodes will be deployed into a new, private, subnet. Default `false` (bool)
 * `fingerprint` - (Required) The fingerprint corresponding to the specified user's private API Key (string)
+* `flex_ocpus` - (Optional) Specifies number of OCPUs for nodes (requires flexible shape specified with `node_shape`) (int)
 * `kubernetes_version` - (Required) The Kubernetes version that will be used for your master *and* OKE worker nodes (string)
 * `load_balancer_subnet_name_1` - (Optional) The name of the first existing subnet to use for Kubernetes services / LB. `vcn_name` is also required when specifying an existing subnet. (string)
 * `load_balancer_subnet_name_2` - (Optional) The name of a second existing subnet to use for Kubernetes services / LB. A second subnet is only required when it is AD-specific (non-regional) (string)

--- a/rancher2/schema_cluster_oke_config.go
+++ b/rancher2/schema_cluster_oke_config.go
@@ -15,10 +15,12 @@ const (
 
 type OracleKubernetesEngineConfig struct {
 	CompartmentID               string `json:"compartmentId,omitempty" yaml:"compartmentId,omitempty"`
+	CustomBootVolumeSize        int64  `json:"customBootVolumeSize,omitempty" yaml:"customBootVolumeSize,omitempty"`
 	Description                 string `json:"description,omitempty" yaml:"description,omitempty"`
 	DisplayName                 string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	EnableKubernetesDashboard   bool   `json:"enableKubernetesDashboard,omitempty" yaml:"enableKubernetesDashboard,omitempty"`
 	Fingerprint                 string `json:"fingerprint,omitempty" yaml:"fingerprint,omitempty"`
+	FlexOCPUs                   int64  `json:"flexOcpus,omitempty" yaml:"flexOcpus,omitempty"`
 	KubernetesVersion           string `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
 	DriverName                  string `json:"driverName,omitempty" yaml:"driverName,omitempty"`
 	Name                        string `json:"name,omitempty" yaml:"name,omitempty"`
@@ -54,15 +56,25 @@ func clusterOKEConfigFields() map[string]*schema.Schema {
 			Required:    true,
 			Description: "The OCID of the compartment in which to create resources (VCN, worker nodes, etc.)",
 		},
+		"custom_boot_volume_size": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "An optional custom boot volume size (in GB) for the nodes",
+		},
 		"fingerprint": {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "The fingerprint corresponding to the specified user's private API Key",
 		},
+		"flex_ocpus": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Optional number of OCPUs for nodes (requires flexible node_shape)",
+		},
 		"kubernetes_version": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The Kubernetes version that will be used for your master *and* worker nodes e.g. v1.17.9",
+			Description: "The Kubernetes version that will be used for your master *and* worker nodes e.g. v1.18.10",
 		},
 		"node_image": {
 			Type:        schema.TypeString,

--- a/rancher2/structure_cluster_oke_config.go
+++ b/rancher2/structure_cluster_oke_config.go
@@ -20,6 +20,10 @@ func flattenClusterOKEConfig(in *OracleKubernetesEngineConfig, p []interface{}) 
 		obj["compartment_id"] = in.CompartmentID
 	}
 
+	if in.CustomBootVolumeSize > 0 {
+		obj["custom_boot_volume_size"] = int(in.CustomBootVolumeSize)
+	}
+
 	if len(in.Description) > 0 {
 		obj["description"] = in.Description
 	}
@@ -29,6 +33,10 @@ func flattenClusterOKEConfig(in *OracleKubernetesEngineConfig, p []interface{}) 
 
 	if len(in.Fingerprint) > 0 {
 		obj["fingerprint"] = in.Fingerprint
+	}
+
+	if in.FlexOCPUs > 0 {
+		obj["flex_ocpus"] = int(in.FlexOCPUs)
 	}
 
 	if len(in.KubernetesVersion) > 0 {
@@ -129,6 +137,10 @@ func expandClusterOKEConfig(p []interface{}, name string) (*OracleKubernetesEngi
 		obj.CompartmentID = v
 	}
 
+	if v, ok := in["custom_boot_volume_size"].(int); ok && v > 0 {
+		obj.CustomBootVolumeSize = int64(v)
+	}
+
 	if v, ok := in["description"].(string); ok && len(v) > 0 {
 		obj.Description = v
 	}
@@ -143,6 +155,10 @@ func expandClusterOKEConfig(p []interface{}, name string) (*OracleKubernetesEngi
 
 	if v, ok := in["fingerprint"].(string); ok && len(v) > 0 {
 		obj.Fingerprint = v
+	}
+
+	if v, ok := in["flex_ocpus"].(int); ok && v > 0 {
+		obj.FlexOCPUs = int64(v)
 	}
 
 	if v, ok := in["kubernetes_version"].(string); ok && len(v) > 0 {

--- a/rancher2/structure_cluster_oke_config_test.go
+++ b/rancher2/structure_cluster_oke_config_test.go
@@ -15,11 +15,13 @@ var (
 func init() {
 	testClusterOKEConfigConf = &OracleKubernetesEngineConfig{
 		CompartmentID:               "compartment",
+		CustomBootVolumeSize:        0,
 		Description:                 "description",
 		DisplayName:                 "test",
 		DriverName:                  clusterDriverOKE,
 		EnableKubernetesDashboard:   true,
 		Fingerprint:                 "fingerprint",
+		FlexOCPUs:                   0,
 		KubernetesVersion:           "version",
 		Name:                        "test",
 		NodeImage:                   "image",
@@ -46,10 +48,12 @@ func init() {
 	testClusterOKEConfigInterface = []interface{}{
 		map[string]interface{}{
 			"compartment_id":              "compartment",
+			"custom_boot_volume_size":     0,
 			"description":                 "description",
 			"enable_kubernetes_dashboard": true,
 			"enable_private_nodes":        false,
 			"fingerprint":                 "fingerprint",
+			"flex_ocpus":                  0,
 			"kubernetes_version":          "version",
 			"node_image":                  "image",
 			"node_pool_dns_domain_name":   "nodedns",


### PR DESCRIPTION
This PR adds support to `oke_config` for specifying a `custom_boot_volume_size` specifying the number of `flex_ocpus` for a flexible shapes. 

Note, these two parameters have a dependency on `v1.5.x` of the [OKE driver](https://github.com/rancher-plugins/kontainer-engine-driver-oke) (merged). The PR to update the driver to v1.5.2 is [here](https://github.com/rancher/rancher/pull/29727).

Below is an example of using both `custom_boot_volume_size` and `flex_ocpus` in an `oke_config` in `rancher2_cluster`:

```hcl
resource "rancher2_cluster" "dev" {
  name        = "dev-oke"
  description = "oke dev-cluster"
  oke_config {
    compartment_id       = "ocid1.compartment.oc1..aaaaaaaaaaaaaaaaaaaaaaaa"
    tenancy_id           = "ocid1.tenancy.oc1..aaaaaaaaaaaaaaaaaaaaaaaa"
    user_ocid            = "ocid1.user.oc1..aaaaaaaaaaaaaaaaaaaaaaaa"
    region               = "us-phoenix-1"
    fingerprint          = "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
    node_shape           = "VM.Standard.E3.Flex"
    flex_ocpus           =  12
    custom_boot_volume_size = 200
    node_image           = "Oracle-Linux-7.9-2020.11.10-1"
    private_key_contents = "-----BEGIN RSA PRIVATE KEY-----\n....\n-----END RSA PRIVATE KEY-----"
  quantity_per_subnet = 1
  kubernetes_version = "v1.18.10"
  enable_private_nodes = "false"
  skip_vcn_delete = false
  }
}
```


