### PR TITLE
Add k3s/rke2 etcd snapshot restore support

### DIFF
--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -420,6 +420,9 @@ The following attributes are exported:
 * `machine_selector_config` - (Optional/Computed) Cluster V2 machine selector config (list)
 * `registries` - (Optional) Cluster V2 docker registries (list maxitems:1)
 * `etcd` - (Optional) Cluster V2 etcd (list maxitems:1)
+* `rotate_certificates` (Optional) Cluster V2 certificate rotation (list maxitems:1)
+* `etcd_snapshot_create` (Optional) Cluster V2 etcd snapshot create (list maxitems:1)
+* `etcd_snapshot_restore` (Optional) Cluster V2 etcd snapshot restore (list maxitems:1)
 
 #### `local_auth_endpoint`
 
@@ -562,6 +565,27 @@ The following attributes are exported:
 * `folder` - (Optional) ETCD snapshot S3 folder (string)
 * `region` - (Optional) ETCD snapshot S3 region (string)
 * `skip_ssl_verify` - (Optional) Disable ETCD skip ssl verify. Default: `false` (bool)
+
+##### `rotate_certificates`
+
+###### Arguments
+
+* `generation` - (Required) Desired certificate rotation generation (int)
+* `services` - (Optional) Service certificates to rotate with this generation (string)
+
+##### `etcd_snapshot_create`
+
+###### Arguments
+
+* `generation` - (Required) ETCD generation to initiate a snapshot (int)
+
+##### `etcd_snapshot_restore`
+
+###### Arguments
+
+* `name` - (Required) ETCD snapshot name to restore (string)
+* `generation` (Required) ETCD snapshot desired generation (int)
+* `restore_rke_config` (Optional) ETCD restore RKE config (set to none, all, or kubernetesVersion) (string)
 
 ### `cluster_registration_token`
 

--- a/rancher2/schema_cluster_v2_rke_config.go
+++ b/rancher2/schema_cluster_v2_rke_config.go
@@ -131,6 +131,24 @@ func clusterV2RKEConfigFields() map[string]*schema.Schema {
 				Schema: clusterV2RKEConfigRotateCertificatesFields(),
 			},
 		},
+		"etcd_snapshot_create": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Cluster V2 etcd snapshot create",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigETCDSnapshotCreateFields(),
+			},
+		},
+		"etcd_snapshot_restore": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Cluster V2 etcd snapshot restore",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigETCDSnapshotRestoreFields(),
+			},
+		},
 	}
 
 	return s

--- a/rancher2/schema_cluster_v2_rke_config_certificate_rotation.go
+++ b/rancher2/schema_cluster_v2_rke_config_certificate_rotation.go
@@ -10,7 +10,7 @@ func clusterV2RKEConfigRotateCertificatesFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"generation": {
 			Type:        schema.TypeInt,
-			Optional:    true,
+			Required:    true,
 			Description: "Desired certificate rotation generation.",
 		},
 		"services": {

--- a/rancher2/schema_cluster_v2_rke_config_snapshot_create.go
+++ b/rancher2/schema_cluster_v2_rke_config_snapshot_create.go
@@ -1,0 +1,17 @@
+package rancher2
+
+import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+//Types
+
+func clusterV2RKEConfigETCDSnapshotCreateFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"generation": {
+			Type:        schema.TypeInt,
+			Required:    true,
+			Description: "ETCD generation to initiate a snapshot",
+		},
+	}
+
+	return s
+}

--- a/rancher2/schema_cluster_v2_rke_config_snapshot_restore.go
+++ b/rancher2/schema_cluster_v2_rke_config_snapshot_restore.go
@@ -1,0 +1,27 @@
+package rancher2
+
+import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+//Types
+
+func clusterV2RKEConfigETCDSnapshotRestoreFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "ETCD snapshot name to restore",
+		},
+		"generation": {
+			Type:        schema.TypeInt,
+			Required:    true,
+			Description: "ETCD snapshot desired generation",
+		},
+		"restore_rke_config": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "ETCD restore RKE config (set to none, all, or kubernetesVersion)",
+		},
+	}
+
+	return s
+}

--- a/rancher2/structure_cluster_v2_rke_config.go
+++ b/rancher2/structure_cluster_v2_rke_config.go
@@ -43,6 +43,12 @@ func flattenClusterV2RKEConfig(in *provisionv1.RKEConfig) []interface{} {
 	if in.RotateCertificates != nil {
 		obj["rotate_certificates"] = flattenClusterV2RKEConfigRotateCertificates(in.RotateCertificates)
 	}
+	if in.ETCDSnapshotCreate != nil {
+		obj["etcd_snapshot_create"] = flattenClusterV2RKEConfigETCDSnapshotCreate(in.ETCDSnapshotCreate)
+	}
+	if in.ETCDSnapshotRestore != nil {
+		obj["etcd_snapshot_restore"] = flattenClusterV2RKEConfigETCDSnapshotRestore(in.ETCDSnapshotRestore)
+	}
 
 	return []interface{}{obj}
 }
@@ -88,6 +94,12 @@ func expandClusterV2RKEConfig(p []interface{}) *provisionv1.RKEConfig {
 
 	if v, ok := in["rotate_certificates"].([]interface{}); ok && len(v) > 0 {
 		obj.RotateCertificates = expandClusterV2RKEConfigRotateCertificates(v)
+	}
+	if v, ok := in["etcd_snapshot_create"].([]interface{}); ok && len(v) > 0 {
+		obj.ETCDSnapshotCreate = expandClusterV2RKEConfigETCDSnapshotCreate(v)
+	}
+	if v, ok := in["etcd_snapshot_restore"].([]interface{}); ok && len(v) > 0 {
+		obj.ETCDSnapshotRestore = expandClusterV2RKEConfigETCDSnapshotRestore(v)
 	}
 
 	return obj

--- a/rancher2/structure_cluster_v2_rke_config_etcd_snapshot_create.go
+++ b/rancher2/structure_cluster_v2_rke_config_etcd_snapshot_create.go
@@ -1,0 +1,33 @@
+package rancher2
+
+import rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+
+func flattenClusterV2RKEConfigETCDSnapshotCreate(in *rkev1.ETCDSnapshotCreate) []interface{} {
+	if in == nil {
+		return nil
+	}
+
+	obj := make(map[string]interface{})
+
+	if in.Generation > 0 {
+		obj["generation"] = in.Generation
+	}
+
+	return []interface{}{obj}
+}
+
+func expandClusterV2RKEConfigETCDSnapshotCreate(p []interface{}) *rkev1.ETCDSnapshotCreate {
+	if p == nil || len(p) == 0 || p[0] == nil {
+		return nil
+	}
+
+	obj := &rkev1.ETCDSnapshotCreate{}
+
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["generation"].(int); ok && v > 0 {
+		obj.Generation = v
+	}
+
+	return obj
+}

--- a/rancher2/structure_cluster_v2_rke_config_etcd_snapshot_create_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_etcd_snapshot_create_test.go
@@ -1,0 +1,66 @@
+package rancher2
+
+import (
+	"reflect"
+	"testing"
+
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+)
+
+var (
+	testClusterV2RKEConfigETCDSnapshotCreateConf      *rkev1.ETCDSnapshotCreate
+	testClusterV2RKEConfigETCDSnapshotCreateInterface []interface{}
+)
+
+func init() {
+	testClusterV2RKEConfigETCDSnapshotCreateConf = &rkev1.ETCDSnapshotCreate{
+		Generation: 1,
+	}
+
+	testClusterV2RKEConfigETCDSnapshotCreateInterface = []interface{}{
+		map[string]interface{}{
+			"generation": 1,
+		},
+	}
+}
+
+func TestFlattenClusterV2RKEConfigETCDSnapshotCreate(t *testing.T) {
+	cases := []struct {
+		Input          *rkev1.ETCDSnapshotCreate
+		ExpectedOutput []interface{}
+	}{
+		{
+			testClusterV2RKEConfigETCDSnapshotCreateConf,
+			testClusterV2RKEConfigETCDSnapshotCreateInterface,
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenClusterV2RKEConfigETCDSnapshotCreate(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestExpandClusterV2RKEConfigETCDSnapshotCreate(t *testing.T) {
+
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *rkev1.ETCDSnapshotCreate
+	}{
+		{
+			testClusterV2RKEConfigETCDSnapshotCreateInterface,
+			testClusterV2RKEConfigETCDSnapshotCreateConf,
+		},
+	}
+
+	for _, tc := range cases {
+		output := expandClusterV2RKEConfigETCDSnapshotCreate(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}

--- a/rancher2/structure_cluster_v2_rke_config_etcd_snapshot_restore.go
+++ b/rancher2/structure_cluster_v2_rke_config_etcd_snapshot_restore.go
@@ -1,0 +1,45 @@
+package rancher2
+
+import rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+
+func flattenClusterV2RKEConfigETCDSnapshotRestore(in *rkev1.ETCDSnapshotRestore) []interface{} {
+	if in == nil {
+		return nil
+	}
+
+	obj := make(map[string]interface{})
+
+	if len(in.Name) > 0 {
+		obj["name"] = in.Name
+	}
+	if in.Generation > 0 {
+		obj["generation"] = in.Generation
+	}
+	if len(in.RestoreRKEConfig) > 0 {
+		obj["restore_rke_config"] = in.RestoreRKEConfig
+	}
+
+	return []interface{}{obj}
+}
+
+func expandClusterV2RKEConfigETCDSnapshotRestore(p []interface{}) *rkev1.ETCDSnapshotRestore {
+	if p == nil || len(p) == 0 || p[0] == nil {
+		return nil
+	}
+
+	obj := &rkev1.ETCDSnapshotRestore{}
+
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["name"].(string); ok && len(v) > 0 {
+		obj.Name = v
+	}
+	if v, ok := in["generation"].(int); ok && v > 0 {
+		obj.Generation = v
+	}
+	if v, ok := in["restore_rke_config"].(string); ok && len(v) > 0 {
+		obj.RestoreRKEConfig = v
+	}
+
+	return obj
+}

--- a/rancher2/structure_cluster_v2_rke_config_etcd_snapshot_restore_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_etcd_snapshot_restore_test.go
@@ -1,0 +1,70 @@
+package rancher2
+
+import (
+	"reflect"
+	"testing"
+
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+)
+
+var (
+	testClusterV2RKEConfigETCDSnapshotRestoreConf      *rkev1.ETCDSnapshotRestore
+	testClusterV2RKEConfigETCDSnapshotRestoreInterface []interface{}
+)
+
+func init() {
+	testClusterV2RKEConfigETCDSnapshotRestoreConf = &rkev1.ETCDSnapshotRestore{
+		Name:             "SnapshotTestName",
+		Generation:       1,
+		RestoreRKEConfig: "all",
+	}
+
+	testClusterV2RKEConfigETCDSnapshotRestoreInterface = []interface{}{
+		map[string]interface{}{
+			"name":               "SnapshotTestName",
+			"generation":         1,
+			"restore_rke_config": "all",
+		},
+	}
+}
+
+func TestFlattenClusterV2RKEConfigETCDSnapshotRestore(t *testing.T) {
+	cases := []struct {
+		Input          *rkev1.ETCDSnapshotRestore
+		ExpectedOutput []interface{}
+	}{
+		{
+			testClusterV2RKEConfigETCDSnapshotRestoreConf,
+			testClusterV2RKEConfigETCDSnapshotRestoreInterface,
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenClusterV2RKEConfigETCDSnapshotRestore(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestExpandClusterV2RKEConfigETCDSnapshotRestore(t *testing.T) {
+
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *rkev1.ETCDSnapshotRestore
+	}{
+		{
+			testClusterV2RKEConfigETCDSnapshotRestoreInterface,
+			testClusterV2RKEConfigETCDSnapshotRestoreConf,
+		},
+	}
+
+	for _, tc := range cases {
+		output := expandClusterV2RKEConfigETCDSnapshotRestore(tc.Input)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}

--- a/rancher2/structure_cluster_v2_rke_config_z_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_z_test.go
@@ -35,6 +35,8 @@ func init() {
 	testClusterV2RKEConfigConf.Registries = testClusterV2RKEConfigRegistryConf
 	testClusterV2RKEConfigConf.ETCD = testClusterV2RKEConfigETCDConf
 	testClusterV2RKEConfigConf.RotateCertificates = testClusterV2RKEConfigRotateCertificatesConf
+	testClusterV2RKEConfigConf.ETCDSnapshotCreate = testClusterV2RKEConfigETCDSnapshotCreateConf
+	testClusterV2RKEConfigConf.ETCDSnapshotRestore = testClusterV2RKEConfigETCDSnapshotRestoreConf
 
 	testClusterV2RKEConfigInterface = []interface{}{
 		map[string]interface{}{
@@ -47,6 +49,8 @@ func init() {
 			"registries":              testClusterV2RKEConfigRegistryInterface,
 			"etcd":                    testClusterV2RKEConfigETCDInterface,
 			"rotate_certificates":     testClusterV2RKEConfigRotateCertificatesInterface,
+			"etcd_snapshot_create":    testClusterV2RKEConfigETCDSnapshotCreateInterface,
+			"etcd_snapshot_restore":   testClusterV2RKEConfigETCDSnapshotRestoreInterface,
 		},
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/rancher/terraform-provider-rancher2/issues/872 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable.  If this is a new feature describe why we need this feature and how it will be used. -->

Implement rke2/k3s etcd snapshot create and restore in terraform.

## Solution
 
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Added the following functionality to rke2/k3s v2 provisioning
* `etcd_snapshot_create` (generation) - creates a snapshot of the cluster's etcd db
* `etcd_snapshot_restore` (name, generation, rke_restore_config) - restores the cluster to the snapshot specified in the `name` field
* Update terraform docs

So now, if you add `etcd_snapshot_create` or `etcd_snapshot_restore` to the `rke_config` field in a terraform config file, terraform will pass that RKE configuration to Rancher and it will be set on the cluster object spec. When Rancher checks for config updates, it will kick off/restore to a snapshot.

```
etcd_snapshot_create {
  generation = 2
}
```
 
```
etcd_snapshot_restore {
  name = "ablender-rke2-downstream-on-demand-ip-172-31-31-249.us-ea-dcf6b"
  generation = 1
}
```

## Testing
 
<!-- Describe what, if any, testing you did.  If you added tests describe what cases they cover and do not cover. -->

Test steps
* Tested on rainbow cluster `rancher 2.6-head`
* Provision an rke2 3 node cluster in AWS EC2 via terraform
* Test `Take Snapshot` Now button to make sure that snapshots work. Use rke2 version `v1.22.9-rc4+rke2r1.` I did not see snapshots appear before this version.
* Add deployment/pod
* Add etcd snapshot create to terraform config, run `terraform apply` to create snapshot
* Remove deployment/pod
* Add etcd snapshot restore to terraform config, run `terraform apply` to restore to the previous snapshot. Verify that your data is restored.