### PR TITLE
Remove locations field from GKE cluster config fix

### DIFF
--- a/rancher2/structure_cluster_gke_config_v2.go
+++ b/rancher2/structure_cluster_gke_config_v2.go
@@ -669,7 +669,6 @@ func fixClusterGKEConfigV2(values map[string]interface{}) map[string]interface{}
 		"network":               newEmptyString(),
 		"subnetwork":            newEmptyString(),
 		"networkPolicyEnabled":  newFalse(),
-		"locations":             []string{},
 		"maintenanceWindow":     newEmptyString(),
 	}
 


### PR DESCRIPTION
There was a type issue with the `locations` field of the GKE V2 cluster config in
the Rancher go cli. As a fix, this field it has always been set to an empty
string array.  In https://github.com/rancher/rancher/commit/2ceb9ed805838ec5e4ce642b7031ac0b38b243c0
the type issue was fixed upstream and it is no longer necessary to overwrite the
`locations` field. 

This will allow you to create/import zonal GKE clusters with an additional zone
configured.