### PR TITLE
Conflict and retry fixes to v2 objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,23 @@
 
 FEATURES:
 
+* **New Data Source** `rancher2_principal` Use this data source to retrieve information about a Rancher v2 Principal resource
 * **New Argument:** `rancher2_bootstrap.initial_password`  - (Optional/Computed/Sensitive) Initial password for Admin user. Default: `admin` (string)
 
 ENHANCEMENTS:
 
+* Added `IsConflict` function to retry on update v2 resources
+* Added `RestartClients` function to restart Rancher2 clients
+* Updated `CatalogV2Client` function to also retry if err `IsNotFound` or `IsForbidden`
+* Refactored `activateNodeDriver` and `activateKontainerDriver` functions to retry if got conflict on node driver action
+* Refactored v2 resources CRUD functions to be defined at resources files. Added retry if got conflict on update
+* Updated `rancher2_cluster_v2` to support creation using Rancher2 standard user token
+* Refactored `config.NormalizeURL` function to return error
 * Updated `rancher2_bootstrap.current_password` argument to be Computed/Sensitive. Please be sure to remove this field from tf file before update.
 
 BUG FIXES:
 
-
+* Fixed `waitAllCatalogV2Downloaded` function avoiding race condition
 
 ## 1.20.1 (October 5, 2021)
 

--- a/rancher2/data_source_rancher2_catalog_v2.go
+++ b/rancher2/data_source_rancher2_catalog_v2.go
@@ -79,7 +79,7 @@ func dataSourceRancher2CatalogV2Read(d *schema.ResourceData, meta interface{}) e
 	clusterID := d.Get("cluster_id").(string)
 	name := d.Get("name").(string)
 
-	catalog, err := meta.(*Config).GetCatalogV2ByID(clusterID, name)
+	catalog, err := getCatalogV2ByID(meta.(*Config), clusterID, name)
 	if err != nil {
 		if IsNotFound(err) || IsForbidden(err) {
 			log.Printf("[INFO] Catalog V2 %s not found at cluster %s", name, clusterID)

--- a/rancher2/data_source_rancher2_secret_v2.go
+++ b/rancher2/data_source_rancher2_secret_v2.go
@@ -59,7 +59,7 @@ func dataSourceRancher2SecretV2Read(d *schema.ResourceData, meta interface{}) er
 	rancherID := namespace + "/" + name
 	d.SetId(clusterID + secretV2ClusterIDsep + rancherID)
 
-	secret, err := meta.(*Config).GetSecretV2ByID(clusterID, rancherID)
+	secret, err := getSecretV2ByID(meta.(*Config), clusterID, rancherID)
 	if err != nil {
 		if IsNotFound(err) || IsForbidden(err) {
 			log.Printf("[INFO] Secret V2 %s not found at cluster %s", rancherID, clusterID)

--- a/rancher2/provider.go
+++ b/rancher2/provider.go
@@ -254,11 +254,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 }
 
 func providerValidateConfig(config *Config) (*Config, error) {
-	if config.URL == providerDefaultEmptyString {
-		return &Config{}, fmt.Errorf("[ERROR] No api_url provided")
+	err := config.NormalizeURL()
+	if err != nil {
+		return &Config{}, fmt.Errorf("[ERROR] %v", err)
 	}
-
-	config.URL = NormalizeURL(config.URL)
 	if config.Bootstrap {
 		// If bootstrap tokenkey accesskey nor secretkey can be provided
 		if config.TokenKey != providerDefaultEmptyString {

--- a/rancher2/resource_rancher2_app_v2.go
+++ b/rancher2/resource_rancher2_app_v2.go
@@ -1,12 +1,16 @@
 package rancher2
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"net/url"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/rancher/norman/types"
+	types2 "github.com/rancher/rancher/pkg/api/steve/catalog/types"
 )
 
 func resourceRancher2AppV2() *schema.Resource {
@@ -51,7 +55,7 @@ func resourceRancher2AppV2Create(d *schema.ResourceData, meta interface{}) error
 	}
 	d.Set("system_default_registry", systemDefaultRegistry.Value)
 
-	repo, chartInfo, err := meta.(*Config).InfoAppV2(clusterID, repoName, chartName, chartVersion)
+	repo, chartInfo, err := infoAppV2(meta.(*Config), clusterID, repoName, chartName, chartVersion)
 	if err != nil {
 		return err
 	}
@@ -61,7 +65,7 @@ func resourceRancher2AppV2Create(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	chartOperation, err := meta.(*Config).InstallAppV2(clusterID, repo, chartInstallAction)
+	chartOperation, err := createAppV2(meta.(*Config), clusterID, repo, chartInstallAction)
 	if err != nil {
 		return err
 	}
@@ -94,7 +98,7 @@ func resourceRancher2AppV2Read(d *schema.ResourceData, meta interface{}) error {
 		d.Set("system_default_registry", systemDefaultRegistry.Value)
 	}
 	_, rancherID := splitID(d.Id())
-	app, err := meta.(*Config).GetAppV2ByID(clusterID, rancherID)
+	app, err := getAppV2ByID(meta.(*Config), clusterID, rancherID)
 	if err != nil {
 		if IsNotFound(err) || IsForbidden(err) {
 			log.Printf("[INFO] App V2 %s not found at %s", name, clusterID)
@@ -114,7 +118,7 @@ func resourceRancher2AppV2Update(d *schema.ResourceData, meta interface{}) error
 	chartVersion := d.Get("chart_version").(string)
 	log.Printf("[INFO] Updating App V2 %s at %s", name, clusterID)
 
-	repo, chartInfo, err := meta.(*Config).InfoAppV2(clusterID, repoName, chartName, chartVersion)
+	repo, chartInfo, err := infoAppV2(meta.(*Config), clusterID, repoName, chartName, chartVersion)
 	if err != nil {
 		return err
 	}
@@ -123,7 +127,7 @@ func resourceRancher2AppV2Update(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	chartOperation, err := meta.(*Config).UpgradeAppV2(clusterID, repo, chartUpgradeAction)
+	chartOperation, err := upgradeAppV2(meta.(*Config), clusterID, repo, chartUpgradeAction)
 	if err != nil {
 		return err
 	}
@@ -140,7 +144,7 @@ func resourceRancher2AppV2Delete(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[INFO] Deleting App V2 %s at %s", name, clusterID)
 
 	_, rancherID := splitID(d.Id())
-	app, err := meta.(*Config).GetAppV2ByID(clusterID, rancherID)
+	app, err := getAppV2ByID(meta.(*Config), clusterID, rancherID)
 	if err != nil {
 		if IsNotFound(err) || IsForbidden(err) {
 			log.Printf("[INFO] App V2 %s not found at %s", name, clusterID)
@@ -149,7 +153,7 @@ func resourceRancher2AppV2Delete(d *schema.ResourceData, meta interface{}) error
 		}
 		return err
 	}
-	err = meta.(*Config).DeleteAppV2(clusterID, app)
+	err = deleteAppV2(meta.(*Config), clusterID, app)
 	if err != nil {
 		return fmt.Errorf("Error removing App V2 %s: %s", name, err)
 	}
@@ -175,14 +179,14 @@ func resourceRancher2AppV2Delete(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("bad format on chart annotation catalog.cattle.io/auto-install: %s", app.Spec.Chart.Metadata.Annotations["catalog.cattle.io/auto-install"])
 		}
 		name := chartAuto[0]
-		app, err = meta.(*Config).GetAppV2ByID(clusterID, namespace+"/"+name)
+		app, err = getAppV2ByID(meta.(*Config), clusterID, namespace+"/"+name)
 		if err != nil {
 			if IsNotFound(err) || IsForbidden(err) {
 				return nil
 			}
 			return err
 		}
-		err = meta.(*Config).DeleteAppV2(clusterID, app)
+		err = deleteAppV2(meta.(*Config), clusterID, app)
 		if err != nil {
 			return fmt.Errorf("Error removing App V2 %s: %s", name, err)
 		}
@@ -206,7 +210,7 @@ func resourceRancher2AppV2Delete(d *schema.ResourceData, meta interface{}) error
 // appV2StateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher App.
 func appV2StateRefreshFunc(meta interface{}, clusterID, appID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		obj, err := meta.(*Config).GetAppV2ByID(clusterID, appID)
+		obj, err := getAppV2ByID(meta.(*Config), clusterID, appID)
 		if err != nil {
 			if IsNotFound(err) || IsForbidden(err) {
 				return obj, "removed", nil
@@ -221,7 +225,7 @@ func appV2StateRefreshFunc(meta interface{}, clusterID, appID string) resource.S
 }
 
 func appV2OperationWait(meta interface{}, clusterID, opID string) error {
-	for obj, err := meta.(*Config).GetAppV2OperationByID(clusterID, opID); ; obj, err = meta.(*Config).GetAppV2OperationByID(clusterID, opID) {
+	for obj, err := getAppV2OperationByID(meta.(*Config), clusterID, opID); ; obj, err = getAppV2OperationByID(meta.(*Config), clusterID, opID) {
 		if err != nil {
 			return err
 		}
@@ -229,7 +233,7 @@ func appV2OperationWait(meta interface{}, clusterID, opID string) error {
 			if state, ok := metadata["state"].(map[string]interface{}); ok && len(state) > 0 {
 				if transitioning, ok := state["transitioning"].(bool); ok && !transitioning {
 					if opError, ok := state["error"].(bool); ok && opError {
-						message, err := meta.(*Config).GetAppV2OperationLogs(clusterID, obj)
+						message, err := getAppV2OperationLogs(meta.(*Config), clusterID, obj)
 						if err != nil {
 							return fmt.Errorf("%s: %s", state["message"], err)
 						}
@@ -242,4 +246,209 @@ func appV2OperationWait(meta interface{}, clusterID, opID string) error {
 		}
 		time.Sleep(5 * time.Second)
 	}
+}
+
+// Rancher2 App V2 API CRUD functions
+func createAppV2(c *Config, clusterID string, repo *ClusterRepo, chartIntall *types2.ChartInstallAction) (*types2.ChartActionOutput, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Creating app V2: Provider config is nil")
+	}
+	if clusterID == "" {
+		return nil, fmt.Errorf("Creating app V2: Cluster ID is nil")
+	}
+	if repo == nil || chartIntall == nil {
+		return nil, fmt.Errorf("Creating app V2: Catalog V2 id and chartIntall should be provided")
+	}
+
+	client, err := c.CatalogV2Client(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	resource := &types.Resource{
+		ID:      repo.ID,
+		Type:    repo.Type,
+		Links:   repo.Links,
+		Actions: repo.Actions,
+	}
+	resp := &types2.ChartActionOutput{}
+	err = client.Action(catalogV2APIType, "install", resource, chartIntall, resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to install app v2: %v", err)
+	}
+	return resp, nil
+}
+
+func upgradeAppV2(c *Config, clusterID string, repo *ClusterRepo, chartUpgrade *types2.ChartUpgradeAction) (*types2.ChartActionOutput, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Upgrading app V2: Provider config is nil")
+	}
+	if clusterID == "" {
+		return nil, fmt.Errorf("Upgrading app V2: Cluster ID is nil")
+	}
+	if repo == nil || chartUpgrade == nil {
+		return nil, fmt.Errorf("Upgrading app V2: Catalog V2 id and chartUpgrade should be provided")
+	}
+
+	client, err := c.CatalogV2Client(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	resource := &types.Resource{
+		ID:      repo.ID,
+		Type:    repo.Type,
+		Links:   repo.Links,
+		Actions: repo.Actions,
+	}
+	resp := &types2.ChartActionOutput{}
+	err = client.Action(catalogV2APIType, "upgrade", resource, chartUpgrade, resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to upgrade app v2: %v", err)
+	}
+	return resp, nil
+}
+
+func deleteAppV2(c *Config, clusterID string, app *AppV2) error {
+	if c == nil {
+		return fmt.Errorf("Deleting app V2: Provider config is nil")
+	}
+	if clusterID == "" {
+		return fmt.Errorf("Deleting app V2: Cluster ID is nil")
+	}
+	if app == nil {
+		return fmt.Errorf("App V2 id is nil")
+	}
+
+	client, err := c.CatalogV2Client(clusterID)
+	if err != nil {
+		return err
+	}
+	resource := &types.Resource{
+		ID:      app.ID,
+		Type:    app.Type,
+		Links:   app.Links,
+		Actions: app.Actions,
+	}
+	var resp interface{}
+	return client.Action(appV2APIType, "uninstall", resource, map[string]interface{}{}, resp)
+}
+
+func infoAppV2(c *Config, clusterID, repoName, chartName, chartVersion string) (*ClusterRepo, *types2.ChartInfo, error) {
+	if c == nil {
+		return nil, nil, fmt.Errorf("Getting app V2 info: Provider config is nil")
+	}
+	if clusterID == "" {
+		return nil, nil, fmt.Errorf("Getting app V2 info: Cluster ID is nil")
+	}
+	if repoName == "" || chartName == "" {
+		return nil, nil, fmt.Errorf("Getting app V2 info: Catalog V2 id and chart name should be provided")
+	}
+	// Waiting for the Catalog V2 is Downloaded
+	repo, err := waitCatalogV2Downloaded(c, clusterID, repoName)
+	if err != nil {
+		return nil, nil, err
+	}
+	resource := types.Resource{
+		ID:      repo.ID,
+		Type:    repo.Type,
+		Links:   repo.Links,
+		Actions: repo.Actions,
+	}
+	link := "info"
+	if resource.Links == nil || len(resource.Links[link]) == 0 {
+		return nil, nil, fmt.Errorf("failed to get chart info %s:%s from catalog v2 %s", chartName, chartVersion, repoName)
+	}
+
+	resource.Links[link] = resource.Links[link] + "&chartName=" + url.QueryEscape(chartName)
+	if len(chartVersion) > 0 {
+		resource.Links[link] = resource.Links[link] + "&version=" + url.QueryEscape(chartVersion)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	client, err := c.CatalogV2Client(clusterID)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp := &types2.ChartInfo{}
+	for {
+		err = client.GetLink(resource, link, resp)
+		if err == nil {
+			return repo, resp, nil
+		}
+		if !IsServerError(err) && !IsNotFound(err) {
+			return nil, nil, fmt.Errorf("failed to get chart info %s:%s from catalog v2 %s: %v", chartName, chartVersion, repoName, err)
+		}
+		select {
+		case <-time.After(rancher2RetriesWait * time.Second):
+		case <-ctx.Done():
+			return nil, nil, fmt.Errorf("Timeout getting chart info %s:%s from catalog v2 %s: %v", chartName, chartVersion, repoName, err)
+		}
+	}
+}
+
+func getAppV2ByID(c *Config, clusterID, id string) (*AppV2, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Getting app V2: Provider config is nil")
+	}
+	if len(clusterID) == 0 || len(id) == 0 {
+		return nil, fmt.Errorf("Getting app V2: Cluster ID and/or App V2 ID is nil")
+	}
+	resp := &AppV2{}
+	err := c.getObjectV2ByID(clusterID, id, appV2APIType, resp)
+	if err != nil {
+		if !IsServerError(err) && !IsNotFound(err) && !IsForbidden(err) {
+			return nil, fmt.Errorf("Getting App V2: %s", err)
+		}
+		return nil, err
+	}
+	return resp, nil
+}
+
+func getAppV2OperationByID(c *Config, clusterID, id string) (map[string]interface{}, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Getting app V2 operation: Provider config is nil")
+	}
+	if len(clusterID) == 0 || len(id) == 0 {
+		return nil, fmt.Errorf("Getting app V2 operation: Cluster ID and/or App V2 ID is nil")
+	}
+	resp := map[string]interface{}{}
+	err := c.getObjectV2ByID(clusterID, id, appV2OperationAPIType, &resp)
+	if err != nil {
+		if !IsServerError(err) && !IsNotFound(err) && !IsForbidden(err) {
+			return nil, fmt.Errorf("Getting App V2 logs: %s", err)
+		}
+		return nil, err
+	}
+	return resp, nil
+}
+
+func getAppV2OperationLogs(c *Config, clusterID string, op map[string]interface{}) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("Getting app V2 operation logs: Provider config is nil")
+	}
+	if len(clusterID) == 0 {
+		return "", fmt.Errorf("Getting app V2 operation logs: Cluster ID is nil")
+	}
+	if op == nil {
+		return "", fmt.Errorf("Getting app V2 operation logs: App V2 operation is nil")
+	}
+	if v, ok := op["id"].(string); !ok || v == "" {
+		return "", fmt.Errorf("Getting app V2 operation logs: App V2 operation id is nil")
+	}
+	opLinks, ok := op["links"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("Getting app V2 operation logs: App V2 operation links are not available")
+	}
+	links := toMapString(opLinks)
+	link := "logs"
+	if links == nil || len(links[link]) == 0 {
+		return "", fmt.Errorf("failed to get app v2 operation log %s", op["id"])
+	}
+
+	resp, err := DoGet(links[link], "", "", c.TokenKey, c.CACerts, c.Insecure)
+	if err != nil {
+		return "", fmt.Errorf("failed to get app v2 operation log %s: %s", op["id"], err)
+	}
+
+	return string(resp), nil
 }

--- a/rancher2/resource_rancher2_app_v2_test.go
+++ b/rancher2/resource_rancher2_app_v2_test.go
@@ -145,14 +145,14 @@ func testAccRancher2AppV2Disappears(cat *AppV2) resource.TestCheckFunc {
 			clusterID := rs.Primary.Attributes["cluster_id"]
 			name := rs.Primary.Attributes["name"]
 			_, rancherID := splitID(rs.Primary.ID)
-			app, err := testAccProvider.Meta().(*Config).GetAppV2ByID(clusterID, rancherID)
+			app, err := getAppV2ByID(testAccProvider.Meta().(*Config), clusterID, rancherID)
 			if err != nil {
 				if IsNotFound(err) || IsForbidden(err) {
 					return nil
 				}
 				return err
 			}
-			err = testAccProvider.Meta().(*Config).DeleteAppV2(clusterID, app)
+			err = deleteAppV2(testAccProvider.Meta().(*Config), clusterID, app)
 			if err != nil {
 				return fmt.Errorf("Error removing App V2 %s: %s", name, err)
 			}
@@ -188,7 +188,7 @@ func testAccCheckRancher2AppV2Exists(n string, cat *AppV2) resource.TestCheckFun
 
 		clusterID := rs.Primary.Attributes["cluster_id"]
 		_, rancherID := splitID(rs.Primary.ID)
-		foundReg, err := testAccProvider.Meta().(*Config).GetAppV2ByID(clusterID, rancherID)
+		foundReg, err := getAppV2ByID(testAccProvider.Meta().(*Config), clusterID, rancherID)
 		if err != nil {
 			if IsNotFound(err) || IsForbidden(err) {
 				return nil
@@ -209,7 +209,7 @@ func testAccCheckRancher2AppV2Destroy(s *terraform.State) error {
 		}
 		clusterID := rs.Primary.Attributes["cluster_id"]
 		_, rancherID := splitID(rs.Primary.ID)
-		_, err := testAccProvider.Meta().(*Config).GetAppV2ByID(clusterID, rancherID)
+		_, err := getAppV2ByID(testAccProvider.Meta().(*Config), clusterID, rancherID)
 		if err != nil {
 			if IsNotFound(err) {
 				return nil

--- a/rancher2/resource_rancher2_bootstrap.go
+++ b/rancher2/resource_rancher2_bootstrap.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -34,8 +33,7 @@ func resourceRancher2BootstrapCreate(d *schema.ResourceData, meta interface{}) e
 	d.Set("user", bootstrapDefaultUser)
 
 	// Set rancher url
-	url := strings.TrimSuffix(meta.(*Config).URL, "/v3")
-	err = meta.(*Config).SetSetting(bootstrapSettingURL, url)
+	err = meta.(*Config).SetSetting(bootstrapSettingURL, meta.(*Config).URL)
 	if err != nil {
 		return err
 	}
@@ -169,8 +167,7 @@ func resourceRancher2BootstrapUpdate(d *schema.ResourceData, meta interface{}) e
 	d.Set("user", bootstrapDefaultUser)
 
 	// Set rancher url
-	url := strings.TrimSuffix(meta.(*Config).URL, "/v3")
-	err = meta.(*Config).SetSetting(bootstrapSettingURL, url)
+	err = meta.(*Config).SetSetting(bootstrapSettingURL, meta.(*Config).URL)
 	if err != nil {
 		return err
 	}

--- a/rancher2/resource_rancher2_catalog_v2.go
+++ b/rancher2/resource_rancher2_catalog_v2.go
@@ -1,13 +1,16 @@
 package rancher2
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/rancher/norman/types"
 	"github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"golang.org/x/sync/errgroup"
 )
 
 func resourceRancher2CatalogV2() *schema.Resource {
@@ -35,7 +38,7 @@ func resourceRancher2CatalogV2Create(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] Creating Catalog V2 %s", name)
 
-	newCatalog, err := meta.(*Config).CreateCatalogV2(clusterID, catalog)
+	newCatalog, err := createCatalogV2(meta.(*Config), clusterID, catalog)
 	if err != nil {
 		return err
 	}
@@ -61,7 +64,7 @@ func resourceRancher2CatalogV2Read(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[INFO] Refreshing Catalog V2 %s", name)
 
 	_, rancherID := splitID(d.Id())
-	catalog, err := meta.(*Config).GetCatalogV2ByID(clusterID, rancherID)
+	catalog, err := getCatalogV2ByID(meta.(*Config), clusterID, rancherID)
 	if err != nil {
 		if IsNotFound(err) || IsForbidden(err) {
 			log.Printf("[INFO] Catalog V2 %s not found", name)
@@ -80,7 +83,7 @@ func resourceRancher2CatalogV2Update(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[INFO] Updating Catalog V2 %s", name)
 
 	_, rancherID := splitID(d.Id())
-	newCatalog, err := meta.(*Config).UpdateCatalogV2(clusterID, rancherID, catalog)
+	newCatalog, err := updateCatalogV2(meta.(*Config), clusterID, rancherID, catalog)
 	if err != nil {
 		return err
 	}
@@ -106,14 +109,14 @@ func resourceRancher2CatalogV2Delete(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[INFO] Deleting Catalog V2 %s", name)
 
 	_, rancherID := splitID(d.Id())
-	catalog, err := meta.(*Config).GetCatalogV2ByID(clusterID, rancherID)
+	catalog, err := getCatalogV2ByID(meta.(*Config), clusterID, rancherID)
 	if err != nil {
 		if IsNotFound(err) || IsForbidden(err) {
 			d.SetId("")
 			return nil
 		}
 	}
-	err = meta.(*Config).DeleteCatalogV2(clusterID, catalog)
+	err = deleteCatalogV2(meta.(*Config), clusterID, catalog)
 	if err != nil {
 		return err
 	}
@@ -136,7 +139,7 @@ func resourceRancher2CatalogV2Delete(d *schema.ResourceData, meta interface{}) e
 // catalogV2StateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher Catalog v2.
 func catalogV2StateRefreshFunc(meta interface{}, clusterID, catalogID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		obj, err := meta.(*Config).GetCatalogV2ByID(clusterID, catalogID)
+		obj, err := getCatalogV2ByID(meta.(*Config), clusterID, catalogID)
 		if err != nil {
 			if IsNotFound(err) || IsForbidden(err) {
 				return obj, "removed", nil
@@ -156,4 +159,197 @@ func catalogV2StateRefreshFunc(meta interface{}, clusterID, catalogID string) re
 		}
 		return obj, "transitioning", nil
 	}
+}
+
+// Rancher2 Catalog V2 API CRUD functions
+func createCatalogV2(c *Config, clusterID string, repo *ClusterRepo) (*ClusterRepo, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Creating catalog V2: Provider config is nil")
+	}
+	if clusterID == "" {
+		return nil, fmt.Errorf("Creating catalog V2: Cluster ID is nil")
+	}
+	if repo == nil {
+		return nil, fmt.Errorf("Creating catalog V2: object is nil")
+	}
+	resp := &ClusterRepo{}
+	err := c.createObjectV2(clusterID, catalogV2APIType, repo, resp)
+	if err != nil {
+		return nil, fmt.Errorf("Creating Catalog V2: %s", err)
+	}
+	return resp, nil
+}
+
+func deleteCatalogV2(c *Config, clusterID string, obj *ClusterRepo) error {
+	if c == nil {
+		return fmt.Errorf("Deleting catalog V2: Provider config is nil")
+	}
+	if clusterID == "" {
+		return fmt.Errorf("Deleting catalog V2: Cluster ID is nil")
+	}
+	if obj == nil {
+		return fmt.Errorf("Deleting catalog V2: Catalog V2 is nil")
+	}
+
+	resource := &types.Resource{
+		ID:      obj.ID,
+		Type:    obj.Type,
+		Links:   obj.Links,
+		Actions: obj.Actions,
+	}
+	return c.deleteObjectV2(clusterID, resource)
+}
+
+func getCatalogV2ByID(c *Config, clusterID, id string) (*ClusterRepo, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Getting catalog V2: Provider config is nil")
+	}
+	if len(clusterID) == 0 || len(id) == 0 {
+		return nil, fmt.Errorf("Getting catalog V2: Cluster ID and/or Catalog V2 ID is nil")
+	}
+	resp := &ClusterRepo{}
+	err := c.getObjectV2ByID(clusterID, id, catalogV2APIType, resp)
+	if err != nil {
+		if !IsServerError(err) && !IsNotFound(err) && !IsForbidden(err) {
+			return nil, fmt.Errorf("Getting Catalog V2: %s", err)
+		}
+		return nil, err
+	}
+	return resp, nil
+}
+
+func updateCatalogV2(c *Config, clusterID, id string, obj *ClusterRepo) (*ClusterRepo, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Updating catalog V2: Provider config is nil")
+	}
+	if len(clusterID) == 0 || len(id) == 0 {
+		return nil, fmt.Errorf("Updating catalog V2: Cluster ID and/or Catalog V2 ID is nil")
+	}
+	if obj == nil {
+		return nil, fmt.Errorf("Updating catalog V2: Cluster V2 is nil")
+	}
+	resp := &ClusterRepo{}
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	for {
+		err := c.updateObjectV2(clusterID, id, catalogV2APIType, obj, resp)
+		if err == nil {
+			return resp, err
+		}
+		if !IsServerError(err) && !IsUnknownSchemaType(err) && !IsConflict(err) {
+			return nil, err
+		}
+		if IsConflict(err) {
+			// Read clusterRepo again and update ObjectMeta.ResourceVersion before retry
+			newObj := &ClusterRepo{}
+			err = c.getObjectV2ByID(clusterID, id, catalogV2APIType, newObj)
+			if err != nil {
+				return nil, err
+			}
+			obj.ObjectMeta.ResourceVersion = newObj.ObjectMeta.ResourceVersion
+		}
+		select {
+		case <-time.After(rancher2RetriesWait * time.Second):
+		case <-ctx.Done():
+			return nil, fmt.Errorf("Timeout updating catalog V2 ID %s: %v", id, err)
+		}
+	}
+}
+
+func getCatalogV2List(c *Config, clusterID string) ([]ClusterRepo, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Getting catalog V2: Provider config is nil")
+	}
+	if clusterID == "" {
+		return nil, fmt.Errorf("Cluster v2 ID is nil")
+	}
+	client, err := c.CatalogV2Client(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	listOpts := NewListOpts(nil)
+	resp := &ClusterRepoCollection{}
+	for {
+		err = client.List(catalogV2APIType, listOpts, resp)
+		if err == nil {
+			return resp.Data, nil
+		}
+		if !IsServerError(err) && !IsUnknownSchemaType(err) && !IsNotFound(err) {
+			return nil, err
+		}
+		select {
+		case <-time.After(rancher2RetriesWait * time.Second):
+		case <-ctx.Done():
+			return nil, fmt.Errorf("Timeout getting catalog V2 list at cluster ID %s: %v", clusterID, err)
+		}
+	}
+}
+
+func waitCatalogV2Downloaded(c *Config, clusterID, catalogID string) (*ClusterRepo, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Waiting for catalog V2: Provider config is nil")
+	}
+	if clusterID == "" || catalogID == "" {
+		return nil, fmt.Errorf("Waiting for catalog V2: Cluster ID and/or Catalog V2 ID is nil")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	for {
+		obj, err := getCatalogV2ByID(c, clusterID, catalogID)
+		if err != nil {
+			return nil, fmt.Errorf("Getting catalog V2 ID (%s): %v", catalogID, err)
+		}
+		for i := range obj.Status.Conditions {
+			if obj.Status.Conditions[i].Type == string(v1.RepoDownloaded) {
+				// Status of the condition, one of True, False, Unknown.
+				if obj.Status.Conditions[i].Status == "Unknown" {
+					break
+				}
+				if obj.Status.Conditions[i].Status == "True" {
+					return obj, nil
+				}
+				return nil, fmt.Errorf("Catalog V2 ID %s: %s", catalogID, obj.Status.Conditions[i].Message)
+			}
+		}
+		select {
+		case <-time.After(rancher2RetriesWait * time.Second):
+		case <-ctx.Done():
+			return nil, fmt.Errorf("[ERROR] Timeout waiting for catalog V2 ID %s at cluster ID (%s): %v", catalogID, clusterID, err)
+		}
+	}
+}
+
+func waitAllCatalogV2Downloaded(c *Config, clusterID string) ([]ClusterRepo, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Waiting for all catalogs V2: Provider config is nil")
+	}
+	clusterRepos, err := getCatalogV2List(c, clusterID)
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] getting catalog V2 list at cluster ID (%s): %s", clusterID, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	g, ctx := errgroup.WithContext(ctx)
+	for _, clusterRepo := range clusterRepos {
+		repoID := clusterRepo.ID
+		g.Go(func() error {
+			repo := repoID
+			_, err := waitCatalogV2Downloaded(c, clusterID, repo)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	err = g.Wait()
+	if err != nil {
+		return clusterRepos, fmt.Errorf("[ERROR] waiting for all catalogs V2 to be active at cluster ID (%s): %s", clusterID, err)
+	}
+
+	return clusterRepos, nil
 }

--- a/rancher2/resource_rancher2_catalog_v2_test.go
+++ b/rancher2/resource_rancher2_catalog_v2_test.go
@@ -106,14 +106,14 @@ func testAccRancher2CatalogV2Disappears(cat *ClusterRepo) resource.TestCheckFunc
 			}
 			clusterID := rs.Primary.Attributes["cluster_id"]
 			_, rancherID := splitID(rs.Primary.ID)
-			catalog, err := testAccProvider.Meta().(*Config).GetCatalogV2ByID(clusterID, rancherID)
+			catalog, err := getCatalogV2ByID(testAccProvider.Meta().(*Config), clusterID, rancherID)
 			if err != nil {
 				if IsNotFound(err) || IsForbidden(err) {
 					return nil
 				}
 				return fmt.Errorf("testAccRancher2CatalogV2Disappears-get: %v", err)
 			}
-			err = testAccProvider.Meta().(*Config).DeleteCatalogV2(clusterID, catalog)
+			err = deleteCatalogV2(testAccProvider.Meta().(*Config), clusterID, catalog)
 			if err != nil {
 				return fmt.Errorf("testAccRancher2CatalogV2Disappears-delete: %v", err)
 			}
@@ -149,7 +149,7 @@ func testAccCheckRancher2CatalogV2Exists(n string, cat *ClusterRepo) resource.Te
 
 		clusterID := rs.Primary.Attributes["cluster_id"]
 		_, rancherID := splitID(rs.Primary.ID)
-		foundReg, err := testAccProvider.Meta().(*Config).GetCatalogV2ByID(clusterID, rancherID)
+		foundReg, err := getCatalogV2ByID(testAccProvider.Meta().(*Config), clusterID, rancherID)
 		if err != nil {
 			if IsNotFound(err) || IsForbidden(err) {
 				return nil
@@ -170,7 +170,7 @@ func testAccCheckRancher2CatalogV2Destroy(s *terraform.State) error {
 		}
 		clusterID := rs.Primary.Attributes["cluster_id"]
 		_, rancherID := splitID(rs.Primary.ID)
-		_, err := testAccProvider.Meta().(*Config).GetCatalogV2ByID(clusterID, rancherID)
+		_, err := getCatalogV2ByID(testAccProvider.Meta().(*Config), clusterID, rancherID)
 		if err != nil {
 			if IsNotFound(err) {
 				return nil

--- a/rancher2/resource_rancher2_cluster_sync.go
+++ b/rancher2/resource_rancher2_cluster_sync.go
@@ -47,7 +47,7 @@ func resourceRancher2ClusterSyncCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if d.Get("wait_catalogs").(bool) {
-		_, err := meta.(*Config).WaitAllCatalogV2Downloaded(clusterID)
+		_, err := waitAllCatalogV2Downloaded(meta.(*Config), clusterID)
 		if err != nil {
 			return fmt.Errorf("[ERROR] waiting for cluster ID (%s) downloading catalogs: %v", clusterID, err)
 		}
@@ -117,7 +117,7 @@ func resourceRancher2ClusterSyncRead(d *schema.ResourceData, meta interface{}) e
 		}
 
 		if d.Get("wait_catalogs").(bool) {
-			_, err := meta.(*Config).WaitAllCatalogV2Downloaded(clusterID)
+			_, err := waitAllCatalogV2Downloaded(meta.(*Config), clusterID)
 			if err != nil {
 				return err
 			}

--- a/rancher2/resource_rancher2_secret_v2.go
+++ b/rancher2/resource_rancher2_secret_v2.go
@@ -1,6 +1,7 @@
 package rancher2
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/rancher/norman/types"
 )
 
 func resourceRancher2SecretV2() *schema.Resource {
@@ -41,7 +43,7 @@ func resourceRancher2SecretV2Create(d *schema.ResourceData, meta interface{}) er
 
 	log.Printf("[INFO] Creating Secret V2 %s", name)
 
-	newSecret, err := meta.(*Config).CreateSecretV2(clusterID, secret)
+	newSecret, err := createSecretV2(meta.(*Config), clusterID, secret)
 	if err != nil {
 		return err
 	}
@@ -65,7 +67,7 @@ func resourceRancher2SecretV2Read(d *schema.ResourceData, meta interface{}) erro
 	clusterID, rancherID := splitID(d.Id())
 	log.Printf("[INFO] Refreshing Secret V2 %s at Cluster ID %s", rancherID, clusterID)
 
-	secret, err := meta.(*Config).GetSecretV2ByID(clusterID, rancherID)
+	secret, err := getSecretV2ByID(meta.(*Config), clusterID, rancherID)
 	if err != nil {
 		if IsNotFound(err) || IsForbidden(err) {
 			log.Printf("[INFO] Secret V2 %s not found at cluster ID %s", rancherID, clusterID)
@@ -82,7 +84,7 @@ func resourceRancher2SecretV2Update(d *schema.ResourceData, meta interface{}) er
 	secret := expandSecretV2(d)
 	log.Printf("[INFO] Updating Secret V2 %s at Cluster ID %s", rancherID, clusterID)
 
-	newSecret, err := meta.(*Config).UpdateSecretV2(clusterID, rancherID, secret)
+	newSecret, err := updateSecretV2(meta.(*Config), clusterID, rancherID, secret)
 	if err != nil {
 		return err
 	}
@@ -108,14 +110,14 @@ func resourceRancher2SecretV2Delete(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[INFO] Deleting Secret V2 %s", name)
 
 	_, rancherID := splitID(d.Id())
-	secret, err := meta.(*Config).GetSecretV2ByID(clusterID, rancherID)
+	secret, err := getSecretV2ByID(meta.(*Config), clusterID, rancherID)
 	if err != nil {
 		if IsNotFound(err) || IsForbidden(err) {
 			d.SetId("")
 			return nil
 		}
 	}
-	err = meta.(*Config).DeleteSecretV2(clusterID, secret)
+	err = deleteSecretV2(meta.(*Config), clusterID, secret)
 	if err != nil {
 		return err
 	}
@@ -138,7 +140,7 @@ func resourceRancher2SecretV2Delete(d *schema.ResourceData, meta interface{}) er
 // secretV2StateRefreshFunc returns a resource.StateRefreshFunc, used to watch a Rancher Secret v2.
 func secretV2StateRefreshFunc(meta interface{}, clusterID, secretID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		obj, err := meta.(*Config).GetSecretV2ByID(clusterID, secretID)
+		obj, err := getSecretV2ByID(meta.(*Config), clusterID, secretID)
 		if err != nil {
 			if IsNotFound(err) || IsForbidden(err) {
 				return obj, "removed", nil
@@ -146,5 +148,117 @@ func secretV2StateRefreshFunc(meta interface{}, clusterID, secretID string) reso
 			return nil, "", err
 		}
 		return obj, "active", nil
+	}
+}
+
+// Rancher2 Secret V2 API CRUD functions
+func createSecretV2(c *Config, clusterID string, secret *SecretV2) (*SecretV2, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Creating secret V2: Provider config is nil")
+	}
+	if clusterID == "" {
+		return nil, fmt.Errorf("Creating secret V2: Cluster ID is nil")
+	}
+	if secret == nil {
+		return nil, fmt.Errorf("Creating secret V2: object is nil")
+	}
+	// Converting secret V2 object to map[string]interface{} as type fields is duplicated
+	secret2, err := interfaceToMap(secret)
+	if err != nil {
+		return nil, err
+	}
+	secret2["type"] = secret2["_type"]
+	resp := &SecretV2{}
+	err = c.createObjectV2(clusterID, secretV2APIType, secret2, resp)
+	if err != nil {
+		return nil, fmt.Errorf("Creating secret V2: %s", err)
+	}
+	return resp, nil
+}
+
+func deleteSecretV2(c *Config, clusterID string, obj *SecretV2) error {
+	if c == nil {
+		return fmt.Errorf("Deleting secret V2: Provider config is nil")
+	}
+	if clusterID == "" {
+		return fmt.Errorf("Deleting secret V2: Cluster ID is nil")
+	}
+	if obj == nil {
+		return fmt.Errorf("Deleting secret V2: object is nil")
+	}
+	resource := &types.Resource{
+		ID:      obj.ID,
+		Type:    secretV2APIType,
+		Links:   obj.Links,
+		Actions: obj.Actions,
+	}
+	return c.deleteObjectV2(clusterID, resource)
+}
+
+func getSecretV2ByID(c *Config, clusterID, id string) (*SecretV2, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Getting secret V2: Provider config is nil")
+	}
+	if len(clusterID) == 0 || len(id) == 0 {
+		return nil, fmt.Errorf("Getting secret V2: Cluster ID and/or Secret V2 ID is nil")
+	}
+	resp := &SecretV2{}
+	err := c.getObjectV2ByID(clusterID, id, secretV2APIType, resp)
+	if err != nil {
+		if !IsServerError(err) && !IsNotFound(err) && !IsForbidden(err) {
+			return nil, fmt.Errorf("Getting secret V2: %s", err)
+		}
+		return nil, err
+	}
+	return resp, nil
+}
+
+func updateSecretV2(c *Config, clusterID, id string, obj *SecretV2) (*SecretV2, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Updating secret V2: Provider config is nil")
+	}
+	if len(clusterID) == 0 || len(id) == 0 {
+		return nil, fmt.Errorf("Updating secret V2: Cluster ID and/or Secret V2 ID is nil")
+	}
+	if obj == nil {
+		return nil, fmt.Errorf("Updating secret V2: Cluster V2 is nil")
+	}
+	// Converting secret V2 object to map[string]interface{} as type fields is duplicated
+	updateMap, err := interfaceToMap(obj)
+	if err != nil {
+		return nil, err
+	}
+	updateMap["type"] = updateMap["_type"]
+	resp := &SecretV2{}
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	for {
+		err := c.updateObjectV2(clusterID, id, secretV2APIType, updateMap, resp)
+		if err == nil {
+			return resp, err
+		}
+		if !IsServerError(err) && !IsUnknownSchemaType(err) && !IsConflict(err) {
+			return nil, err
+		}
+		if IsConflict(err) {
+			// Read secret again and update ObjectMeta.ResourceVersion before retry
+			newObj := &SecretV2{}
+			err = c.getObjectV2ByID(clusterID, id, secretV2APIType, newObj)
+			if err != nil {
+				return nil, err
+			}
+			obj.ObjectMeta.ResourceVersion = newObj.ObjectMeta.ResourceVersion
+			// Converting secret V2 object to map[string]interface{} as type fields is duplicated
+			updateMap, err := interfaceToMap(obj)
+			if err != nil {
+				return nil, err
+			}
+			updateMap["type"] = updateMap["_type"]
+		}
+		select {
+		case <-time.After(rancher2RetriesWait * time.Second):
+		case <-ctx.Done():
+			return nil, fmt.Errorf("Timeout updating secret V2 ID %s: %v", id, err)
+		}
 	}
 }

--- a/rancher2/resource_rancher2_secret_v2_test.go
+++ b/rancher2/resource_rancher2_secret_v2_test.go
@@ -122,14 +122,14 @@ func testAccRancher2SecretV2Disappears(cat *SecretV2) resource.TestCheckFunc {
 			}
 			clusterID := rs.Primary.Attributes["cluster_id"]
 			_, rancherID := splitID(rs.Primary.ID)
-			secret, err := testAccProvider.Meta().(*Config).GetSecretV2ByID(clusterID, rancherID)
+			secret, err := getSecretV2ByID(testAccProvider.Meta().(*Config), clusterID, rancherID)
 			if err != nil {
 				if IsNotFound(err) || IsForbidden(err) {
 					return nil
 				}
 				return fmt.Errorf("testAccRancher2SecretV2Disappears-get: %v", err)
 			}
-			err = testAccProvider.Meta().(*Config).DeleteSecretV2(clusterID, secret)
+			err = deleteSecretV2(testAccProvider.Meta().(*Config), clusterID, secret)
 			if err != nil {
 				return fmt.Errorf("testAccRancher2SecretV2Disappears-delete: %v", err)
 			}
@@ -165,7 +165,7 @@ func testAccCheckRancher2SecretV2Exists(n string, cat *SecretV2) resource.TestCh
 
 		clusterID := rs.Primary.Attributes["cluster_id"]
 		_, rancherID := splitID(rs.Primary.ID)
-		foundReg, err := testAccProvider.Meta().(*Config).GetSecretV2ByID(clusterID, rancherID)
+		foundReg, err := getSecretV2ByID(testAccProvider.Meta().(*Config), clusterID, rancherID)
 		if err != nil {
 			if IsNotFound(err) || IsForbidden(err) {
 				return nil
@@ -186,7 +186,7 @@ func testAccCheckRancher2SecretV2Destroy(s *terraform.State) error {
 		}
 		clusterID := rs.Primary.Attributes["cluster_id"]
 		_, rancherID := splitID(rs.Primary.ID)
-		_, err := testAccProvider.Meta().(*Config).GetSecretV2ByID(clusterID, rancherID)
+		_, err := getSecretV2ByID(testAccProvider.Meta().(*Config), clusterID, rancherID)
 		if err != nil {
 			if IsNotFound(err) {
 				return nil


### PR DESCRIPTION
Issue https://github.com/rancher/terraform-provider-rancher2/issues/765

This PR contains:
* Added `IsConflict` function to retry on update v2 resources
* Added `RestartClients` function to restart Rancher2 clients
* Updated `CatalogV2Client` function to also retry if err `IsNotFound` or `IsForbidden`
* Refactored `activateNodeDriver` and `activateKontainerDriver` functions to retry if got conflict on node driver action
* Refactored v2 resources CRUD functions to be defined at resources files. Added retry if got conflict on update
* Updated `rancher2_cluster_v2` to support creation using Rancher2 standard user token
* Refactored `config.NormalizeURL` function to return error
