### PR TITLE
Allow to include azure driver config when importing node-templates

### DIFF
--- a/rancher2/schema_node_template_azure.go
+++ b/rancher2/schema_node_template_azure.go
@@ -11,34 +11,34 @@ const (
 //Types
 
 type azureConfig struct {
-	AvailabilitySet    string   `json:"availabilitySet,omitempty" yaml:"availabilitySet,omitempty"`
-	ClientID           string   `json:"clientId,omitempty" yaml:"clientId,omitempty"`
-	ClientSecret       string   `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
-	CustomData         string   `json:"customData,omitempty" yaml:"customData,omitempty"`
-	DiskSize           string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
-	DNS                string   `json:"dns,omitempty" yaml:"dns,omitempty"`
-	Environment        string   `json:"environment,omitempty" yaml:"environment,omitempty"`
-	FaultDomainCount   string   `json:"faultDomainCount,omitempty" yaml:"faultDomainCount,omitempty"`
-	Image              string   `json:"image,omitempty" yaml:"image,omitempty"`
-	Location           string   `json:"location,omitempty" yaml:"location,omitempty"`
-	ManagedDisks       bool     `json:"managedDisks,omitempty" yaml:"managedDisks,omitempty"`
-	NoPublicIP         bool     `json:"noPublicIp,omitempty" yaml:"noPublicIp,omitempty"`
-	NSG                string   `json:"nsg,omitempty" yaml:"nsg,omitempty"`
-	Plan               string   `json:"plan,omitempty" yaml:"plan,omitempty"`
-	OpenPort           []string `json:"openPort,omitempty" yaml:"openPort,omitempty"`
-	PrivateAddressOnly bool     `json:"privateAddressOnly,omitempty" yaml:"privateAddressOnly,omitempty"`
-	PrivateIPAddress   string   `json:"privateIpAddress,omitempty" yaml:"privateIpAddress,omitempty"`
-	ResourceGroup      string   `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
-	Size               string   `json:"size,omitempty" yaml:"size,omitempty"`
-	SSHUser            string   `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
-	StaticPublicIP     bool     `json:"staticPublicIp,omitempty" yaml:"staticPublicIp,omitempty"`
-	StorageType        string   `json:"storageType,omitempty" yaml:"storageType,omitempty"`
-	Subnet             string   `json:"subnet,omitempty" yaml:"subnet,omitempty"`
-	SubnetPrefix       string   `json:"subnetPrefix,omitempty" yaml:"subnetPrefix,omitempty"`
-	SubscriptionID     string   `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
-	UpdateDomainCount  string   `json:"updateDomainCount,omitempty" yaml:"updateDomainCount,omitempty"`
-	UsePrivateIP       bool     `json:"usePrivateIp,omitempty" yaml:"usePrivateIp,omitempty"`
-	Vnet               string   `json:"vnet,omitempty" yaml:"vnet,omitempty"`
+	AvailabilitySet   string   `json:"availabilitySet,omitempty" yaml:"availabilitySet,omitempty"`
+	ClientID          string   `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret      string   `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+	CustomData        string   `json:"customData,omitempty" yaml:"customData,omitempty"`
+	DiskSize          string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
+	DNS               string   `json:"dns,omitempty" yaml:"dns,omitempty"`
+	DockerPort        string   `json:"dockerPort,omitempty" yaml:"dockerPort,omitempty"`
+	Environment       string   `json:"environment,omitempty" yaml:"environment,omitempty"`
+	FaultDomainCount  string   `json:"faultDomainCount,omitempty" yaml:"faultDomainCount,omitempty"`
+	Image             string   `json:"image,omitempty" yaml:"image,omitempty"`
+	Location          string   `json:"location,omitempty" yaml:"location,omitempty"`
+	ManagedDisks      bool     `json:"managedDisks,omitempty" yaml:"managedDisks,omitempty"`
+	NoPublicIP        bool     `json:"noPublicIp,omitempty" yaml:"noPublicIp,omitempty"`
+	NSG               string   `json:"nsg,omitempty" yaml:"nsg,omitempty"`
+	Plan              string   `json:"plan,omitempty" yaml:"plan,omitempty"`
+	OpenPort          []string `json:"openPort,omitempty" yaml:"openPort,omitempty"`
+	PrivateIPAddress  string   `json:"privateIpAddress,omitempty" yaml:"privateIpAddress,omitempty"`
+	ResourceGroup     string   `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
+	Size              string   `json:"size,omitempty" yaml:"size,omitempty"`
+	SSHUser           string   `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	StaticPublicIP    bool     `json:"staticPublicIp,omitempty" yaml:"staticPublicIp,omitempty"`
+	StorageType       string   `json:"storageType,omitempty" yaml:"storageType,omitempty"`
+	Subnet            string   `json:"subnet,omitempty" yaml:"subnet,omitempty"`
+	SubnetPrefix      string   `json:"subnetPrefix,omitempty" yaml:"subnetPrefix,omitempty"`
+	SubscriptionID    string   `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
+	UpdateDomainCount string   `json:"updateDomainCount,omitempty" yaml:"updateDomainCount,omitempty"`
+	UsePrivateIP      bool     `json:"usePrivateIp,omitempty" yaml:"usePrivateIp,omitempty"`
+	Vnet              string   `json:"vnet,omitempty" yaml:"vnet,omitempty"`
 }
 
 //Schemas
@@ -124,7 +124,6 @@ func azureConfigFields() map[string]*schema.Schema {
 		"nsg": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "docker-machine-nsg",
 			Description: "Azure Network Security Group to assign this node to (accepts either a name or resource ID, default is to create a new NSG for each machine)",
 		},
 		"plan": {

--- a/rancher2/structure_node_template.go
+++ b/rancher2/structure_node_template.go
@@ -26,6 +26,10 @@ func flattenNodeTemplate(d *schema.ResourceData, in *NodeTemplate) error {
 		if in.AzureConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires azure_config", in.Driver)
 		}
+		err := d.Set("azure_config", flattenAzureConfig(in.AzureConfig))
+		if err != nil {
+			return err
+		}
 	case digitaloceanConfigDriver:
 		if in.DigitaloceanConfig == nil {
 			return fmt.Errorf("[ERROR] Node template driver %s requires digitalocean_config", in.Driver)

--- a/rancher2/structure_node_template_azure.go
+++ b/rancher2/structure_node_template_azure.go
@@ -32,6 +32,10 @@ func flattenAzureConfig(in *azureConfig) []interface{} {
 		obj["dns"] = in.DNS
 	}
 
+	if len(in.DockerPort) > 0 {
+		obj["docker_port"] = in.DockerPort
+	}
+
 	if len(in.Environment) > 0 {
 		obj["environment"] = in.Environment
 	}
@@ -62,8 +66,6 @@ func flattenAzureConfig(in *azureConfig) []interface{} {
 	if len(in.OpenPort) > 0 {
 		obj["open_port"] = toArrayInterface(in.OpenPort)
 	}
-
-	obj["private_address_only"] = in.PrivateAddressOnly
 
 	if len(in.PrivateIPAddress) > 0 {
 		obj["private_ip_address"] = in.PrivateIPAddress
@@ -179,10 +181,6 @@ func expandAzureConfig(p []interface{}) *azureConfig {
 
 	if v, ok := in["open_port"].([]interface{}); ok && len(v) > 0 {
 		obj.OpenPort = toArrayString(v)
-	}
-
-	if v, ok := in["private_address_only"].(bool); ok {
-		obj.PrivateAddressOnly = v
 	}
 
 	if v, ok := in["private_ip_address"].(string); ok && len(v) > 0 {


### PR DESCRIPTION
Why this pull request?

This pull request allows to include the azure driver config into the statefile when importing a node-template based on azure. The pull request is related to https://github.com/rancher/terraform-provider-rancher2/pull/910 in which the azure driver config has been skipped because of the complications outlined below:

To accomplish including the attribute azure_config in the terraform imports of node-templates, three extra changes need to happen:

1. PrivateAddressOnly has been removed as an attribute. This attribute is nowhere to be found in the rancher api for the azure_config resource schema and it breaks the test.
2. DockerPort was missing as an attribute for the azure_config, also breaking the test as it is created with a default. It has been added.
3. The default value "docker-machine-nsg" for the new nsg attribute has been removed. This is potentially breaking existing terraform configurations. Since this attribute does not exist in rancher 2.3.6 or 2.4.2 it is however also breaking diffs / updates to rancher clusters still running with these versions. Omit the attribute when empty and only push it to rancher when explicitly defined seemed like the best solution for this kind of attributes. However I'd be happy to hear about other solutions.