### PR TITLE
Deprecating retries argument in favour of timeout new argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
-## 1.15.0 (Unreleased)
+## 1.15.0 (May 20, 2021)
 
 FEATURES:
 
 * **Deprecated Argument:** `rancher2_cluster.aks_config.tag` - (Deprecated) Use `tags` argument instead as []string
 * **New Argument:** `rancher2_cluster.aks_config.tags` - (Optional/Computed) Tags for Kubernetes cluster. For example, `["foo=bar","bar=foo"]` (list)
 * **New Argument:** `rancher2_cluster.agent_env_vars` - (Optional) Optional Agent Env Vars for Rancher agent. Just for Rancher v2.5.6 and above (list)
+* **Deprecated provider Argument:** `retries` - (Deprecated) Use timeout instead
+* **New provider Argument:** `timeout` - (Optional) Timeout duration to retry for Rancher connectivity and resource operations. Default: `"120s"`
+* **New Argument:** `rancher2_cluster.oke_config.pod_cidr` - (Optional) A CIDR IP range from which to assign Kubernetes Pod IPs (string)
+* **New Argument:** `rancher2_cluster.oke_config.service_cidr` - (Optional) A CIDR IP range from which to assign Kubernetes Service IPs (string)
 
 ENHANCEMENTS:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,4 +77,5 @@ The following arguments are supported:
 * `ca_certs` - CA certificates used to sign Rancher server tls certificates. Mandatory if self signed tls and insecure option false. It can also be sourced from the `RANCHER_CA_CERTS` environment variable.
 * `insecure` - (Optional) Allow insecure connection to Rancher. Mandatory if self signed tls and not ca_certs provided. It can also be sourced from the `RANCHER_INSECURE` environment variable.
 * `bootstrap` - (Optional) Enable bootstrap mode to manage `rancher2_bootstrap` resource. It can also be sourced from the `RANCHER_BOOTSTRAP` environment variable. Default: `false`
-* `retries` - (Optional) Number of retries to check Rancher connectivity and `rancher2_node_template` resource deletion. Default: `10`
+* `retries` - (Deprecated) Use timeout instead
+* `timeout` - (Optional) Timeout duration to retry for Rancher connectivity and resource operations. Default: `"120s"`

--- a/rancher2/0_provider_upgrade_test.go
+++ b/rancher2/0_provider_upgrade_test.go
@@ -214,7 +214,6 @@ provider "rancher2" {
 ` + testAccRancher2CloudCredentialConfigAmazonec2 + `
 ` + testAccRancher2CloudCredentialConfigAzure + `
 ` + testAccRancher2CloudCredentialConfigDigitalocean + `
-` + testAccRancher2CloudCredentialConfigGoogle + `
 ` + testAccRancher2CloudCredentialConfigOpenstack + `
 ` + testAccRancher2CloudCredentialConfigVsphere + `
 ` + testAccRancher2ClusterConfigRKE + `
@@ -343,19 +342,11 @@ func testAccRancher2UpgradeRancher() resource.TestCheckFunc {
 		if err != nil {
 			return fmt.Errorf("Upgrading rancher to %s: %s\n%v", testAccCheckRancher2UpgradeVersion[testAccCheckRancher2RunningVersionIndex], out, err)
 		}
-		clusterActive, _, err := testAccProvider.Meta().(*Config).isClusterActive(testAccRancher2ClusterID)
-		for retry := 0; retry < 10 && !clusterActive; clusterActive, _, err = testAccProvider.Meta().(*Config).isClusterActive(testAccRancher2ClusterID) {
-			fmt.Printf("Waiting for cluster ID %s becomes active %d\n", testAccRancher2ClusterID, retry+1)
-			time.Sleep(5 * time.Second)
-			retry++
-		}
-
+		_, err = testAccProvider.Meta().(*Config).WaitForClusterState(testAccRancher2ClusterID, clusterActiveCondition, (120 * time.Second))
 		if err != nil {
-			return fmt.Errorf("Getting cluster ID %s state: %s", testAccRancher2ClusterID, err)
+			return fmt.Errorf("Waiting for cluster ID %s to be active: %v", testAccRancher2ClusterID, err)
 		}
-		if !clusterActive {
-			return fmt.Errorf("Cluster ID %s is not active", testAccRancher2ClusterID)
-		}
+		time.Sleep(5 * time.Second)
 		return nil
 	}
 }

--- a/rancher2/resource_rancher2_app_v2.go
+++ b/rancher2/resource_rancher2_app_v2.go
@@ -45,7 +45,7 @@ func resourceRancher2AppV2Create(d *schema.ResourceData, meta interface{}) error
 	}
 	d.Set("cluster_name", cluster.Name)
 
-	systemDefaultRegistry, err := meta.(*Config).GetSettingV2ByID(clusterID, appV2DefaultRegistryID)
+	systemDefaultRegistry, err := meta.(*Config).GetSettingV2ByID(appV2DefaultRegistryID)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func resourceRancher2AppV2Read(d *schema.ResourceData, meta interface{}) error {
 		d.Set("cluster_name", cluster.Name)
 	}
 	if systemDefaultRegistry, ok := d.Get("system_default_registry").(string); !ok || len(systemDefaultRegistry) == 0 {
-		systemDefaultRegistry, err := meta.(*Config).GetSettingV2ByID(clusterID, appV2DefaultRegistryID)
+		systemDefaultRegistry, err := meta.(*Config).GetSettingV2ByID(appV2DefaultRegistryID)
 		if err != nil {
 			return err
 		}

--- a/rancher2/resource_rancher2_catalog_v2.go
+++ b/rancher2/resource_rancher2_catalog_v2.go
@@ -127,7 +127,7 @@ func resourceRancher2CatalogV2Delete(d *schema.ResourceData, meta interface{}) e
 	}
 	_, waitErr := stateConf.WaitForState()
 	if waitErr != nil {
-		return fmt.Errorf("[ERROR] waiting for catalog (%s) to be active: %s", catalog.ID, waitErr)
+		return fmt.Errorf("[ERROR] waiting for catalog (%s) to be deleted: %s", catalog.ID, waitErr)
 	}
 	d.SetId("")
 	return nil

--- a/rancher2/resource_rancher2_catalog_v2_test.go
+++ b/rancher2/resource_rancher2_catalog_v2_test.go
@@ -121,13 +121,13 @@ func testAccRancher2CatalogV2Disappears(cat *ClusterRepo) resource.TestCheckFunc
 				Pending:    []string{},
 				Target:     []string{"removed"},
 				Refresh:    catalogV2StateRefreshFunc(testAccProvider.Meta(), clusterID, catalog.ID),
-				Timeout:    10 * time.Second,
+				Timeout:    120 * time.Second,
 				Delay:      1 * time.Second,
 				MinTimeout: 3 * time.Second,
 			}
 			_, waitErr := stateConf.WaitForState()
 			if waitErr != nil {
-				return fmt.Errorf("[ERROR] waiting for catalog (%s) to be active: %s", catalog.ID, waitErr)
+				return fmt.Errorf("[ERROR] waiting for catalog (%s) to be deleted: %s", catalog.ID, waitErr)
 			}
 		}
 		return nil

--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -1,6 +1,7 @@
 package rancher2
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -172,16 +173,22 @@ func resourceRancher2ClusterCreate(d *schema.ResourceData, meta interface{}) err
 			Links:   newCluster.Links,
 			Actions: newCluster.Actions,
 		}
-		// Retry enabling monitoring if got apierr 500 https://github.com/rancher/rancher/issues/30188
-		for i := 0; i < rancher2RetriesOnServerError; i++ {
+		// Retry enabling monitoring until timeout if got apierr 500 https://github.com/rancher/rancher/issues/30188
+		ctx, cancel := context.WithTimeout(context.Background(), meta.(*Config).Timeout)
+		defer cancel()
+		for {
 			err = client.APIBaseClient.Action(managementClient.ClusterType, monitoringActionEnable, clusterResource, monitoringInput, nil)
 			if err == nil {
-				break
+				return resourceRancher2ClusterRead(d, meta)
 			}
-			if !IsServerError(err) || (i+1) == rancher2RetriesOnServerError {
+			if !IsServerError(err) {
 				return err
 			}
-			time.Sleep(2 * time.Second)
+			select {
+			case <-time.After(rancher2RetriesWait * time.Second):
+			case <-ctx.Done():
+				break
+			}
 		}
 	}
 

--- a/rancher2/resource_rancher2_secret_v2_test.go
+++ b/rancher2/resource_rancher2_secret_v2_test.go
@@ -137,13 +137,13 @@ func testAccRancher2SecretV2Disappears(cat *SecretV2) resource.TestCheckFunc {
 				Pending:    []string{},
 				Target:     []string{"removed"},
 				Refresh:    secretV2StateRefreshFunc(testAccProvider.Meta(), clusterID, secret.ID),
-				Timeout:    10 * time.Second,
+				Timeout:    120 * time.Second,
 				Delay:      1 * time.Second,
 				MinTimeout: 3 * time.Second,
 			}
 			_, waitErr := stateConf.WaitForState()
 			if waitErr != nil {
-				return fmt.Errorf("[ERROR] waiting for secret (%s) to be active: %s", secret.ID, waitErr)
+				return fmt.Errorf("[ERROR] waiting for secret (%s) to be deleted: %s", secret.ID, waitErr)
 			}
 		}
 		return nil

--- a/rancher2/schema_catalog_v2.go
+++ b/rancher2/schema_catalog_v2.go
@@ -12,7 +12,6 @@ const (
 	catalogV2APIVersion       = "v1"
 	catalogV2APIType          = rancher2CatalogTypePrefix + ".clusterrepo"
 	catalogV2ClusterIDsep     = "."
-	catalogV2Timeout          = 120
 	catalogV2DefaultGitBranch = "master"
 )
 

--- a/rancher2/util.go
+++ b/rancher2/util.go
@@ -265,6 +265,10 @@ func RootURL(url string) string {
 	return url
 }
 
+func IsUnknownSchemaType(err error) bool {
+	return strings.HasPrefix(err.Error(), "Unknown schema type")
+}
+
 func IsNotFound(err error) bool {
 	return clientbase.IsNotFound(err)
 }


### PR DESCRIPTION
This PR contains:
- Deprecation of `retries` provider config argument in favour of timeout
- Created new `timeout` provider config argument.
- Fix for app V2 to properly get system-default-registry from Rancher v2.5.8

Issues, https://github.com/rancher/terraform-provider-rancher2/issues/662 and https://github.com/rancher/rancher/issues/32642