### PR TITLE
Update labels argument description

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -434,7 +434,7 @@ The following arguments are supported:
 * `enable_cluster_istio` - (Deprecated) Deploy istio on `system` project and `istio-system` namespace, using rancher2_app resource instead. See above example.
 * `enable_network_policy` - (Optional/Computed) Enable project network isolation (bool)
 * `scheduled_cluster_scan`- (Optional/Computed) Cluster scheduled cis scan. For Rancher v2.4.0 or above (List maxitems:1)
-* `annotations` - (Optional/Computed) Annotations for Node Pool object (map)
+* `annotations` - (Optional/Computed) Annotations for the Cluster (map)
 * `labels` - (Optional/Computed) Labels for the Cluster (map)
 * `windows_prefered_cluster` - (Optional) Windows preferred cluster. Default: `false` (bool)
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -435,7 +435,7 @@ The following arguments are supported:
 * `enable_network_policy` - (Optional/Computed) Enable project network isolation (bool)
 * `scheduled_cluster_scan`- (Optional/Computed) Cluster scheduled cis scan. For Rancher v2.4.0 or above (List maxitems:1)
 * `annotations` - (Optional/Computed) Annotations for Node Pool object (map)
-* `labels` - (Optional/Computed) Labels for Node Pool object (map)
+* `labels` - (Optional/Computed) Labels for the Cluster (map)
 * `windows_prefered_cluster` - (Optional) Windows preferred cluster. Default: `false` (bool)
 
 


### PR DESCRIPTION
To avoid confusion, update `labels` argument to refer to the cluster instead of a node pool (possible copy/paste typo)

Related: https://github.com/rancher/terraform-provider-rancher2/issues/582