### PR TITLE
Fix RKE2 EC2 cluster creation with standard user token

### DIFF
--- a/rancher2/resource_rancher2_cluster_v2.go
+++ b/rancher2/resource_rancher2_cluster_v2.go
@@ -96,7 +96,7 @@ func resourceRancher2ClusterV2Read(d *schema.ResourceData, meta interface{}) err
 
 	cluster, err := getClusterV2ByID(meta.(*Config), d.Id())
 	if err != nil {
-		if IsNotFound(err) || IsForbidden(err) || IsNotLookForByID(err) {
+		if IsNotFound(err) || IsForbidden(err) || IsNotAccessibleByID(err) {
 			log.Printf("[INFO] Cluster V2 %s not found", d.Id())
 			d.SetId("")
 			return nil
@@ -165,7 +165,7 @@ func clusterV2StateRefreshFunc(meta interface{}, objID string) resource.StateRef
 	return func() (interface{}, string, error) {
 		obj, err := getClusterV2ByID(meta.(*Config), objID)
 		if err != nil {
-			if IsNotFound(err) || IsForbidden(err) || IsNotLookForByID(err) {
+			if IsNotFound(err) || IsForbidden(err) || IsNotAccessibleByID(err) {
 				return obj, "removed", nil
 			}
 			return nil, "", err
@@ -273,10 +273,10 @@ func waitForClusterV2State(c *Config, id, state string, interval time.Duration) 
 		obj, err := getClusterV2ByID(c, id)
 		if err != nil {
 			log.Printf("[DEBUG] Retrying on error Refreshing Cluster V2 %s: %v", id, err)
-			if !IsNotFound(err) && !IsForbidden(err) && !IsNotLookForByID(err) {
+			if !IsNotFound(err) && !IsForbidden(err) && !IsNotAccessibleByID(err) {
 				return nil, fmt.Errorf("Getting cluster V2 ID (%s): %v", id, err)
 			}
-			if IsNotLookForByID(err) {
+			if IsNotAccessibleByID(err) {
 				// Restarting clients to update RBAC
 				c.RestartClients()
 			}

--- a/rancher2/resource_rancher2_machine_config_v2.go
+++ b/rancher2/resource_rancher2_machine_config_v2.go
@@ -1,6 +1,7 @@
 package rancher2
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -18,7 +19,7 @@ func resourceRancher2MachineConfigV2() *schema.Resource {
 		Delete: resourceRancher2MachineConfigV2Delete,
 		Schema: machineConfigV2Fields(),
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
+			Create: schema.DefaultTimeout(3 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
@@ -38,20 +39,42 @@ func resourceRancher2MachineConfigV2Create(d *schema.ResourceData, meta interfac
 
 	d.SetId(newObj.ID)
 	d.Set("kind", newObj.TypeMeta.Kind)
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{},
-		Target:     []string{"active"},
-		Refresh:    machineConfigV2StateRefreshFunc(meta, newObj.ID, newObj.TypeMeta.Kind),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      1 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-	_, waitErr := stateConf.WaitForState()
-	if waitErr != nil {
-		return fmt.Errorf("[ERROR] waiting for machine config (%s) to be active: %s", newObj.ID, waitErr)
+
+	err = waitForMachineConfigV2(d, meta.(*Config), d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return fmt.Errorf("[ERROR] waiting for machine config (%s) to be active: %s", newObj.ID, err)
 	}
 
 	return flattenMachineConfigV2(d, newObj)
+}
+
+func waitForMachineConfigV2(d *schema.ResourceData, config *Config, interval time.Duration) error {
+	log.Printf("[INFO] Waiting for state Machine Config V2 %s", d.Id())
+
+	ctx, cancel := context.WithTimeout(context.Background(), interval)
+	defer cancel()
+	for {
+		kind := d.Get("kind").(string)
+		_, err := getMachineConfigV2ByID(config, d.Id(), kind)
+		if err == nil {
+			return nil
+		}
+		log.Printf("[INFO] Retrying on error Refreshing Machine Config V2 %s: %v", d.Id(), err)
+		if IsNotFound(err) || IsForbidden(err) {
+			d.SetId("")
+			return fmt.Errorf("Machine Config V2 %s not found: %s", d.Id(), err)
+		}
+		if IsNotAccessibleByID(err) {
+			// Restarting clients to update RBAC
+			config.RestartClients()
+		}
+
+		select {
+		case <-time.After(rancher2RetriesWait * time.Second):
+		case <-ctx.Done():
+			return fmt.Errorf("Timeout waiting for machine config V2 ID %s", d.Id())
+		}
+	}
 }
 
 func resourceRancher2MachineConfigV2Read(d *schema.ResourceData, meta interface{}) error {
@@ -60,7 +83,7 @@ func resourceRancher2MachineConfigV2Read(d *schema.ResourceData, meta interface{
 	kind := d.Get("kind").(string)
 	obj, err := getMachineConfigV2ByID(meta.(*Config), d.Id(), kind)
 	if err != nil {
-		if IsNotFound(err) || IsForbidden(err) || IsNotLookForByID(err) {
+		if IsNotFound(err) || IsForbidden(err) || IsNotAccessibleByID(err) {
 			log.Printf("[INFO] Machine Config V2 %s not found", d.Id())
 			d.SetId("")
 			return nil
@@ -102,7 +125,7 @@ func resourceRancher2MachineConfigV2Delete(d *schema.ResourceData, meta interfac
 
 	obj, err := getMachineConfigV2ByID(meta.(*Config), d.Id(), kind)
 	if err != nil {
-		if IsNotFound(err) || IsForbidden(err) || IsNotLookForByID(err) {
+		if IsNotFound(err) || IsForbidden(err) || IsNotAccessibleByID(err) {
 			d.SetId("")
 			return nil
 		}
@@ -137,7 +160,7 @@ func machineConfigV2StateRefreshFunc(meta interface{}, objID, kind string) resou
 				return obj, "removed", nil
 			}
 			// This is required to allow standard user to use this resource
-			if !IsNotLookForByID(err) {
+			if !IsNotAccessibleByID(err) {
 				return obj, "active", nil
 			}
 			return nil, "", err

--- a/rancher2/util.go
+++ b/rancher2/util.go
@@ -341,7 +341,7 @@ func IsUnknownSchemaType(err error) bool {
 	return strings.Contains(err.Error(), "Unknown schema type")
 }
 
-func IsNotLookForByID(err error) bool {
+func IsNotAccessibleByID(err error) bool {
 	return strings.Contains(err.Error(), "can not be looked up by ID")
 }
 


### PR DESCRIPTION
Issue: https://github.com/rancher/terraform-provider-rancher2/issues/824 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. --> 
 
## Problem
 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable.  If this is a new feature describe why we need this feature and how it will be used. -->

The problem was that Terraform would throw an error for RKE2 clusters provisioned with a standard user token. The cluster was being prevented from becoming active on refresh if the terraform provider couldn't look up the machine config by ID. The root cause is that that RBAC is not configured to allow standard users access to the machine configs in `rke-machine-config.cattle.io.` Instead, the [authprovisioning controller](https://github.com/rancher/rancher/blob/ac92c2a38a122dddd9a859259775d31602b98eb0/pkg/controllers/management/authprovisioningv2/machineconfigs.go#L22) in Rancher gives a user access to the specific machine config that it creates, after provisioning. This caused Terraform to error out because it would try to create the cluster before Rancher set the machine config permissions.
 
## Solution
 
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Add code in the Terraform provider to retry 5 times if the machine config state returns an error; specifically, restart RBAC if the machine config can't be looked up by ID.

Here
https://github.com/annablender/terraform-provider-rancher2/blob/50446e14852764b47192b745aeb187636c95412c/rancher2/resource_rancher2_machine_config_v2.go#L51

## Testing
 
<!-- Describe what, if any, testing you did.  If you added tests describe what cases they cover and do not cover. -->

Verify these scenarios work _the first time_ without error
* Provision an RKE2 EC2 cluster via terraform using an admin token
* Provision an RKE2 EC2 cluster via terraform using a standard user token (click the `Create Clusters` box when creating the user. It is not added by default)