### PR TITLE
Add `rancher2_principal` data source

### DIFF
--- a/docs/data-sources/principal.md
+++ b/docs/data-sources/principal.md
@@ -1,0 +1,30 @@
+---
+page_title: "rancher2_principal Data Source"
+---
+
+# rancher2\_principal Data Source
+
+Use this data source to retrieve information about a Rancher v2 Principal resource.
+
+## Example Usage
+
+```hcl
+data "rancher2_principal" "foo" {
+  email = "group@example.com"
+  type  = "group"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `email` - (Required) The email address of the identity (string)
+* `type` - (Required) The type of the identity (string). Only `group` and `user` values are supported (string)
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - (Computed) The ID of the resource (string)

--- a/docs/data-sources/principal.md
+++ b/docs/data-sources/principal.md
@@ -10,8 +10,7 @@ Use this data source to retrieve information about a Rancher v2 Principal resour
 
 ```hcl
 data "rancher2_principal" "foo" {
-  email = "group@example.com"
-  type  = "group"
+  name = "user@example.com"
 }
 ```
 
@@ -19,8 +18,8 @@ data "rancher2_principal" "foo" {
 
 The following arguments are supported:
 
-* `email` - (Required) The email address of the identity (string)
-* `type` - (Required) The type of the identity (string). Only `group` and `user` values are supported (string)
+* `name` - (Required) The full name of the principal (string)
+* `type` - (Optional) The type of the identity (string). Defaults to `user`. Only `user` and `group` values are supported (string)
 
 
 ## Attributes Reference

--- a/rancher2/data_source_rancher2_principal.go
+++ b/rancher2/data_source_rancher2_principal.go
@@ -72,6 +72,7 @@ func flattenDataSourcePrincipal(d *schema.ResourceData, in *managementClient.Pri
 	}
 
 	d.Set("id", in.ID)
+	d.Set("name", in.Name)
 	d.Set("type", in.PrincipalType)
 
 	return nil

--- a/rancher2/data_source_rancher2_principal.go
+++ b/rancher2/data_source_rancher2_principal.go
@@ -20,10 +20,6 @@ func dataSourceRancher2Principal() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"provider_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -66,7 +62,6 @@ func flattenDataSourcePrincipal(d *schema.ResourceData, in *managementClient.Pri
 	d.SetId(in.ID)
 	d.Set("id", in.ID)
 	d.Set("type", in.PrincipalType)
-	d.Set("provider_name", in.Provider)
 
 	return nil
 }

--- a/rancher2/data_source_rancher2_principal.go
+++ b/rancher2/data_source_rancher2_principal.go
@@ -1,0 +1,72 @@
+package rancher2
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
+)
+
+func dataSourceRancher2Principal() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRancher2PrincipalRead,
+
+		Schema: map[string]*schema.Schema{
+			"email": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"provider_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRancher2PrincipalRead(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return err
+	}
+
+	email := d.Get("email").(string)
+	principalType := d.Get("type").(string)
+
+	collection, err := client.Principal.List(nil)
+	if err != nil {
+		return err
+	}
+
+	principals, err := client.Principal.CollectionActionSearch(collection, &managementClient.SearchPrincipalsInput{
+		Name:          email,
+		PrincipalType: principalType,
+	})
+	if err != nil {
+		return err
+	}
+
+	count := len(principals.Data)
+	if count <= 0 {
+		return fmt.Errorf("[ERROR] principal \"%s\" of type \"%s\" not found", email, principalType)
+	}
+
+	return flattenDataSourcePrincipal(d, &principals.Data[0])
+}
+
+func flattenDataSourcePrincipal(d *schema.ResourceData, in *managementClient.Principal) error {
+	if in == nil {
+		return nil
+	}
+
+	d.SetId(in.ID)
+	d.Set("id", in.ID)
+	d.Set("type", in.PrincipalType)
+	d.Set("provider_name", in.Provider)
+
+	return nil
+}

--- a/rancher2/data_source_rancher2_principal.go
+++ b/rancher2/data_source_rancher2_principal.go
@@ -71,7 +71,7 @@ func flattenDataSourcePrincipal(d *schema.ResourceData, in *managementClient.Pri
 		return nil
 	}
 
-	d.Set("id", in.ID)
+	d.SetId(in.ID)
 	d.Set("name", in.Name)
 	d.Set("type", in.PrincipalType)
 

--- a/rancher2/provider.go
+++ b/rancher2/provider.go
@@ -189,6 +189,7 @@ func Provider() terraform.ResourceProvider {
 			"rancher2_node_template":                 dataSourceRancher2NodeTemplate(),
 			"rancher2_notifier":                      dataSourceRancher2Notifier(),
 			"rancher2_pod_security_policy_template":  dataSourceRancher2PodSecurityPolicyTemplate(),
+			"rancher2_principal":                     dataSourceRancher2Principal(),
 			"rancher2_project":                       dataSourceRancher2Project(),
 			"rancher2_project_alert_group":           dataSourceRancher2ProjectAlertGroup(),
 			"rancher2_project_alert_rule":            dataSourceRancher2ProjectAlertRule(),


### PR DESCRIPTION
This PR adds `rancher2_principal` data source. This functionality simplifies email -> principal lookups, making easier to manage IAM binding management in resources like `rancher2_global_role_binding`, `rancher2_project_role_template_binding`, etc. 

Example:
```hcl
# User lookup
data "rancher2_principal" "user" {
  name = "user@google.com"
  type   = "user"
}

output "user_principal" {
  value = data.rancher2_principal.user
}

# Group lookup
data "rancher2_principal" "group" {
  name = "group@google.com"
  type   = "group"
}

output "group_principal" {
  value = data.rancher2_principal.group
}
```

Running `terraform plan` results in: 
```
Changes to Outputs:
  + group_principal = {
      + name         = "group@google.com"
      + id            = "googleoauth_group://..."
      + type          = "group"
    }
  + user_principal  = {
      + name          = "user@google.com"
      + id            = "googleoauth_user://..."
      + type          = "user"
    }
```

**Note**: I have only tested this with the Google provider, but looking at the API, the behaviour should be the same across all other providers. 