### PR TITLE
remove cloud_credential_secret_name from rke machine pool

### DIFF
--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -64,10 +64,10 @@ resource "rancher2_cluster_v2" "foo-rke2" {
   kubernetes_version = "v1.21.4+rke2r2"
   enable_network_policy = false
   default_cluster_role_for_project_members = "user"
+  cloud_credential_secret_name = rancher2_cloud_credential.foo.id
   rke_config {
     machine_pools {
       name = "pool1"
-      cloud_credential_secret_name = rancher2_cloud_credential.foo.id
       control_plane_role = true
       etcd_role = true
       worker_role = true
@@ -86,10 +86,10 @@ resource "rancher2_cluster_v2" "foo-k3s" {
   kubernetes_version = "v1.21.4+k3s1"
   enable_network_policy = false
   default_cluster_role_for_project_members = "user"
+  cloud_credential_secret_name = rancher2_cloud_credential.foo.id
   rke_config {
     machine_pools {
       name = "pool1"
-      cloud_credential_secret_name = rancher2_cloud_credential.foo.id
       control_plane_role = true
       etcd_role = true
       worker_role = true
@@ -130,10 +130,10 @@ resource "rancher2_cluster_v2" "foo" {
   name = "foo"
   kubernetes_version = "v1.21.4+k3s1"
   enable_network_policy = false
+  cloud_credential_secret_name = rancher2_cloud_credential.foo.id
   rke_config {
     machine_pools {
       name = "pool1"
-      cloud_credential_secret_name = rancher2_cloud_credential.foo.id
       control_plane_role = true
       etcd_role = true
       worker_role = true

--- a/rancher2/schema_cluster_v2_rke_config_machine_pool.go
+++ b/rancher2/schema_cluster_v2_rke_config_machine_pool.go
@@ -48,11 +48,6 @@ func clusterV2RKEConfigMachinePoolFields() map[string]*schema.Schema {
 			Required:    true,
 			Description: "Machine pool name",
 		},
-		"cloud_credential_secret_name": {
-			Type:        schema.TypeString,
-			Required:    true,
-			Description: "Machine pool cloud credential secret name",
-		},
 		"machine_config": {
 			Type:        schema.TypeList,
 			Required:    true,

--- a/rancher2/structure_cluster_v2_rke_config_machine_pool.go
+++ b/rancher2/structure_cluster_v2_rke_config_machine_pool.go
@@ -47,9 +47,6 @@ func flattenClusterV2RKEConfigMachinePools(p []provisionv1.RKEMachinePool) []int
 		obj := map[string]interface{}{}
 
 		obj["name"] = in.Name
-		if len(in.CloudCredentialSecretName) > 0 {
-			obj["cloud_credential_secret_name"] = in.CloudCredentialSecretName
-		}
 		if in.NodeConfig != nil {
 			obj["machine_config"] = flattenClusterV2RKEConfigMachinePoolMachineConfig(in.NodeConfig)
 		}
@@ -134,9 +131,6 @@ func expandClusterV2RKEConfigMachinePools(p []interface{}) []provisionv1.RKEMach
 		if v, ok := in["name"].(string); ok {
 			obj.Name = v
 			obj.DisplayName = v
-		}
-		if v, ok := in["cloud_credential_secret_name"].(string); ok && len(v) > 0 {
-			obj.CloudCredentialSecretName = v
 		}
 		if v, ok := in["machine_config"].([]interface{}); ok && len(v) > 0 {
 			obj.NodeConfig = expandClusterV2RKEConfigMachinePoolMachineConfig(v)

--- a/rancher2/structure_cluster_v2_rke_config_machine_pool_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_machine_pool_test.go
@@ -64,7 +64,6 @@ func init() {
 			WorkerRole:    true,
 		},
 	}
-	testClusterV2RKEConfigMachinePoolsConf[0].CloudCredentialSecretName = "cloud_credential_secret_name"
 	testClusterV2RKEConfigMachinePoolsConf[0].Taints = []corev1.Taint{
 		{
 			Key:    "key",
@@ -74,11 +73,10 @@ func init() {
 	}
 	testClusterV2RKEConfigMachinePoolsInterface = []interface{}{
 		map[string]interface{}{
-			"name":                         "test",
-			"cloud_credential_secret_name": "cloud_credential_secret_name",
-			"machine_config":               testClusterV2RKEConfigMachinePoolMachineConfigInterface,
-			"control_plane_role":           true,
-			"etcd_role":                    true,
+			"name":               "test",
+			"machine_config":     testClusterV2RKEConfigMachinePoolMachineConfigInterface,
+			"control_plane_role": true,
+			"etcd_role":          true,
 			"annotations": map[string]interface{}{
 				"anno_one": "one",
 				"anno_two": "two",


### PR DESCRIPTION
I believe that the cloud_credential_secret_name should not be in the machine pool config. I couldn't find any rancher documentation to support this. The only clue was the absence of the option in the rancher ui for the credential under the machine pool config. The terraform apply also provides a valid plan with this proposed change off course.

Nevertheless I would recommend someone with deeper understanding of the v2 clusters to review this change.

rancher/terraform-provider-rancher2#835 