### PR TITLE
Policy validator add specialized verbs

### DIFF
--- a/docs/resources/global_role.md
+++ b/docs/resources/global_role.md
@@ -51,7 +51,7 @@ The following attributes are exported:
 * `non_resource_urls` - (Optional) Policy rule non resource urls (list)
 * `resource_names` - (Optional) Policy rule resource names (list)
 * `resources` - (Optional) Policy rule resources (list)
-* `verbs` - (Optional) Policy rule verbs. `create`, `delete`, `deletecollection`, `get`, `list`, `patch`, `update`, `view`, `watch`, `own` and `*` values are supported (list)
+* `verbs` - (Optional) Policy rule verbs. `bind`, `create`, `delete`, `deletecollection`, `escalate`, `get`, `impersonate`, `list`, `patch`, `update`, `use`, `view`, `watch`, `own` and `*` values are supported (list)
 
 ## Timeouts
 

--- a/docs/resources/role_template.md
+++ b/docs/resources/role_template.md
@@ -74,7 +74,7 @@ The following attributes are exported:
 * `non_resource_urls` - (Optional) Policy rule non resource urls (list)
 * `resource_names` - (Optional) Policy rule resource names (list)
 * `resources` - (Optional) Policy rule resources (list)
-* `verbs` - (Optional) Policy rule verbs. `create`, `delete`, `deletecollection`, `get`, `list`, `patch`, `update`, `view`, `watch`, `own` and `*` values are supported (list)
+* `verbs` - (Optional) Policy rule verbs. `bind`, `create`, `delete`, `deletecollection`, `escalate`, `get`, `impersonate`, `list`, `patch`, `update`, `use`, `view`, `watch`, `own` and `*` values are supported (list)
 
 ## Timeouts
 

--- a/rancher2/schema_policy_rule.go
+++ b/rancher2/schema_policy_rule.go
@@ -6,17 +6,21 @@ import (
 )
 
 const (
-	policyRuleAll                  = "*"
-	policyRuleVerbCreate           = "create"
-	policyRuleVerbDelete           = "delete"
-	policyRuleVerbDeleteCollection = "deletecollection"
-	policyRuleVerbGet              = "get"
-	policyRuleVerbList             = "list"
-	policyRuleVerbPatch            = "patch"
-	policyRuleVerbUpdate           = "update"
-	policyRuleVerbView             = "view"
-	policyRuleVerbWatch            = "watch"
-	policyRuleVerbOwn              = "own"
+	policyRuleAll                        = "*"
+	policyRuleVerbCreate                 = "create"
+	policyRuleVerbDelete                 = "delete"
+	policyRuleVerbDeleteCollection       = "deletecollection"
+	policyRuleVerbGet                    = "get"
+	policyRuleVerbList                   = "list"
+	policyRuleVerbPatch                  = "patch"
+	policyRuleVerbUpdate                 = "update"
+	policyRuleVerbView                   = "view"
+	policyRuleVerbWatch                  = "watch"
+	policyRuleVerbOwn                    = "own"
+	policyRuleSpecializedVerbUse         = "use"
+	policyRuleSpecializedVerbBind        = "bind"
+	policyRuleSpecializedVerbEscalate    = "escalate"
+	policyRuleSpecializedVerbImpersonate = "impersonate"
 )
 
 var (
@@ -32,6 +36,10 @@ var (
 		policyRuleVerbView,
 		policyRuleVerbWatch,
 		policyRuleVerbOwn,
+		policyRuleSpecializedVerbUse,
+		policyRuleSpecializedVerbBind,
+		policyRuleSpecializedVerbEscalate,
+		policyRuleSpecializedVerbImpersonate,
 	}
 )
 

--- a/rancher2/schema_policy_rule.go
+++ b/rancher2/schema_policy_rule.go
@@ -6,21 +6,21 @@ import (
 )
 
 const (
-	policyRuleAll                        = "*"
-	policyRuleVerbCreate                 = "create"
-	policyRuleVerbDelete                 = "delete"
-	policyRuleVerbDeleteCollection       = "deletecollection"
-	policyRuleVerbGet                    = "get"
-	policyRuleVerbList                   = "list"
-	policyRuleVerbPatch                  = "patch"
-	policyRuleVerbUpdate                 = "update"
-	policyRuleVerbView                   = "view"
-	policyRuleVerbWatch                  = "watch"
-	policyRuleVerbOwn                    = "own"
-	policyRuleSpecializedVerbUse         = "use"
-	policyRuleSpecializedVerbBind        = "bind"
-	policyRuleSpecializedVerbEscalate    = "escalate"
-	policyRuleSpecializedVerbImpersonate = "impersonate"
+	policyRuleAll                  = "*"
+	policyRuleVerbCreate           = "create"
+	policyRuleVerbDelete           = "delete"
+	policyRuleVerbDeleteCollection = "deletecollection"
+	policyRuleVerbGet              = "get"
+	policyRuleVerbList             = "list"
+	policyRuleVerbPatch            = "patch"
+	policyRuleVerbUpdate           = "update"
+	policyRuleVerbView             = "view"
+	policyRuleVerbWatch            = "watch"
+	policyRuleVerbOwn              = "own"
+	policyRuleVerbUse              = "use"
+	policyRuleVerbBind             = "bind"
+	policyRuleVerbEscalate         = "escalate"
+	policyRuleVerbImpersonate      = "impersonate"
 )
 
 var (
@@ -36,10 +36,10 @@ var (
 		policyRuleVerbView,
 		policyRuleVerbWatch,
 		policyRuleVerbOwn,
-		policyRuleSpecializedVerbUse,
-		policyRuleSpecializedVerbBind,
-		policyRuleSpecializedVerbEscalate,
-		policyRuleSpecializedVerbImpersonate,
+		policyRuleVerbUse,
+		policyRuleVerbBind,
+		policyRuleVerbEscalate,
+		policyRuleVerbImpersonate,
 	}
 )
 


### PR DESCRIPTION
Kubernetes has specialized verbs for specific use cases.

https://kubernetes.io/docs/reference/access-authn-authz/authorization/#determine-the-request-verb

This PR adds the specialized verbs to the validator list and allows creating role templates using those specialized verbs.
