### PR TITLE
fix: support updating logging enable_json_parsing field

### DIFF
--- a/rancher2/resource_rancher2_cluster_logging.go
+++ b/rancher2/resource_rancher2_cluster_logging.go
@@ -106,6 +106,7 @@ func resourceRancher2ClusterLoggingUpdate(d *schema.ResourceData, meta interface
 	update := map[string]interface{}{
 		"name":                d.Get("name").(string),
 		"namespaceId":         d.Get("namespace_id").(string),
+		"enable_json_parsing": d.Get("enable_json_parsing").(bool),
 		"outputFlushInterval": int64(d.Get("output_flush_interval").(int)),
 		"outputTags":          toMapString(d.Get("output_tags").(map[string]interface{})),
 		"annotations":         toMapString(d.Get("annotations").(map[string]interface{})),

--- a/rancher2/resource_rancher2_project_logging.go
+++ b/rancher2/resource_rancher2_project_logging.go
@@ -106,6 +106,7 @@ func resourceRancher2ProjectLoggingUpdate(d *schema.ResourceData, meta interface
 	update := map[string]interface{}{
 		"name":                d.Get("name").(string),
 		"namespaceId":         d.Get("namespace_id").(string),
+		"enable_json_parsing": d.Get("enable_json_parsing").(bool),
 		"outputFlushInterval": int64(d.Get("output_flush_interval").(int)),
 		"outputTags":          toMapString(d.Get("output_tags").(map[string]interface{})),
 		"annotations":         toMapString(d.Get("annotations").(map[string]interface{})),


### PR DESCRIPTION
right now, the `enable_json_parsing` is only used when reading or creating a new resource, not when updating one.
This fix ensures the `enable_json_parsing` field is also set when updating an existing resource.