### PR TITLE
Add support to import cloud credentials

### DIFF
--- a/docs/resources/cloud_credential.md
+++ b/docs/resources/cloud_credential.md
@@ -123,20 +123,13 @@ The following attributes are exported:
 
 ## Import
 
-Node Template can be imported using the Rancher Node Template ID
+Cloud Credential can be imported using the Cloud Credential ID and the Driver name.
 
 ```bash
-terraform import rancher2_cloud_credential.foo &lt;cloud_credential_id&gt;.&lt;driver&gt;
+terraform import rancher2_cloud_credential.foo &lt;CLOUD_CREDENTIAL_ID&gt;.&lt;DRIVER&gt;
 ```
 
-### Argument Reference
-
-The following arguments are supported:
-
-* `cloud_credential_id` - (Required) The ID of the Cloud Credential (string)
-* `driver` - (Required) The driver of the Cloud Credential (string)
-
-Supported drivers:
+The following drivers are supported:
 
 * amazonec2
 * azure

--- a/docs/resources/cloud_credential.md
+++ b/docs/resources/cloud_credential.md
@@ -126,7 +126,7 @@ The following attributes are exported:
 Node Template can be imported using the Rancher Node Template ID
 
 ```bash
-terraform import rancher2_cloud_credential.foo &lt;cloud_credential_id&gt.&lt;driver&gt;
+terraform import rancher2_cloud_credential.foo &lt;cloud_credential_id&gt;.&lt;driver&gt;
 ```
 
 ### Argument Reference

--- a/docs/resources/cloud_credential.md
+++ b/docs/resources/cloud_credential.md
@@ -120,3 +120,29 @@ The following attributes are exported:
 - `create` - (Default `10 minutes`) Used for creating cloud credentials.
 - `update` - (Default `10 minutes`) Used for cloud credential modifications.
 - `delete` - (Default `10 minutes`) Used for deleting cloud credentials.
+
+## Import
+
+Node Template can be imported using the Rancher Node Template ID
+
+```bash
+terraform import rancher2_cloud_credential.foo &lt;cloud_credential_id&gt.&lt;driver&gt;
+```
+
+### Argument Reference
+
+The following arguments are supported:
+
+* `cloud_credential_id` - (Required) The ID of the Cloud Credential (string)
+* `driver` - (Required) The driver of the Cloud Credential (string)
+
+Supported drivers:
+
+* amazonec2
+* azure
+* digitalocean
+* googlekubernetesengine
+* linode
+* openstack
+* s3
+* vmwarevsphere

--- a/rancher2/import_rancher2_cloud_credentials.go
+++ b/rancher2/import_rancher2_cloud_credentials.go
@@ -6,33 +6,23 @@ import (
 )
 
 func resourceRancher2CloudCredentialsImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	cloudCredentialID, driver := splitID(d.Id())
+	d.Set("driver", driver)
+
 	client, err := meta.(*Config).ManagementClient()
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}
 
 	cloudCredential := &CloudCredential{}
-	err = client.APIBaseClient.ByID(managementClient.CloudCredentialType, d.Id(), cloudCredential)
+	err = client.APIBaseClient.ByID(managementClient.CloudCredentialType, cloudCredentialID, cloudCredential)
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}
 
-	drivers := []string{
-		amazonec2ConfigDriver,
-		azureConfigDriver,
-		digitaloceanConfigDriver,
-		googleConfigDriver,
-		s3ConfigDriver,
-		vmwarevsphereConfigDriver,
-	}
-
-	// Missing "driver" field in api.
-	for _, driver := range drivers {
-		d.Set("driver", driver)
-		err = flattenCloudCredential(d, cloudCredential)
-		if err != nil {
-			return []*schema.ResourceData{}, err
-		}
+	err = flattenCloudCredential(d, cloudCredential)
+	if err != nil {
+		return []*schema.ResourceData{}, err
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/rancher2/import_rancher2_cloud_credentials.go
+++ b/rancher2/import_rancher2_cloud_credentials.go
@@ -1,0 +1,39 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
+)
+
+func resourceRancher2CloudCredentialsImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	cloudCredential := &CloudCredential{}
+	err = client.APIBaseClient.ByID(managementClient.CloudCredentialType, d.Id(), cloudCredential)
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+
+	drivers := []string{
+		amazonec2ConfigDriver,
+		azureConfigDriver,
+		digitaloceanConfigDriver,
+		googleConfigDriver,
+		s3ConfigDriver,
+		vmwarevsphereConfigDriver,
+	}
+
+	// Missing "driver" field in api.
+	for _, driver := range drivers {
+		d.Set("driver", driver)
+		err = flattenCloudCredential(d, cloudCredential)
+		if err != nil {
+			return []*schema.ResourceData{}, err
+		}
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/resource_rancher2_cloud_credential.go
+++ b/rancher2/resource_rancher2_cloud_credential.go
@@ -17,7 +17,9 @@ func resourceRancher2CloudCredential() *schema.Resource {
 		Read:   resourceRancher2CloudCredentialRead,
 		Update: resourceRancher2CloudCredentialUpdate,
 		Delete: resourceRancher2CloudCredentialDelete,
-
+		Importer: &schema.ResourceImporter{
+			State: resourceRancher2CloudCredentialsImport,
+		},
 		Schema: cloudCredentialFields(),
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),

--- a/rancher2/resource_rancher2_cloud_credential_test.go
+++ b/rancher2/resource_rancher2_cloud_credential_test.go
@@ -12,14 +12,7 @@ import (
 )
 
 const (
-	testAccRancher2CloudCredentialType   = "rancher2_cloud_credential"
-	testAccRancher2CloudCredentialConfig = `
-resource "` + testAccRancher2CloudCredentialType + `" "foo-import" {
-  name = "foo"
-  description= "Terraform cloudCredential acceptance test - import"
-}	  
-`
-
+	testAccRancher2CloudCredentialType            = "rancher2_cloud_credential"
 	testAccRancher2CloudCredentialConfigAmazonec2 = `
 resource "` + testAccRancher2CloudCredentialType + `" "foo-aws" {
   name = "foo-aws"
@@ -608,53 +601,6 @@ func TestAccRancher2CloudCredential_disappears_Vsphere(t *testing.T) {
 	})
 }
 
-func TestAccRancher2CloudCredential_import_Vpshere(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		PreCheck:   func() { testAccPreCheck(t) },
-		Providers:  testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:   testAccRancher2CloudCredentialConfig,
-				PlanOnly: true,
-			},
-			{
-				ResourceName:      testAccRancher2CloudCredentialType + ".foo-vsphere",
-				ImportState:       true,
-				ImportStateCheck:  checkImport(testAccRancher2CloudCredentialType + ".foo-vsphere"),
-				ImportStateVerify: true,
-				// ImportStateId:      testAccRancher2CloudCredentialType + ".foo-vsphere",
-			},
-		},
-	})
-}
-
-func checkImport(tableName string) resource.ImportStateCheckFunc {
-	return func(s []*terraform.InstanceState) error {
-		if len(s) == 0 {
-			return fmt.Errorf("No Instance found")
-		}
-
-		if len(s) != 1 {
-			return fmt.Errorf("Expected one Instance: %d", len(s))
-		}
-
-		name := s[0].Attributes["name"]
-
-		if name != tableName {
-			return fmt.Errorf("Expected name %s: %s", tableName, name)
-		}
-
-		to := s[0].Attributes["to"]
-
-		if to != "ftp://192.168.1.1/" {
-			return fmt.Errorf("Expected to ftp://192.168.1.1/: %s", to)
-		}
-
-		return nil
-	}
-}
-
 func testAccRancher2CloudCredentialDisappears(cloudCredential *CloudCredential) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
@@ -730,30 +676,6 @@ func testAccCheckRancher2CloudCredentialExists(n string, cloudCredential *CloudC
 
 		return nil
 	}
-}
-
-func testAccCheckRancher2CloudCredentialCreate(s *terraform.State) error {
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != testAccRancher2CloudCredentialType {
-			continue
-		}
-		client, err := testAccProvider.Meta().(*Config).ManagementClient()
-		if err != nil {
-			return err
-		}
-
-		cloudCredential := &CloudCredential{}
-		err = client.APIBaseClient.ByID(managementClient.CloudCredentialType, rs.Primary.ID, cloudCredential)
-		if err != nil {
-			if IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-		return fmt.Errorf("Cloud Credential still exists")
-	}
-	return nil
-
 }
 
 func testAccCheckRancher2CloudCredentialDestroy(s *terraform.State) error {


### PR DESCRIPTION
**Problem**

The resource in rancher2 already exists.
We use a remote state file, that i can't edit.

**Result**

```
Error: resource rancher2_cloud_credential doesn't support import
```

**Solution**

Support import for `rancher2_cloud_credentials`

```bash
terraform import rancher2_cloud_credential.resource_id rancher_id
```

The reason why i use a range loop is because the API does not give me a "driver" field to retrieve.
`d.Get("driver")` yields no results and ends up in the got no driver error.

**Better result**

```
rancher2_cloud_credential.resource: Importing from ID "cattle-global-data:resource"...
rancher2_cloud_credential.resource: Import prepared!
  Prepared rancher2_cloud_credential for import
rancher2_cloud_credential.resource: Refreshing state... [id=cattle-global-data:resource]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```