### PR TITLE
Allow import on node template config drivers for all drivers that allow it without additional modification

### DIFF
--- a/rancher2/structure_node_template.go
+++ b/rancher2/structure_node_template.go
@@ -22,6 +22,10 @@ func flattenNodeTemplate(d *schema.ResourceData, in *NodeTemplate) error {
 		if in.Amazonec2Config == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires amazonec2_config", in.Driver)
 		}
+		err := d.Set("amazonec2_config", flattenAmazonec2Config(in.Amazonec2Config))
+		if err != nil {
+			return err
+		}
 	case azureConfigDriver:
 		if in.AzureConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires azure_config", in.Driver)
@@ -30,9 +34,17 @@ func flattenNodeTemplate(d *schema.ResourceData, in *NodeTemplate) error {
 		if in.DigitaloceanConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires digitalocean_config", in.Driver)
 		}
+		err := d.Set("digitalocean_config", flattenDigitaloceanConfig(in.DigitaloceanConfig))
+		if err != nil {
+			return err
+		}
 	case linodeConfigDriver:
 		if in.LinodeConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires linode_config", in.Driver)
+		}
+		err := d.Set("linode_config", flattenLinodeConfig(in.LinodeConfig))
+		if err != nil {
+			return err
 		}
 	case openstackConfigDriver:
 		if in.OpenstackConfig == nil {
@@ -42,13 +54,25 @@ func flattenNodeTemplate(d *schema.ResourceData, in *NodeTemplate) error {
 		if in.HetznerConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires hetzner_config", in.Driver)
 		}
+		err := d.Set("hetzner_config", flattenHetznerConfig(in.HetznerConfig))
+		if err != nil {
+			return err
+		}
 	case harvesterConfigDriver:
 		if in.HarvesterConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires harvester_config", in.Driver)
 		}
+		err := d.Set("harvester_config", flattenHarvesterConfig(in.HarvesterConfig))
+		if err != nil {
+			return err
+		}
 	case vmwarevsphereConfigDriver:
 		if in.VmwarevsphereConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires vsphere_config", in.Driver)
+		}
+		err := d.Set("vsphere_config", flattenVsphereConfig(in.VmwarevsphereConfig))
+		if err != nil {
+			return err
 		}
 	case opennebulaConfigDriver:
 		if in.OpennebulaConfig == nil {


### PR DESCRIPTION
Why this pull request?

When importing node-template the config driver configuration are not included. For example an imported node-template with a vsphere diver configuration will generate a statefile like below:

```json
  "resources": [
    {
      "mode": "managed",
      "type": "rancher2_node_template",
      "name": "myname",
      "provider": "provider[\"registry.terraform.io/rancher/rancher2\"]",
      "instances": [
        {
          ...
         "attributes": {
            "use_internal_ip_address": true,
            "vsphere_config": []
          },
          "sensitive_attributes": [],
          "private": "myprivatekey"
        }
      ]
    }
  ]
```
Allowing the driver config to be set will correctly import the driver configuration as well:

```json
  "resources": [
    {
      "mode": "managed",
      "type": "rancher2_node_template",
      "name": "myname",
      "provider": "provider[\"registry.terraform.io/rancher/rancher2\"]",
      "instances": [
        {
          ...
          "attributes": {
            "use_internal_ip_address": true,
            "vsphere_config": [
              {
                "boot2docker_url": "",
                "cfgparam": [
                  "disk.enableUUID=TRUE"
                ],
                ...
                "vcenter": "",
                "vcenter_port": "443"
              }
            ]
          },
          "sensitive_attributes": [],
          "private": "myprivatekey"
        }
      ]
    }
  ]
```
Azure config driver has been excluded for now because it appears that are some attributes still configured in terraform which no longer exist in rancher. As a result the tests fail when running against rancher version 2.3.6+.

Openstack and opennebula have also be excluded as I can't find any reference of these driver configs in rancher version 2.3.6+.

I'm open to a different approach, but currently I suggest to solve the azure config driver in a separate pull request and leaving the openstack and opennebula config drivers out.