### PR TITLE
Add image purchase plan to Azure driver on node_template resource

### DIFF
--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -178,6 +178,7 @@ The following attributes are exported:
 * `managed_disks` - (Optional) Configures VM and availability set for managed disks. Just for Rancher v2.3.x and above. Default `false` (bool)
 * `no_public_ip` - (Optional) Do not create a public IP address for the machine. Default `false` (bool)
 * `nsg` - (Optional) Azure Network Security Group to assign this node to (accepts either a name or resource ID, default is to create a new NSG for each machine). Default `docker-machine-nsg` (string)
+* `plan` - (Optional) Azure marketplace purchase plan for Azure Virtual Machine. Format is `<publisher>:<product>:<plan>`. (string)
 * `open_port` - (Optional) Make the specified port number accessible from the Internet. (list)
 * `private_ip_address` - (Optional) Specify a static private IP address for the machine. (string)
 * `resource_group` - (Optional) Azure Resource Group name (will be created if missing). Default `docker-machine` (string)

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -178,7 +178,7 @@ The following attributes are exported:
 * `managed_disks` - (Optional) Configures VM and availability set for managed disks. Just for Rancher v2.3.x and above. Default `false` (bool)
 * `no_public_ip` - (Optional) Do not create a public IP address for the machine. Default `false` (bool)
 * `nsg` - (Optional) Azure Network Security Group to assign this node to (accepts either a name or resource ID, default is to create a new NSG for each machine). Default `docker-machine-nsg` (string)
-* `plan` - (Optional) Azure marketplace purchase plan for Azure Virtual Machine. Format is `<publisher>:<product>:<plan>`. (string)
+* `plan` - (Optional) Azure marketplace purchase plan for Azure Virtual Machine. Format is `<publisher>:<product>:<plan>`. Just for Rancher v2.6.3 and above. (string)
 * `open_port` - (Optional) Make the specified port number accessible from the Internet. (list)
 * `private_ip_address` - (Optional) Specify a static private IP address for the machine. (string)
 * `resource_group` - (Optional) Azure Resource Group name (will be created if missing). Default `docker-machine` (string)

--- a/rancher2/schema_node_template_azure.go
+++ b/rancher2/schema_node_template_azure.go
@@ -24,6 +24,7 @@ type azureConfig struct {
 	ManagedDisks       bool     `json:"managedDisks,omitempty" yaml:"managedDisks,omitempty"`
 	NoPublicIP         bool     `json:"noPublicIp,omitempty" yaml:"noPublicIp,omitempty"`
 	NSG                string   `json:"nsg,omitempty" yaml:"nsg,omitempty"`
+	Plan               string   `json:"plan,omitempty" yaml:"plan,omitempty"`
 	OpenPort           []string `json:"openPort,omitempty" yaml:"openPort,omitempty"`
 	PrivateAddressOnly bool     `json:"privateAddressOnly,omitempty" yaml:"privateAddressOnly,omitempty"`
 	PrivateIPAddress   string   `json:"privateIpAddress,omitempty" yaml:"privateIpAddress,omitempty"`
@@ -125,6 +126,11 @@ func azureConfigFields() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     "docker-machine-nsg",
 			Description: "Azure Network Security Group to assign this node to (accepts either a name or resource ID, default is to create a new NSG for each machine)",
+		},
+		"plan": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Purchase plan for Azure Virtual Machine (in <name>:<publisher>:<product> format)",
 		},
 		"open_port": {
 			Type:        schema.TypeList,

--- a/rancher2/schema_node_template_azure.go
+++ b/rancher2/schema_node_template_azure.go
@@ -130,7 +130,7 @@ func azureConfigFields() map[string]*schema.Schema {
 		"plan": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "Purchase plan for Azure Virtual Machine (in <name>:<publisher>:<product> format)",
+			Description: "Purchase plan for Azure Virtual Machine (in <publisher>:<product>:<plan> format)",
 		},
 		"open_port": {
 			Type:        schema.TypeList,

--- a/rancher2/structure_node_template_azure.go
+++ b/rancher2/structure_node_template_azure.go
@@ -55,6 +55,10 @@ func flattenAzureConfig(in *azureConfig) []interface{} {
 		obj["nsg"] = in.NSG
 	}
 
+	if len(in.Plan) > 0 {
+		obj["plan"] = in.Plan
+	}
+
 	if len(in.OpenPort) > 0 {
 		obj["open_port"] = toArrayInterface(in.OpenPort)
 	}
@@ -167,6 +171,10 @@ func expandAzureConfig(p []interface{}) *azureConfig {
 
 	if v, ok := in["nsg"].(string); ok && len(v) > 0 {
 		obj.NSG = v
+	}
+
+	if v, ok := in["plan"].(string); ok && len(v) > 0 {
+		obj.Plan = v
 	}
 
 	if v, ok := in["open_port"].([]interface{}); ok && len(v) > 0 {


### PR DESCRIPTION
Adds plan attribute on the `node_template`'s `azure_config` for creating vms from marketplace images that have a cost.

Depends on: rancher/machine#122

Issues: 
- rancher/rancher#27854
- rancher/rancher#22927