### PR TITLE
Add admission_configuration configuration

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1228,6 +1228,41 @@ The following attributes are exported:
 * `service_cluster_ip_range` - (Optional/Computed) Service Cluster IP Range option for kube API service (string)
 * `service_node_port_range` - (Optional/Computed) Service Node Port Range option for kube API service (string)
 
+
+###### `admission_configuration`
+
+###### Arguments
+
+* `api_version` - (Optional) Admission configuration ApiVersion. Default: `apiserver.config.k8s.io/v1` (string)
+* `kind` - (Optional) Admission configuration Kind. Default: `AdmissionConfiguration` (string)
+* `plugins` - (Optional) Admission configuration plugins. (list `plugin`)
+
+###### `plugin`
+
+###### Arguments
+
+* `name` - (Optional) Plugin name. (string)
+* `path` - (Optional) Plugin path. Default: `""` (string)
+* `configuration` - (Optional) Plugin configuration. (string) Ex:
+
+```
+configuration = <<EOF
+apiVersion: pod-security.admission.config.k8s.io/v1alpha1
+kind: PodSecurityConfiguration
+defaults:
+  enforce: restricted
+  enforce-version: latest
+  audit: restricted
+  audit-version: latest
+  warn: restricted
+  warn-version: latest
+exemptions:
+  usernames: []
+  runtimeClasses: []
+  namespaces: []
+EOF
+
+
 ###### `audit_log`
 
 ###### Arguments

--- a/rancher2/schema_cluster_rke_config_services_kube_api.go
+++ b/rancher2/schema_cluster_rke_config_services_kube_api.go
@@ -128,14 +128,16 @@ func clusterRKEConfigServicesKubeAPIAuditLogFields() map[string]*schema.Schema {
 func clusterRKEConfigServicesKubeAPIAdmissionConfigurationFieldsV0() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"api_version": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault,
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault,
+			Description: "Admission configuration ApiVersion",
 		},
 		"kind": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault,
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault,
+			Description: "Admission configuration Kind",
 		},
 		"plugins": {
 			Type:     schema.TypeList,
@@ -144,6 +146,7 @@ func clusterRKEConfigServicesKubeAPIAdmissionConfigurationFieldsV0() map[string]
 			Elem: &schema.Resource{
 				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFieldsV0(),
 			},
+			Description: "Admission configuration plugins",
 		},
 	}
 	return s
@@ -152,14 +155,16 @@ func clusterRKEConfigServicesKubeAPIAdmissionConfigurationFieldsV0() map[string]
 func clusterRKEConfigServicesKubeAPIAdmissionConfigurationFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"api_version": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault,
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault,
+			Description: "Admission configuration ApiVersion",
 		},
 		"kind": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault,
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault,
+			Description: "Admission configuration Kind",
 		},
 		"plugins": {
 			Type:     schema.TypeList,
@@ -168,6 +173,7 @@ func clusterRKEConfigServicesKubeAPIAdmissionConfigurationFields() map[string]*s
 			Elem: &schema.Resource{
 				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFields(),
 			},
+			Description: "Admission configuration plugins",
 		},
 	}
 	return s
@@ -176,19 +182,22 @@ func clusterRKEConfigServicesKubeAPIAdmissionConfigurationFields() map[string]*s
 func clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFieldsV0() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"name": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Plugin name",
 		},
 		"path": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  "",
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "",
+			Description: "Plugin path",
 		},
 		"configuration": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Plugin configuration",
 		},
 	}
 	return s
@@ -196,14 +205,16 @@ func clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFieldsV0() map[string]
 func clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"name": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Plugin name",
 		},
 		"path": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  "",
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "",
+			Description: "Plugin path",
 		},
 		"configuration": {
 			Type:     schema.TypeString,
@@ -229,6 +240,7 @@ func clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFields() map[string]*s
 				newMap, _ := ghodssyamlToMapInterface(new)
 				return reflect.DeepEqual(oldMap, newMap)
 			},
+			Description: "Plugin configuration",
 		},
 	}
 	return s
@@ -400,6 +412,7 @@ func clusterRKEConfigServicesKubeAPIFieldsV0() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigurationFieldsV0(),
 			},
+			Description: "Cluster admission configuration",
 		},
 		"always_pull_images": {
 			Type:     schema.TypeBool,
@@ -482,6 +495,7 @@ func clusterRKEConfigServicesKubeAPIFields() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigurationFields(),
 			},
+			Description: "Cluster admission configuration",
 		},
 		"always_pull_images": {
 			Type:     schema.TypeBool,
@@ -565,6 +579,7 @@ func clusterRKEConfigServicesKubeAPIFieldsData() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigurationFields(),
 			},
+			Description: "Cluster admission configuration",
 		},
 		"always_pull_images": {
 			Type:     schema.TypeBool,

--- a/rancher2/schema_cluster_rke_config_services_kube_api.go
+++ b/rancher2/schema_cluster_rke_config_services_kube_api.go
@@ -15,9 +15,11 @@ const (
 	clusterRKEConfigServicesKubeAPIAuditLogConfigPolicyAPIDefault  = "audit.k8s.io/v1"
 	clusterRKEConfigServicesKubeAPIEventRateLimitConfigAPIDefault  = "eventratelimit.admission.k8s.io/v1alpha1"
 	clusterRKEConfigServicesKubeAPIEncryptionConfigAPIDefault      = "apiserver.config.k8s.io/v1"
+	clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault       = "apiserver.config.k8s.io/v1"
 	clusterRKEConfigServicesKubeAPIAuditLogConfigPolicyKindDefault = "Policy"
 	clusterRKEConfigServicesKubeAPIEventRateLimitConfigKindDefault = "Configuration"
 	clusterRKEConfigServicesKubeAPIEncryptionConfigKindDefault     = "EncryptionConfiguration"
+	clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault      = "AdmissionConfiguration"
 )
 
 var (
@@ -118,6 +120,115 @@ func clusterRKEConfigServicesKubeAPIAuditLogFields() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
+		},
+	}
+	return s
+}
+
+func clusterRKEConfigServicesKubeAPIAdmissionConfigurationFieldsV0() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"api_version": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault,
+		},
+		"kind": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault,
+		},
+		"plugins": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFieldsV0(),
+			},
+		},
+	}
+	return s
+}
+
+func clusterRKEConfigServicesKubeAPIAdmissionConfigurationFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"api_version": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault,
+		},
+		"kind": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault,
+		},
+		"plugins": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFields(),
+			},
+		},
+	}
+	return s
+}
+
+func clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFieldsV0() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"path": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  "",
+		},
+		"configuration": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+	}
+	return s
+}
+func clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"path": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  "",
+		},
+		"configuration": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+				v, ok := val.(string)
+				if !ok || len(v) == 0 {
+					return
+				}
+				_, err := ghodssyamlToMapInterface(v)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("%q must be in yaml format, error: %v", key, err))
+					return
+				}
+				return
+			},
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				if old == "" || new == "" {
+					return false
+				}
+				oldMap, _ := ghodssyamlToMapInterface(old)
+				newMap, _ := ghodssyamlToMapInterface(new)
+				return reflect.DeepEqual(oldMap, newMap)
+			},
 		},
 	}
 	return s
@@ -283,8 +394,12 @@ func clusterRKEConfigServicesKubeAPISecretsEncryptionConfigFieldsData() map[stri
 func clusterRKEConfigServicesKubeAPIFieldsV0() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"admission_configuration": {
-			Type:     schema.TypeMap,
+			Type:     schema.TypeList,
+			MaxItems: 1,
 			Optional: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigurationFieldsV0(),
+			},
 		},
 		"always_pull_images": {
 			Type:     schema.TypeBool,
@@ -361,8 +476,12 @@ func clusterRKEConfigServicesKubeAPIFieldsV0() map[string]*schema.Schema {
 func clusterRKEConfigServicesKubeAPIFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"admission_configuration": {
-			Type:     schema.TypeMap,
+			Type:     schema.TypeList,
+			MaxItems: 1,
 			Optional: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigurationFields(),
+			},
 		},
 		"always_pull_images": {
 			Type:     schema.TypeBool,
@@ -440,8 +559,12 @@ func clusterRKEConfigServicesKubeAPIFields() map[string]*schema.Schema {
 func clusterRKEConfigServicesKubeAPIFieldsData() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"admission_configuration": {
-			Type:     schema.TypeMap,
+			Type:     schema.TypeList,
+			MaxItems: 1,
 			Optional: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigurationFields(),
+			},
 		},
 		"always_pull_images": {
 			Type:     schema.TypeBool,

--- a/rancher2/structure_cluster_rke_config_services_kube_api_test.go
+++ b/rancher2/structure_cluster_rke_config_services_kube_api_test.go
@@ -8,16 +8,20 @@ import (
 )
 
 var (
-	testClusterRKEConfigServicesKubeAPIAuditLogConfigConf               *managementClient.AuditLogConfig
-	testClusterRKEConfigServicesKubeAPIAuditLogConfigInterface          []interface{}
-	testClusterRKEConfigServicesKubeAPIAuditLogConf                     *managementClient.AuditLog
-	testClusterRKEConfigServicesKubeAPIAuditLogInterface                []interface{}
-	testClusterRKEConfigServicesKubeAPIEventRateLimitConf               *managementClient.EventRateLimit
-	testClusterRKEConfigServicesKubeAPIEventRateLimitInterface          []interface{}
-	testClusterRKEConfigServicesKubeAPISecretsEncryptionConfigConf      *managementClient.SecretsEncryptionConfig
-	testClusterRKEConfigServicesKubeAPISecretsEncryptionConfigInterface []interface{}
-	testClusterRKEConfigServicesKubeAPIConf                             *managementClient.KubeAPIService
-	testClusterRKEConfigServicesKubeAPIInterface                        []interface{}
+	testClusterRKEConfigServicesKubeAPIAuditLogConfigConf                     *managementClient.AuditLogConfig
+	testClusterRKEConfigServicesKubeAPIAuditLogConfigInterface                []interface{}
+	testClusterRKEConfigServicesKubeAPIAuditLogConf                           *managementClient.AuditLog
+	testClusterRKEConfigServicesKubeAPIAuditLogInterface                      []interface{}
+	testClusterRKEConfigServicesKubeAPIEventRateLimitConf                     *managementClient.EventRateLimit
+	testClusterRKEConfigServicesKubeAPIEventRateLimitInterface                []interface{}
+	testClusterRKEConfigServicesKubeAPISecretsEncryptionConfigConf            *managementClient.SecretsEncryptionConfig
+	testClusterRKEConfigServicesKubeAPISecretsEncryptionConfigInterface       []interface{}
+	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationConf             map[string]interface{}
+	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationInterface        []interface{}
+	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsConf      []interface{}
+	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsInterface []interface{}
+	testClusterRKEConfigServicesKubeAPIConf                                   *managementClient.KubeAPIService
+	testClusterRKEConfigServicesKubeAPIInterface                              []interface{}
 )
 
 func init() {
@@ -81,10 +85,43 @@ func init() {
 			"custom_config": "apiVersion: " + clusterRKEConfigServicesKubeAPIEncryptionConfigAPIDefault + "\nkind: " + clusterRKEConfigServicesKubeAPIEncryptionConfigKindDefault + "\nresources:\n- {}\n",
 		},
 	}
+	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsConf = []interface{}{
+		map[string]interface{}{
+			"name": "EventRateLimit",
+			"path": "",
+			"configuration": map[string]interface{}{
+				"apiVersion": clusterRKEConfigServicesKubeAPIEventRateLimitConfigAPIDefault,
+				"kind":       clusterRKEConfigServicesKubeAPIEventRateLimitConfigKindDefault,
+				"limits": []interface{}{
+					map[string]interface{}{},
+				},
+			},
+		},
+	}
+	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsInterface = []interface{}{
+		map[string]interface{}{
+			"name":          "EventRateLimit",
+			"path":          "",
+			"configuration": "apiVersion: " + clusterRKEConfigServicesKubeAPIEventRateLimitConfigAPIDefault + "\nkind: " + clusterRKEConfigServicesKubeAPIEventRateLimitConfigKindDefault + "\nlimits:\n- {}\n",
+		},
+	}
+	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationConf = map[string]interface{}{
+		"apiVersion": clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault,
+		"kind":       clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault,
+		"plugins":    testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsConf,
+	}
+	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationInterface = []interface{}{
+		map[string]interface{}{
+			"api_version": clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault,
+			"kind":        clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault,
+			"plugins":     testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsInterface,
+		},
+	}
 	testClusterRKEConfigServicesKubeAPIConf = &managementClient.KubeAPIService{
-		AlwaysPullImages: true,
-		AuditLog:         testClusterRKEConfigServicesKubeAPIAuditLogConf,
-		EventRateLimit:   testClusterRKEConfigServicesKubeAPIEventRateLimitConf,
+		AlwaysPullImages:       true,
+		AuditLog:               testClusterRKEConfigServicesKubeAPIAuditLogConf,
+		EventRateLimit:         testClusterRKEConfigServicesKubeAPIEventRateLimitConf,
+		AdmissionConfiguration: testClusterRKEConfigServicesKubeAPIAdmissionConfigurationConf,
 		ExtraArgs: map[string]string{
 			"arg_one": "one",
 			"arg_two": "two",
@@ -99,9 +136,10 @@ func init() {
 	}
 	testClusterRKEConfigServicesKubeAPIInterface = []interface{}{
 		map[string]interface{}{
-			"always_pull_images": true,
-			"audit_log":          testClusterRKEConfigServicesKubeAPIAuditLogInterface,
-			"event_rate_limit":   testClusterRKEConfigServicesKubeAPIEventRateLimitInterface,
+			"always_pull_images":      true,
+			"admission_configuration": testClusterRKEConfigServicesKubeAPIAdmissionConfigurationInterface,
+			"audit_log":               testClusterRKEConfigServicesKubeAPIAuditLogInterface,
+			"event_rate_limit":        testClusterRKEConfigServicesKubeAPIEventRateLimitInterface,
 			"extra_args": map[string]interface{}{
 				"arg_one": "one",
 				"arg_two": "two",
@@ -234,6 +272,54 @@ func TestFlattenClusterRKEConfigServicesKubeAPI(t *testing.T) {
 	}
 }
 
+func TestFlattenClusterRKEConfigServicesKubeAPIAdmissionConfigurationPlugins(t *testing.T) {
+
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput []interface{}
+	}{
+		{
+			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsConf,
+			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsInterface,
+		},
+	}
+
+	for _, tc := range cases {
+		output, err := flattenClusterRKEConfigServicesKubeAPIAdmissionConfigurationPlugins(tc.Input)
+		if err != nil {
+			t.Fatalf("[ERROR] on flattener: %#v", err)
+		}
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestFlattenClusterRKEConfigServicesKubeAPIAdmissionConfiguration(t *testing.T) {
+
+	cases := []struct {
+		Input          map[string]interface{}
+		ExpectedOutput []interface{}
+	}{
+		{
+			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationConf,
+			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationInterface,
+		},
+	}
+
+	for _, tc := range cases {
+		output, err := flattenClusterRKEConfigServicesKubeAPIAdmissionConfiguration(tc.Input)
+		if err != nil {
+			t.Fatalf("[ERROR] on flattener: %#v", err)
+		}
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
 func TestExpandClusterRKEConfigServicesKubeAPIAuditLogConfig(t *testing.T) {
 
 	cases := []struct {
@@ -343,6 +429,54 @@ func TestExpandClusterRKEConfigServicesKubeAPI(t *testing.T) {
 		}
 		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
 			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestExpandClusterRKEConfigServicesKubeAPIAdmissionConfigurationPlugins(t *testing.T) {
+
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput []interface{}
+	}{
+		{
+			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsInterface,
+			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsConf,
+		},
+	}
+
+	for _, tc := range cases {
+		output, err := expandClusterRKEConfigServicesKubeAPIAdmissionConfigurationPlugins(tc.Input)
+		if err != nil {
+			t.Fatalf("[ERROR] on flattener: %#v", err)
+		}
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestExpandClusterRKEConfigServicesKubeAPIAdmissionConfiguration(t *testing.T) {
+
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput map[string]interface{}
+	}{
+		{
+			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationInterface,
+			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationConf,
+		},
+	}
+
+	for _, tc := range cases {
+		output, err := expandClusterRKEConfigServicesKubeAPIAdmissionConfiguration(tc.Input)
+		if err != nil {
+			t.Fatalf("[ERROR] on flattener: %#v", err)
+		}
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
 				tc.ExpectedOutput, output)
 		}
 	}


### PR DESCRIPTION
Addresses https://github.com/rancher/terraform-provider-rancher2/issues/908 

I'm rather new to write Golang and using the terraform SDK. I'm open to any help in improving this code.

Unfortunately as specified here: https://github.com/rancher/rancher/issues/37455 AdmissionConfiguration type coming from K8s is erased and is mapped to `map[string]interface{}` this forces me to do a lot of casting to make it work.

With this fix with the following terraform code:
```
admission_configuration {
  api_version = "apiserver.config.k8s.io/v1"
  kind        = "AdmissionConfiguration"
  plugins {
    name          = "PodSecurity"
    path          = ""
    configuration = file("files/security.yml")
  }
  plugins {
    name          = "EventRateLimit"
    path          = ""
    configuration = file("files/ratelimit.yml")
  }
}
```

We obtain the following code in the terraform state
```
"admission_configuration": [
  {
    "api_version": "apiserver.config.k8s.io/v1",
    "kind": "AdmissionConfiguration",
    "plugins": [
      {
        "configuration": "apiVersion: pod-security.admission.config.k8s.io/v1alpha1\ndefaults:\n  audit: restricted\n  audit-version: latest\n  enforce: restricted\n  enforce-version: latest\n  warn: restricted\n  warn-version: latest\nexemptions:\n  namespaces: []\n  runtimeClasses: []\n  usernames: []\nkind: PodSecurityConfiguration\n",
        "name": "PodSecurity",
        "path": ""
      },
      {
        "configuration": "apiVersion: eventratelimit.admission.k8s.io/v1alpha1\nkind: Configuration\nlimits:\n- burst: 20000\n  qps: 5000\n  type: Server\n",
        "name": "EventRateLimit",
        "path": ""
      }
    ]
  }
]
```