### PR TITLE
Add drain before delete to cluster_v2 resource

### DIFF
--- a/rancher2/schema_cluster_v2_rke_config_machine_pool.go
+++ b/rancher2/schema_cluster_v2_rke_config_machine_pool.go
@@ -72,6 +72,12 @@ func clusterV2RKEConfigMachinePoolFields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Machine pool etcd role",
 		},
+		"drain_before_delete": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Machine pool drain before delete",
+		},
 		"paused": {
 			Type:        schema.TypeBool,
 			Optional:    true,

--- a/rancher2/structure_cluster_v2_rke_config_machine_pool.go
+++ b/rancher2/structure_cluster_v2_rke_config_machine_pool.go
@@ -55,6 +55,7 @@ func flattenClusterV2RKEConfigMachinePools(p []provisionv1.RKEMachinePool) []int
 		}
 		obj["control_plane_role"] = in.ControlPlaneRole
 		obj["etcd_role"] = in.EtcdRole
+		obj["drain_before_delete"] = in.DrainBeforeDelete
 
 		if len(in.MachineDeploymentAnnotations) > 0 {
 			obj["annotations"] = toMapInterface(in.MachineDeploymentAnnotations)
@@ -146,6 +147,9 @@ func expandClusterV2RKEConfigMachinePools(p []interface{}) []provisionv1.RKEMach
 		}
 		if v, ok := in["etcd_role"].(bool); ok {
 			obj.EtcdRole = v
+		}
+		if v, ok := in["drain_before_delete"].(bool); ok {
+			obj.DrainBeforeDelete = v
 		}
 		if v, ok := in["annotations"].(map[string]interface{}); ok && len(v) > 0 {
 			obj.MachineDeploymentAnnotations = toMapString(v)

--- a/rancher2/structure_cluster_v2_rke_config_machine_pool_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_machine_pool_test.go
@@ -45,11 +45,12 @@ func init() {
 	quantity := int32(10)
 	testClusterV2RKEConfigMachinePoolsConf = []provisionv1.RKEMachinePool{
 		{
-			Name:             "test",
-			DisplayName:      "test",
-			NodeConfig:       testClusterV2RKEConfigMachinePoolMachineConfigConf,
-			ControlPlaneRole: true,
-			EtcdRole:         true,
+			Name:              "test",
+			DisplayName:       "test",
+			NodeConfig:        testClusterV2RKEConfigMachinePoolMachineConfigConf,
+			ControlPlaneRole:  true,
+			EtcdRole:          true,
+			DrainBeforeDelete: true,
 			MachineDeploymentAnnotations: map[string]string{
 				"anno_one": "one",
 				"anno_two": "two",
@@ -79,6 +80,7 @@ func init() {
 			"machine_config":               testClusterV2RKEConfigMachinePoolMachineConfigInterface,
 			"control_plane_role":           true,
 			"etcd_role":                    true,
+			"drain_before_delete":          true,
 			"annotations": map[string]interface{}{
 				"anno_one": "one",
 				"anno_two": "two",


### PR DESCRIPTION
Issue: https://github.com/rancher/terraform-provider-rancher2/issues/873 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable.  If this is a new feature describe why we need this feature and how it will be used. -->

This is a new feature. A user can specify a `DrainBeforeDelete` flag in the Rancher UI when creating an RKE/K3s cluster. This feature adds a `drain_before_delete` field to the [rancher2_cluster_v2](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/cluster_v2) machine pool configuration so the same option can be set via Terraform when you provision an RKE/K3s cluster. Not setting the field adds a CAPI annotation on the machine deployment that excludes nodes from being drained. Setting it to true removes the CAPI annotation and will drain nodes on deletion (except for etcd nodes).
 
## Solution
 
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

* Added drain_before_delete field to rke2/k3s [machine pool schema](https://github.com/rancher/terraform-provider-rancher2/blob/b875ecdefccfdf65f0603df177a77f739bc76f20/rancher2/schema_cluster_v2_rke_config_machine_pool.go#L44)
* Added drain_before_delete to the rke2/k3s [machine pool](https://github.com/rancher/terraform-provider-rancher2/blob/master/rancher2/structure_cluster_v2_rke_config_machine_pool.go)
* Updated tests

## Testing
 
<!-- Describe what, if any, testing you did.  If you added tests describe what cases they cover and do not cover. -->

* Create an RKE2 cluster via Terraform with 2 downstream nodes (1 cp/etcd with `drain_before_delete` not set, 1 worker with `drain_before_delete = true`)
* Create a K3s cluster with the same spec
* View each MachineDeployment in the Rancher UI. The MachineDeployment for cp/etcd nodes should have the CAPI annotation `machine.cluster.x-k8s.io/exclude-node-draining`set in the deployment spec. The MachineDeployment for the worker nodes should not have that annotation.