### PR TITLE
Add support for server labels in hetzner_config

### DIFF
--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -217,7 +217,7 @@ The following attributes are exported:
 
 * `api_token` - (Required/Sensitive) Hetzner Cloud project API token (string)
 * `image` - (Optional) Hetzner Cloud server image. Default `ubuntu-18.04` (string)
-* `server_labels` - (Optional) Comma-separated list of labels which will be assigned to the server (string)
+* `server_labels` - (Optional) Map of labels which will be assigned to the server. This argument is only available on [Hetzner Docker Node Driver:v3.6.0](https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases/tag/3.6.0) and above (map)
 * `server_location` - (Optional) Hetzner Cloud datacenter. Default `nbg1` (string)
 * `server_type` - (Optional) Hetzner Cloud server type. Default `cx11` (string)
 * `networks` - (Optional) Comma-separated list of network IDs or names which should be attached to the server private network interface (string)

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -217,7 +217,7 @@ The following attributes are exported:
 
 * `api_token` - (Required/Sensitive) Hetzner Cloud project API token (string)
 * `image` - (Optional) Hetzner Cloud server image. Default `ubuntu-18.04` (string)
-* `server_labels` - (Optional) Comma-separated list of labels which should be assigned to the server (string)
+* `server_labels` - (Optional) Comma-separated list of labels which will be assigned to the server (string)
 * `server_location` - (Optional) Hetzner Cloud datacenter. Default `nbg1` (string)
 * `server_type` - (Optional) Hetzner Cloud server type. Default `cx11` (string)
 * `networks` - (Optional) Comma-separated list of network IDs or names which should be attached to the server private network interface (string)

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -64,7 +64,7 @@ resource "rancher2_node_driver" "hetzner_node_driver" {
   builtin  = false
   name     = "Hetzner"
   ui_url   = "https://storage.googleapis.com/hcloud-rancher-v2-ui-driver/component.js"
-  url      = "https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases/download/3.0.0/docker-machine-driver-hetzner_3.0.0_linux_amd64.tar.gz"
+  url      = "https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases/download/3.6.0/docker-machine-driver-hetzner_3.6.0_linux_amd64.tar.gz"
   whitelist_domains = ["storage.googleapis.com"]
 }
 
@@ -217,7 +217,7 @@ The following attributes are exported:
 
 * `api_token` - (Required/Sensitive) Hetzner Cloud project API token (string)
 * `image` - (Optional) Hetzner Cloud server image. Default `ubuntu-18.04` (string)
-* `server_labels` - (Optional) Map of labels which will be assigned to the server. This argument is only available on [Hetzner Docker Node Driver:v3.6.0](https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases/tag/3.6.0) and above (map)
+* `server_labels` - (Optional) Map of the labels which will be assigned to the server. This argument is only available on [Hetzner Docker Node Driver:v3.6.0](https://github.com/JonasProgrammer/docker-machine-driver-hetzner/releases/tag/3.6.0) and above (map)
 * `server_location` - (Optional) Hetzner Cloud datacenter. Default `nbg1` (string)
 * `server_type` - (Optional) Hetzner Cloud server type. Default `cx11` (string)
 * `networks` - (Optional) Comma-separated list of network IDs or names which should be attached to the server private network interface (string)

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -217,6 +217,7 @@ The following attributes are exported:
 
 * `api_token` - (Required/Sensitive) Hetzner Cloud project API token (string)
 * `image` - (Optional) Hetzner Cloud server image. Default `ubuntu-18.04` (string)
+* `server_labels` - (Optional) Comma-separated list of labels which should be assigned to the server (string)
 * `server_location` - (Optional) Hetzner Cloud datacenter. Default `nbg1` (string)
 * `server_type` - (Optional) Hetzner Cloud server type. Default `cx11` (string)
 * `networks` - (Optional) Comma-separated list of network IDs or names which should be attached to the server private network interface (string)

--- a/rancher2/schema_node_template_hetzner.go
+++ b/rancher2/schema_node_template_hetzner.go
@@ -41,7 +41,7 @@ func hetznerConfigFields() map[string]*schema.Schema {
 		"server_labels": {
 			Type:        schema.TypeMap,
 			Optional:    true,
-			Description: "Comma-separated list of labels which should be assigned to the server",
+			Description: "Map of the labels which will be assigned to the server",
 		},
 		"server_location": {
 			Type:        schema.TypeString,

--- a/rancher2/schema_node_template_hetzner.go
+++ b/rancher2/schema_node_template_hetzner.go
@@ -11,15 +11,15 @@ const (
 //Types
 
 type hetznerConfig struct {
-	APIToken          string   `json:"apiToken,omitempty" yaml:"apiToken,omitempty"`
-	Image             string   `json:"image,omitempty" yaml:"image,omitempty"`
-	ServerLabels      []string `json:"serverLabels,omitempty" yaml:"serverLabels,omitempty"`
-	ServerLocation    string   `json:"serverLocation,omitempty" yaml:"serverLocation,omitempty"`
-	ServerType        string   `json:"serverType,omitempty" yaml:"serverType,omitempty"`
-	Networks          []string `json:"networks,omitempty" yaml:"networks,omitempty"`
-	UsePrivateNetwork bool     `json:"usePrivateNetwork,omitempty" yaml:"usePrivateNetwork,omitempty"`
-	UserData          string   `json:"userData,omitempty" yaml:"userData,omitempty"`
-	Volumes           []string `json:"volumes,omitempty" yaml:"volumes,omitempty"`
+	APIToken          string            `json:"apiToken,omitempty" yaml:"apiToken,omitempty"`
+	Image             string            `json:"image,omitempty" yaml:"image,omitempty"`
+	ServerLabels      map[string]string `json:"serverLabels,omitempty" yaml:"serverLabels,omitempty"`
+	ServerLocation    string            `json:"serverLocation,omitempty" yaml:"serverLocation,omitempty"`
+	ServerType        string            `json:"serverType,omitempty" yaml:"serverType,omitempty"`
+	Networks          []string          `json:"networks,omitempty" yaml:"networks,omitempty"`
+	UsePrivateNetwork bool              `json:"usePrivateNetwork,omitempty" yaml:"usePrivateNetwork,omitempty"`
+	UserData          string            `json:"userData,omitempty" yaml:"userData,omitempty"`
+	Volumes           []string          `json:"volumes,omitempty" yaml:"volumes,omitempty"`
 }
 
 //Schemas
@@ -39,7 +39,7 @@ func hetznerConfigFields() map[string]*schema.Schema {
 			Description: "Hetzner Cloud server image",
 		},
 		"server_labels": {
-			Type:        schema.TypeString,
+			Type:        schema.TypeMap,
 			Optional:    true,
 			Description: "Comma-separated list of labels which should be assigned to the server",
 		},

--- a/rancher2/schema_node_template_hetzner.go
+++ b/rancher2/schema_node_template_hetzner.go
@@ -13,6 +13,7 @@ const (
 type hetznerConfig struct {
 	APIToken          string   `json:"apiToken,omitempty" yaml:"apiToken,omitempty"`
 	Image             string   `json:"image,omitempty" yaml:"image,omitempty"`
+	ServerLabels      []string `json:"serverLabels,omitempty" yaml:"serverLabels,omitempty"`
 	ServerLocation    string   `json:"serverLocation,omitempty" yaml:"serverLocation,omitempty"`
 	ServerType        string   `json:"serverType,omitempty" yaml:"serverType,omitempty"`
 	Networks          []string `json:"networks,omitempty" yaml:"networks,omitempty"`
@@ -36,6 +37,11 @@ func hetznerConfigFields() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     "ubuntu-18.04",
 			Description: "Hetzner Cloud server image",
+		},
+		"server_labels": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Comma-separated list of labels which should be assigned to the server",
 		},
 		"server_location": {
 			Type:        schema.TypeString,

--- a/rancher2/structure_node_template_hetzner.go
+++ b/rancher2/structure_node_template_hetzner.go
@@ -19,7 +19,7 @@ func flattenHetznerConfig(in *hetznerConfig) []interface{} {
 	}
 
 	if len(in.ServerLabels) > 0 {
-		obj["server_labels"] = strings.Join(in.ServerLabels, ",")
+		obj["server_labels"] = toMapInterface(in.ServerLabels)
 	}
 
 	if len(in.ServerLocation) > 0 {
@@ -64,8 +64,8 @@ func expandHetznercloudConfig(p []interface{}) *hetznerConfig {
 		obj.Image = v
 	}
 
-	if v, ok := in["server_labels"].(string); ok && len(v) > 0 {
-		obj.ServerLabels = strings.Split(v, ",")
+	if v, ok := in["server_labels"].(map[string]interface{}); ok && len(v) > 0 {
+		obj.ServerLabels = toMapString(v)
 	}
 
 	if v, ok := in["server_location"].(string); ok && len(v) > 0 {

--- a/rancher2/structure_node_template_hetzner.go
+++ b/rancher2/structure_node_template_hetzner.go
@@ -18,6 +18,10 @@ func flattenHetznerConfig(in *hetznerConfig) []interface{} {
 		obj["image"] = in.Image
 	}
 
+	if len(in.ServerLabels) > 0 {
+		obj["server_labels"] = strings.Join(in.ServerLabels, ",")
+	}
+
 	if len(in.ServerLocation) > 0 {
 		obj["server_location"] = in.ServerLocation
 	}
@@ -58,6 +62,10 @@ func expandHetznercloudConfig(p []interface{}) *hetznerConfig {
 
 	if v, ok := in["image"].(string); ok && len(v) > 0 {
 		obj.Image = v
+	}
+
+	if v, ok := in["server_labels"].(string); ok && len(v) > 0 {
+		obj.ServerLabels = strings.Split(v, ",")
 	}
 
 	if v, ok := in["server_location"].(string); ok && len(v) > 0 {


### PR DESCRIPTION
This PR solves rancher/terraform-provider-rancher2#657. The [docker-machine-driver-hetzner](https://github.com/JonasProgrammer/docker-machine-driver-hetzner) latest tag makes the ServerLabels property public, so that should not be an issue anymore. 🤞🏻 