### PR TITLE
Add details: how to identify rancher2_app_v2 at import

### DIFF
--- a/docs/resources/app_v2.md
+++ b/docs/resources/app_v2.md
@@ -60,7 +60,7 @@ The following attributes are exported:
 
 ## Import
 
-V2 apps can be imported using the Rancher cluster ID and App V2 name.
+V2 apps can be imported using the Rancher cluster ID and App V2 name, which is composed of `<namespace>/<application_name>`
 
 ```
 $ terraform import rancher2_app_v2.foo &lt;CLUSTER_ID&gt;.&lt;APP_V2_NAME&gt;

--- a/docs/resources/app_v2.md
+++ b/docs/resources/app_v2.md
@@ -60,7 +60,7 @@ The following attributes are exported:
 
 ## Import
 
-V2 apps can be imported using the Rancher cluster ID and App V2 name, which is composed of `<namespace>/<application_name>`
+V2 apps can be imported using the Rancher cluster ID and App V2 name, which is composed of `<namespace>/<application_name>`.
 
 ```
 $ terraform import rancher2_app_v2.foo &lt;CLUSTER_ID&gt;.&lt;APP_V2_NAME&gt;


### PR DESCRIPTION
I got mislead by https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/app_v2#import saying `terraform import rancher2_app_v2.foo <CLUSTER_ID>.<APP_V2_NAME>` - this was successful, but `terraform show` revealed that empty app has been imported.

Meanwhile, what really worked was `terraform import rancher2_app_v2.foo <CLUSTER_ID>.<NAMESPACE>/<APP_NAME>`.
Maybe it's just that by `<APP_V2_NAME>` you actually meant `<NAMESPACE>/<APP_NAME>`, but I have not find such info on the afore-linked page.

Not sure if this is the right place to correct it - if not, please apply it where relevant :pray: 