### PR TITLE
Update rancher2_cluster.aks_config_v2 schema and structure to fix aks cluster import errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 ENHANCEMENTS:
 
 * Updated `waitForRancherLocalActive` function to allow `rancher2_bootstrap` works when using Rancher [restricted-admin](https://rancher.com/docs/rancher/v2.6/en/admin-settings/rbac/global-permissions/#restricted-admin) at Rancher 2.6.x
+* Updated `rancher2_cluster.aks_config_v2` schema and structure to fix aks cluster import errors https://github.com/rancher/terraform-provider-rancher2/issues/757 https://github.com/rancher/terraform-provider-rancher2/issues/771
 
 BUG FIXES:
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -514,12 +514,11 @@ resource "rancher2_cloud_credential" "foo-aks" {
     subscription_id = "<SUBSCRIPTION_ID>"
   }
 }
-
+# For imported AKS clusters, don't add any other aks_config_v2 field
 resource "rancher2_cluster" "foo" {
-  name = "foo"
+  name = <CLUSTER_NAME>
   description = "Terraform AKS cluster"
   aks_config_v2 {
-    name = <CLUSTER_NAME>
     cloud_credential_id = rancher2_cloud_credential.foo-aks.id
     resource_group = "<RESOURCE_GROUP>"
     resource_location = "<RESOURCE_LOCATION>"
@@ -1363,27 +1362,30 @@ The following arguments are supported:
 * `cloud_credential_id` - (Required) The AKS Cloud Credential ID to use (string)
 * `resource_group` - (Required) The AKS resource group (string)
 * `resource_location` - (Required) The AKS resource location (string)
+* `imported` - (Optional) Is AKS cluster imported? Defaul: `false` (bool)
+
+The following arguments are supported just for creating new AKS clusters (`imported=false`): 
+
+* `node_pools` - (Optional) The AKS nnode pools. Required if `imported=false` (list)
+* `dns_prefix` - (Optional/ForceNew) The AKS dns prefix. Required if `imported=false` (string)
+* `kubernetes_version` - (Optional) The kubernetes master version. Required if `imported=false` (string)
+* `network_plugin` - (Optional) The AKS network plugin. Required if `imported=false` (string)
+* `name` - (Optional/Computed) The AKS cluster name (string)
 * `auth_base_url` - (Optional) The AKS auth base url (string)
 * `authorized_ip_ranges` - (Optional) The AKS authorized ip ranges (list)
 * `base_url` - (Optional) The AKS base url (string)
-* `dns_prefix` - (Optional/Computed/ForceNew) The AKS dns prefix. Required if `imported=false` (string)
 * `http_application_routing` - (Optional/Computed) Enable AKS http application routing? (bool)
-* `imported` - (Optional) Is AKS cluster imported? Defaul: `false` (bool)
-* `kubernetes_version` - (Optional/Computed) The kubernetes master version (string)
 * `linux_admin_username` - (Optional/Computed) The AKS linux admin username (string)
 * `linux_ssh_public_key` - (Optional/Computed) The AKS linux ssh public key (string)
 * `load_balancer_sku` - (Optional/Computed) The AKS load balancer sku (string)
 * `log_analytics_workspace_group` - (Optional/Computed) The AKS log analytics workspace group (string)
 * `log_analytics_workspace_name` - (Optional/Computed) The AKS log analytics workspace name (string)
 * `monitoring` - (Optional/Computed) Is AKS cluster monitoring enabled? (bool)
-* `name` - (Optional/Computed) The AKS cluster name (string)
 * `network_dns_service_ip` - (Optional/Computed) The AKS network dns service ip (string)
 * `network_docker_bridge_cidr` - (Optional/Computed) The AKS network docker bridge cidr (string)
-* `network_plugin` - (Optional/Computed) The AKS network plugin. Required if `imported=false` (string)
 * `network_pod_cidr` - (Optional/Computed) The AKS network pod cidr (string)
 * `network_policy` - (Optional/Computed) The AKS network policy (string)
 * `network_service_cidr` - (Optional/Computed) The AKS network service cidr (string)
-* `node_pools` - (Optional/Computed) The AKS nnode pools (list)
 * `private_cluster` - (Optional/Computed) Is AKS cluster private? (bool)
 * `subnet` - (Optional/Computed) The AKS subnet (string)
 * `tags` - (Optional/Computed) The AKS cluster tags" (map)

--- a/rancher2/schema_cluster_aks_config_v2.go
+++ b/rancher2/schema_cluster_aks_config_v2.go
@@ -132,9 +132,8 @@ func clusterAKSConfigV2Fields() map[string]*schema.Schema {
 		"dns_prefix": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Computed:    true,
 			ForceNew:    true,
-			Description: "The AKS dns prefix",
+			Description: "The AKS dns prefix. Required if `import=false`",
 		},
 		"http_application_routing": {
 			Type:        schema.TypeBool,
@@ -151,8 +150,7 @@ func clusterAKSConfigV2Fields() map[string]*schema.Schema {
 		"kubernetes_version": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Computed:    true,
-			Description: "The kubernetes master version",
+			Description: "The kubernetes master version. Required if `import=false`",
 		},
 		"linux_admin_username": {
 			Type:        schema.TypeString,
@@ -211,8 +209,7 @@ func clusterAKSConfigV2Fields() map[string]*schema.Schema {
 		"network_plugin": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Computed:    true,
-			Description: "The AKS network plugin",
+			Description: "The AKS network plugin. Required if `import=false`",
 		},
 		"network_pod_cidr": {
 			Type:        schema.TypeString,
@@ -235,8 +232,7 @@ func clusterAKSConfigV2Fields() map[string]*schema.Schema {
 		"node_pools": {
 			Type:        schema.TypeList,
 			Optional:    true,
-			Computed:    true,
-			Description: "The AKS node pools to use",
+			Description: "The AKS node pools to use. Required if `import=false`",
 			Elem: &schema.Resource{
 				Schema: clusterAKSConfigV2NodePoolsFields(),
 			},


### PR DESCRIPTION
Issues https://github.com/rancher/terraform-provider-rancher2/issues/757 https://github.com/rancher/terraform-provider-rancher2/issues/771

Based on the PR https://github.com/rancher/terraform-provider-rancher2/pull/772 thanks to @polivbr with some additions:
- Apply same logic to the `flattenClusterAKSConfigV2` function to avoid potential false diff
- Update `clusterAKSConfigV2Fields` schema properly
- Update docs and examples to clarify.