### PR TITLE
Wait for permissions to be applied when creating namespace

### DIFF
--- a/rancher2/resource_rancher2_namespace_test.go
+++ b/rancher2/resource_rancher2_namespace_test.go
@@ -153,7 +153,7 @@ func testAccRancher2NamespaceDisappears(ns *clusterClient.Namespace) resource.Te
 
 			stateConf := &resource.StateChangeConf{
 				Pending:    []string{"removing"},
-				Target:     []string{"removed"},
+				Target:     []string{"removed", "forbidden"},
 				Refresh:    namespaceStateRefreshFunc(client, ns.ID),
 				Timeout:    10 * time.Minute,
 				Delay:      1 * time.Second,


### PR DESCRIPTION
Hi there! We're hitting a problem where this provider reliably fails to create `rancher2_namespace` resources as a project-level user, seemingly due to a timing issue in the way roletemplate permissions are applied in the target cluster. I'll do my best to explain...

In our permissions model, we have users who can create projects, and then create namespaces within them, but cannot `list` or `get` other namespaces. (Pretty typical I guess.) When one of these users creates a namespace, Rancher sees that and creates/updates the user's cluster/rolebindings for the new namespace according to their project-level permissions. But, this isn't instantaneous, so there's a brief period during which the namespace exists but the user cannot (yet) `get` it, and instead gets a 403 when they try. This causes problems for this provider, because it doesn't distinguish between `IsForbidden` and `IsNotFound` when creating a namespace, so when it hits that short window in `WaitForState` it throws an error (the error is `"waiting for namespace (foo) to be created: unexpected state 'removed', wanted target 'active'"`). To fix this, we've allowed the `StateChangeConf` to wait out the 403s when creating a namespace.

I'm not sure this is the best fix, but was hoping to get some feedback. First, does that explanation make sense, and if so is there a better fix for this problem? I was thinking that instead, perhaps the server should always update the user's `namespaces-edit` clusterrole with the new namespace _before_ creating it, but I haven't had a chance to look into that yet, maybe it does already and I'm missing something else. On the other hand, if this all sounds right, I _think_ namespaced resource types may have a similar issue, for example you might see the same with a `rancher2_secret_v2` resource if the rolebinding that grants `secrets-view` is created after the one that allows accessing the target namespace, right?