### PR TITLE
Hetzner node template support PlacementGroup, Firewalls, AdditionalKeys, ImageID

### DIFF
--- a/rancher2/schema_node_template_hetzner.go
+++ b/rancher2/schema_node_template_hetzner.go
@@ -45,7 +45,7 @@ func hetznerConfigFields() map[string]*schema.Schema {
 		"image_id": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "15512617",
+			Default:     "0",
 			Description: "Hetzner Cloud server image id",
 		},
 		"server_labels": {

--- a/rancher2/schema_node_template_hetzner.go
+++ b/rancher2/schema_node_template_hetzner.go
@@ -13,6 +13,7 @@ const (
 type hetznerConfig struct {
 	APIToken          string            `json:"apiToken,omitempty" yaml:"apiToken,omitempty"`
 	Image             string            `json:"image,omitempty" yaml:"image,omitempty"`
+	ImageID           string            `json:"imageId,omitempty" yaml:"imageId,omitempty"`
 	ServerLabels      map[string]string `json:"serverLabels,omitempty" yaml:"serverLabels,omitempty"`
 	ServerLocation    string            `json:"serverLocation,omitempty" yaml:"serverLocation,omitempty"`
 	ServerType        string            `json:"serverType,omitempty" yaml:"serverType,omitempty"`
@@ -20,6 +21,9 @@ type hetznerConfig struct {
 	UsePrivateNetwork bool              `json:"usePrivateNetwork,omitempty" yaml:"usePrivateNetwork,omitempty"`
 	UserData          string            `json:"userData,omitempty" yaml:"userData,omitempty"`
 	Volumes           []string          `json:"volumes,omitempty" yaml:"volumes,omitempty"`
+	Firewalls         []string          `json:"firewalls,omitempty" yaml:"firewalls,omitempty"`
+	AdditionalKeys    []string          `json:"additionalKey,omitempty" yaml:"additionalKey,omitempty"`
+	PlacementGroup    string            `json:"placementGroup,omitempty" yaml:"placementGroup,omitempty"`
 }
 
 //Schemas
@@ -37,6 +41,12 @@ func hetznerConfigFields() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     "ubuntu-18.04",
 			Description: "Hetzner Cloud server image",
+		},
+		"image_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "15512617",
+			Description: "Hetzner Cloud server image id",
 		},
 		"server_labels": {
 			Type:        schema.TypeMap,
@@ -75,6 +85,23 @@ func hetznerConfigFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "Comma-separated list of volume IDs or names which should be attached to the server",
+		},
+		"firewalls": {
+			Type:        schema.TypeList,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Optional:    true,
+			Description: "List of firewall IDs or name which should be attached to the server",
+		},
+		"additional_keys": {
+			Type:        schema.TypeList,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Optional:    true,
+			Description: "List of ssh keys which should be used to provision the machine with",
+		},
+		"placement_group": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Placement group string",
 		},
 	}
 

--- a/rancher2/structure_node_template_hetzner.go
+++ b/rancher2/structure_node_template_hetzner.go
@@ -18,6 +18,10 @@ func flattenHetznerConfig(in *hetznerConfig) []interface{} {
 		obj["image"] = in.Image
 	}
 
+	if len(in.ImageID) > 0 {
+		obj["image_id"] = in.ImageID
+	}
+
 	if len(in.ServerLabels) > 0 {
 		obj["server_labels"] = toMapInterface(in.ServerLabels)
 	}
@@ -44,6 +48,18 @@ func flattenHetznerConfig(in *hetznerConfig) []interface{} {
 		obj["volumes"] = strings.Join(in.Volumes, ",")
 	}
 
+	if len(in.Firewalls) > 0 {
+		obj["firewalls"] = toArrayInterface(in.Firewalls)
+	}
+
+	if len(in.AdditionalKeys) > 0 {
+		obj["additional_keys"] = toArrayInterface(in.AdditionalKeys)
+	}
+
+	if len(in.PlacementGroup) > 0 {
+		obj["placement_group"] = in.PlacementGroup
+	}
+
 	return []interface{}{obj}
 }
 
@@ -62,6 +78,10 @@ func expandHetznercloudConfig(p []interface{}) *hetznerConfig {
 
 	if v, ok := in["image"].(string); ok && len(v) > 0 {
 		obj.Image = v
+	}
+
+	if v, ok := in["image_id"].(string); ok && len(v) > 0 {
+		obj.ImageID = v
 	}
 
 	if v, ok := in["server_labels"].(map[string]interface{}); ok && len(v) > 0 {
@@ -90,6 +110,18 @@ func expandHetznercloudConfig(p []interface{}) *hetznerConfig {
 
 	if v, ok := in["volumes"].(string); ok && len(v) > 0 {
 		obj.Volumes = strings.Split(v, ",")
+	}
+
+	if v, ok := in["firewalls"].([]interface{}); ok && len(v) > 0 {
+		obj.Firewalls = toArrayString(v)
+	}
+
+	if v, ok := in["additional_keys"].([]interface{}); ok && len(v) > 0 {
+		obj.AdditionalKeys = toArrayString(v)
+	}
+
+	if v, ok := in["placement_group"].(string); ok && len(v) > 0 {
+		obj.PlacementGroup = v
 	}
 
 	return obj


### PR DESCRIPTION
This PR provides improved support for the Hetzner Node Template resource by adding:

- The ability to set the node image id via `image_id` (resolves https://github.com/rancher/terraform-provider-rancher2/issues/751)
- The ability to set node ssh keys via `additional_keys` (resolves https://github.com/rancher/terraform-provider-rancher2/issues/654)
- The ability to set the node placement group via `placement_group`
- The ability to set the node firewalls via `firewalls` (resolves https://github.com/rancher/terraform-provider-rancher2/issues/865)

The existing firewalls PR (https://github.com/rancher/terraform-provider-rancher2/pull/866) expects a comma separated string for the list values, whereas this PR allows them to be specified in a list (like other multi-valued fields are specified in other driver configs e.g. AWS EC2, Azure, vSphere).  It would make sense that the other two fields for this config (`networks` and `volumes`) would be made into string lists, but I have opted to not include this as it would break backward compatibility. 

I've opened an issue for that here: https://github.com/rancher/terraform-provider-rancher2/issues/893
