### PR TITLE
add "own" to allowed list of verbs for policy rules

### DIFF
--- a/docs/resources/global_role.md
+++ b/docs/resources/global_role.md
@@ -51,7 +51,7 @@ The following attributes are exported:
 * `non_resource_urls` - (Optional) Policy rule non resource urls (list)
 * `resource_names` - (Optional) Policy rule resource names (list)
 * `resources` - (Optional) Policy rule resources (list)
-* `verbs` - (Optional) Policy rule verbs. `create`, `delete`, `deletecollection`, `get`, `list`, `patch`, `update`, `view`, `watch` and `*` values are supported (list)
+* `verbs` - (Optional) Policy rule verbs. `create`, `delete`, `deletecollection`, `get`, `list`, `patch`, `update`, `view`, `watch`, `own` and `*` values are supported (list)
 
 ## Timeouts
 

--- a/docs/resources/role_template.md
+++ b/docs/resources/role_template.md
@@ -74,7 +74,7 @@ The following attributes are exported:
 * `non_resource_urls` - (Optional) Policy rule non resource urls (list)
 * `resource_names` - (Optional) Policy rule resource names (list)
 * `resources` - (Optional) Policy rule resources (list)
-* `verbs` - (Optional) Policy rule verbs. `create`, `delete`, `deletecollection`, `get`, `list`, `patch`, `update`, `view`, `watch` and `*` values are supported (list)
+* `verbs` - (Optional) Policy rule verbs. `create`, `delete`, `deletecollection`, `get`, `list`, `patch`, `update`, `view`, `watch`, `own` and `*` values are supported (list)
 
 ## Timeouts
 

--- a/rancher2/schema_policy_rule.go
+++ b/rancher2/schema_policy_rule.go
@@ -16,6 +16,7 @@ const (
 	policyRuleVerbUpdate           = "update"
 	policyRuleVerbView             = "view"
 	policyRuleVerbWatch            = "watch"
+	policyRuleVerbOwn              = "own"
 )
 
 var (
@@ -30,6 +31,7 @@ var (
 		policyRuleVerbUpdate,
 		policyRuleVerbView,
 		policyRuleVerbWatch,
+		policyRuleVerbOwn,
 	}
 )
 


### PR DESCRIPTION
Rancher uses this for example in the "Project Owner" role, and the API
supports setting it without any problem. We wanted to duplicate this
role with our own changes and couldn't do so properly because we could
not set the verb to "own".