### PR TITLE
Add token support to rancher2_user resource

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -26,6 +26,20 @@ resource "rancher2_global_role_binding" "foo" {
 }
 ```
 
+```hcl
+# Create a new rancher2 User with Token
+resource "rancher2_user" "foo" {
+  name = "Foo user"
+  username = "foo"
+  password = "changeme"
+  enabled = true
+  token_config {
+    description = "Token for user Foo"
+    ttl = 18000
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -35,7 +49,7 @@ The following arguments are supported:
 * `name` - (Optional) The user full name (string)
 * `annotations` - (Optional/Computed) Annotations for global role binding (map)
 * `labels` - (Optional/Computed) Labels for global role binding (map)
-
+* `token_config` - (Optional) The config for a token to generate. This automatically adds a `user-base` global role binding. (list maxitems:1)
 
 ## Attributes Reference
 
@@ -43,6 +57,27 @@ The following attributes are exported:
 
 * `id` - (Computed) The ID of the resource (string)
 * `principal_ids` - (Computed) The user principal IDs (list)
+* `login_role_binding_id` - (Computed) The ID of the login role binding resource (string)
+* `access_key` - (Computed) Token access key part (string)
+* `auth_token` - (Computed/Sensitive) Token value (string)
+* `secret_key` - (Computed/Sensitive) Token secret key part (string)
+* `token_enabled` - (Computed) Token is enabled (bool)
+* `token_expired` - (Computed) Token is expired (bool)
+* `token_id` - (Computed) The ID of the token resource (string)
+* `token_name` - (Computed) Token name (string)
+* `temp_token` - (Computed/Sensitive) Generated API temporary token as helper. Should be empty (string)
+* `temp_token_id` - (Computed) Generated API temporary token id as helper. Should be empty (string)
+
+## Nested blocks
+
+### `token_config`
+
+#### Arguments
+
+* `cluster_id` - (Optional) Cluster ID for scoped token (string)
+* `description` - (Optional) Token description (string)
+* `renew` - (Optional) Renew token if expired or disabled. If `true`, a terraform diff would be generated to renew the token if it's disabled or expired. If `false`, the token will not be renewed. Default `true` (bool)
+* `ttl` - (Optional) Token time to live in seconds. Default `0` (int) 
 
 ## Timeouts
 
@@ -55,7 +90,7 @@ The following attributes are exported:
 
 ## Import
 
-Users can be imported using the Rancher User ID
+Users can be imported using the Rancher User ID (note: a token cannot be imported)
 
 ```
 $ terraform import rancher2_user.foo &lt;user_id&gt;

--- a/rancher2/resource_rancher2_user.go
+++ b/rancher2/resource_rancher2_user.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	norman "github.com/rancher/norman/types"
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 )
 
@@ -19,8 +20,8 @@ func resourceRancher2User() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceRancher2UserImport,
 		},
-
-		Schema: userFields(),
+		CustomizeDiff: userTokenComputedIf(userTokenFieldsList),
+		Schema:        userFields(),
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(5 * time.Minute),
@@ -60,7 +61,97 @@ func resourceRancher2UserCreate(d *schema.ResourceData, meta interface{}) error 
 			"[ERROR] waiting for user (%s) to be created: %s", newUser.ID, waitErr)
 	}
 
+	if v, ok := d.Get("token_config").([]interface{}); ok && len(v) > 0 {
+		patch, err := meta.(*Config).IsRancherVersionGreaterThanOrEqualAndLessThan(rancher2TokeTTLMinutesVersion, rancher2TokeTTLMilisVersion)
+		if err != nil {
+			return err
+		}
+
+		if token := expandUserToken(d, patch); token != nil {
+			err = resourceRancher2UserCreateLoginBinding(d, client)
+			if err != nil {
+				return err
+			}
+
+			userClient, err := getClientForUser(d, meta)
+			if err != nil {
+				return err
+			}
+			defer doUserLogout(d, userClient)
+
+			err = resourceRancher2UserRecreateToken(d, meta, userClient, token)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return resourceRancher2UserRead(d, meta)
+}
+
+func resourceRancher2UserCreateLoginBinding(d *schema.ResourceData, client *managementClient.Client) error {
+	log.Printf("[INFO] Creating login Role Binding for User %s", d.Id())
+	newLoginRoleBinding, err := client.GlobalRoleBinding.Create(&managementClient.GlobalRoleBinding{
+		GlobalRoleID: "user-base",
+		UserID:       d.Id(),
+	})
+	if err != nil {
+		return err
+	}
+
+	d.Set("login_role_binding_id", newLoginRoleBinding.ID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"active"},
+		Target:     []string{"active"},
+		Refresh:    globalRoleBindingStateRefreshFunc(client, newLoginRoleBinding.ID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      1 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, waitErr := stateConf.WaitForState()
+	if waitErr != nil {
+		return fmt.Errorf(
+			"[ERROR] waiting for login role binding (%s) to be created: %s", newLoginRoleBinding.ID, waitErr)
+	}
+
+	return nil
+}
+
+func resourceRancher2UserRecreateToken(d *schema.ResourceData, meta interface{}, client *managementClient.Client, token *managementClient.Token) error {
+	// Delete current token, if exists
+	if v, ok := d.Get("token_id").(string); ok && len(v) > 0 {
+		log.Printf("[DEBUG] Removing token %s from user %s", v, d.Id())
+		currentToken, err := client.Token.ByID(v)
+		if err != nil {
+			if IsNotFound(err) {
+				clearUserTokenFields(d)
+			} else {
+				return err
+			}
+		}
+
+		err = client.Token.Delete(currentToken)
+		if err != nil {
+			return nil
+		}
+
+		clearUserTokenFields(d)
+	}
+
+	newToken, err := client.Token.Create(token)
+	if err != nil {
+		return fmt.Errorf("[ERROR] Creating User token: %s", err)
+	}
+
+	d.Set("token_id", newToken.ID)
+
+	patch, err := meta.(*Config).IsRancherVersionGreaterThanOrEqualAndLessThan(rancher2TokeTTLMinutesVersion, rancher2TokeTTLMilisVersion)
+	if err != nil {
+		return err
+	}
+
+	return flattenUserToken(d, newToken, patch)
 }
 
 func resourceRancher2UserRead(d *schema.ResourceData, meta interface{}) error {
@@ -80,7 +171,42 @@ func resourceRancher2UserRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	if v, ok := d.Get("token_id").(string); ok && len(v) > 0 {
+		userClient, err := getClientForUser(d, meta)
+		if err != nil {
+			return err
+		}
+		defer doUserLogout(d, userClient)
+
+		err = resourceRancher2UserTokenRead(d, meta, userClient)
+		if err != nil {
+			return err
+		}
+	}
+
 	return flattenUser(d, user)
+}
+
+func resourceRancher2UserTokenRead(d *schema.ResourceData, meta interface{}, client *managementClient.Client) error {
+	tokenID := d.Get("token_id").(string)
+	log.Printf("[INFO] Refreshing Token ID %s for User %s", tokenID, d.Id())
+
+	token, err := client.Token.ByID(tokenID)
+	if err != nil {
+		if IsNotFound(err) || IsForbidden(err) {
+			log.Printf("[INFO] Token ID %s not found.", tokenID)
+			clearUserTokenFields(d)
+			return nil
+		}
+		return err
+	}
+
+	patch, err := meta.(*Config).IsRancherVersionGreaterThanOrEqualAndLessThan(rancher2TokeTTLMinutesVersion, rancher2TokeTTLMilisVersion)
+	if err != nil {
+		return err
+	}
+
+	return flattenUserToken(d, token, patch)
 }
 
 func resourceRancher2UserUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -127,7 +253,103 @@ func resourceRancher2UserUpdate(d *schema.ResourceData, meta interface{}) error 
 			"[ERROR] waiting for user (%s) to be updated: %s", newUser.ID, waitErr)
 	}
 
+	if v, ok := d.Get("token_config").([]interface{}); ok && len(v) > 0 {
+		err := recreateUserTokenIfNecessary(d, meta)
+		if err != nil {
+			return err
+		}
+	} else if v, ok := d.Get("token_id").(string); ok && len(v) > 0 {
+		err := deleteUserToken(d, meta)
+		if err != nil {
+			return err
+		}
+	}
+
 	return resourceRancher2UserRead(d, meta)
+}
+
+func recreateUserTokenIfNecessary(d *schema.ResourceData, meta interface{}) error {
+	hasChange := d.HasChange("token_config")
+	renewTokenIfNecessary := d.Get("token_config.0.renew").(bool)
+
+	if hasChange || renewTokenIfNecessary {
+		client, err := getClientForUser(d, meta)
+		if err != nil {
+			return err
+		}
+		defer doUserLogout(d, client)
+
+		expiredToken := false
+		if !hasChange && renewTokenIfNecessary {
+			expiredToken, err = isUserTokenExpired(client, d.Get("token_id").(string))
+			if err != nil {
+				return err
+			}
+		}
+
+		if hasChange || expiredToken {
+			log.Printf("[INFO] Recreating Token for User ID %s (change=%v, renew=%v, expired=%v)", d.Id(), hasChange, renewTokenIfNecessary, expiredToken)
+
+			patch, err := meta.(*Config).IsRancherVersionGreaterThanOrEqualAndLessThan(rancher2TokeTTLMinutesVersion, rancher2TokeTTLMilisVersion)
+			if err != nil {
+				return err
+			}
+
+			token := expandUserToken(d, patch)
+
+			err = resourceRancher2UserRecreateToken(d, meta, client, token)
+			if err != nil {
+				return err
+			}
+
+			return resourceRancher2UserTokenRead(d, meta, client)
+		}
+	}
+
+	return nil
+}
+
+func isUserTokenExpired(client *managementClient.Client, id string) (bool, error) {
+	if len(id) == 0 {
+		return true, nil
+	}
+
+	token, err := client.Token.ByID(id)
+	if err != nil {
+		if IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+
+	return token.Expired, nil
+}
+
+func deleteUserToken(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Deleting Token ID %s", d.Get("token_id").(string))
+	client, err := getClientForUser(d, meta)
+	if err != nil {
+		return err
+	}
+	defer doUserLogout(d, client)
+
+	token, err := client.Token.ByID(d.Get("token_id").(string))
+	if err != nil {
+		if IsNotFound(err) {
+			clearUserTokenFields(d)
+			return nil
+		}
+		return err
+	}
+
+	err = client.Token.Delete(token)
+	if err != nil {
+		return err
+	}
+
+	clearUserTokenFields(d)
+
+	return nil
 }
 
 func resourceRancher2UserDelete(d *schema.ResourceData, meta interface{}) error {
@@ -186,4 +408,74 @@ func userStateRefreshFunc(client *managementClient.Client, userID string) resour
 		}
 		return obj, obj.State, nil
 	}
+}
+
+func getClientForUser(d *schema.ResourceData, meta interface{}) (*managementClient.Client, error) {
+	if v, ok := d.Get("temp_token").(string); ok && len(v) > 0 {
+		client, err := newManagementClient(meta, v)
+		if err != nil {
+			if IsNotFound(err) || IsUnauthorized(err) || IsForbidden(err) {
+				d.Set("temp_token_id", "")
+				d.Set("temp_token", "")
+				return doUserLogin(d, meta)
+			}
+			return nil, err
+		}
+
+		return client, nil
+	}
+
+	return doUserLogin(d, meta)
+}
+
+func newManagementClient(meta interface{}, token string) (*managementClient.Client, error) {
+	options := meta.(*Config).CreateClientOpts()
+	options.URL = options.URL + rancher2ClientAPIVersion
+	options.TokenKey = token
+	return managementClient.NewClient(options)
+}
+
+func doUserLogin(d *schema.ResourceData, meta interface{}) (*managementClient.Client, error) {
+	log.Printf("[DEBUG] Creating Temp Token for User %s", d.Id())
+	tempTokenID, tempTokenValue, err := DoUserLogin(meta.(*Config).URL, d.Get("username").(string), d.Get("password").(string), "0", "Temp Terraform API token", meta.(*Config).CACerts, meta.(*Config).Insecure)
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Login with %s user: %v", d.Id(), err)
+	}
+
+	d.Set("temp_token_id", tempTokenID)
+	d.Set("temp_token", tempTokenValue)
+
+	return newManagementClient(meta, tempTokenValue)
+}
+
+func doUserLogout(d *schema.ResourceData, client *managementClient.Client) error {
+	if v, ok := d.Get("temp_token_id").(string); ok && len(v) > 0 {
+		log.Printf("[DEBUG] Deleting Temp Token for User %s", d.Id())
+		existing := &norman.Resource{
+			ID: v,
+			Actions: map[string]string{
+				"logout": client.Opts.URL + "/tokens?action=logout",
+			},
+		}
+
+		err := client.APIBaseClient.Action("token", "logout", existing, map[string]interface{}{}, nil)
+		if err != nil {
+			return err
+		}
+
+		d.Set("temp_token_id", "")
+		d.Set("temp_token", "")
+	}
+
+	return nil
+}
+
+func clearUserTokenFields(d *schema.ResourceData) {
+	d.Set("token_id", "")
+	d.Set("token_name", "")
+	d.Set("token_enabled", false)
+	d.Set("token_expired", true)
+	d.Set("auth_token", "")
+	d.Set("access_key", "")
+	d.Set("secret_key", "")
 }

--- a/rancher2/resource_rancher2_user_test.go
+++ b/rancher2/resource_rancher2_user_test.go
@@ -2,11 +2,14 @@ package rancher2
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/rancher/norman/types"
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 )
 
@@ -15,8 +18,10 @@ const (
 )
 
 var (
-	testAccRancher2User       string
-	testAccRancher2UserUpdate string
+	testAccRancher2User, testAccRancher2UserUpdate                   string
+	testAccRancher2UserWithToken, testAccRancher2UserWithTokenUpdate string
+
+	token *managementClient.Token
 )
 
 func init() {
@@ -28,6 +33,18 @@ resource "` + testAccRancher2UserType + `" "foo" {
   enabled = true
 }
 `
+	testAccRancher2UserWithToken = `
+resource "` + testAccRancher2UserType + `" "foo" {
+  name = "Terraform user acceptance test"
+  username = "foo"
+  password = "TestACC123456"
+  enabled = true
+  token_config {
+	description = "foo"
+	ttl = 120000
+  }
+}
+`
 	testAccRancher2UserUpdate = `
 resource "` + testAccRancher2UserType + `" "foo" {
   name = "Terraform user acceptance test - Updated"
@@ -35,7 +52,19 @@ resource "` + testAccRancher2UserType + `" "foo" {
   password = "TestACC1234567"
   enabled = false
 }
- `
+`
+	testAccRancher2UserWithTokenUpdate = `
+ resource "` + testAccRancher2UserType + `" "foo" {
+   name = "Terraform user acceptance test"
+   username = "foo"
+   password = "TestACC123456"
+   enabled = true
+   token_config {
+	 description = "foo"
+	 ttl = 240000
+   }
+ }
+`
 }
 
 func TestAccRancher2User_basic(t *testing.T) {
@@ -52,6 +81,7 @@ func TestAccRancher2User_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "name", "Terraform user acceptance test"),
 					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "password", "TestACC123456"),
 					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "enabled", "true"),
+					resource.TestCheckNoResourceAttr(testAccRancher2UserType+".foo", "token_id"),
 				),
 			},
 			{
@@ -70,6 +100,53 @@ func TestAccRancher2User_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "name", "Terraform user acceptance test"),
 					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "password", "TestACC123456"),
 					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRancher2User_token(t *testing.T) {
+	var user *managementClient.User
+
+	tokenNameCheck, _ := regexp.Compile("token-\\w+")
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2UserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRancher2UserWithToken,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2UserExists(testAccRancher2UserType+".foo", user),
+					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "name", "Terraform user acceptance test"),
+					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "password", "TestACC123456"),
+					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "enabled", "true"),
+					testAccCheckRancher2UserToken(testAccRancher2UserType+".foo"),
+					resource.TestMatchResourceAttr(testAccRancher2UserType+".foo", "token_name", tokenNameCheck),
+					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "token_enabled", "true"),
+					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "token_expired", "false"),
+					resource.TestCheckResourceAttrSet(testAccRancher2UserType+".foo", "auth_token"),
+					resource.TestCheckResourceAttrSet(testAccRancher2UserType+".foo", "access_key"),
+					resource.TestCheckResourceAttrSet(testAccRancher2UserType+".foo", "secret_key"),
+				),
+			},
+			{
+				Config: testAccRancher2UserWithTokenUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2UserExists(testAccRancher2UserType+".foo", user),
+					testAccCheckRancher2UserTokenChanged(testAccRancher2UserType+".foo"),
+				),
+			},
+			{
+				Config: testAccRancher2User,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2UserExists(testAccRancher2UserType+".foo", user),
+					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "token_id", ""),
+					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "token_name", ""),
+					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "auth_token", ""),
+					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "access_key", ""),
+					resource.TestCheckResourceAttr(testAccRancher2UserType+".foo", "secret_key", ""),
 				),
 			},
 		},
@@ -165,6 +242,66 @@ func testAccCheckRancher2UserExists(n string, pro *managementClient.User) resour
 		}
 
 		pro = foundPro
+
+		return nil
+	}
+}
+
+func testAccCheckRancher2UserToken(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.Attributes["token_id"] == "" {
+			return fmt.Errorf("No Token ID is set")
+		}
+
+		token = &managementClient.Token{
+			Resource: types.Resource{
+				ID: rs.Primary.Attributes["token_id"],
+			},
+			Name:  rs.Primary.Attributes["token_name"],
+			Token: rs.Primary.Attributes["auth_token"],
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckRancher2UserTokenChanged(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.Attributes["token_id"] == "" {
+			return fmt.Errorf("No Token ID is set")
+		}
+
+		if rs.Primary.Attributes["token_id"] == token.ID {
+			return fmt.Errorf("Token ID has not changed")
+		}
+
+		if rs.Primary.Attributes["token_name"] == token.Name {
+			return fmt.Errorf("Token name has not changed")
+		}
+
+		if rs.Primary.Attributes["auth_token"] == token.Token {
+			return fmt.Errorf("Token value has not changed")
+		}
+
+		key := strings.Split(token.Token, ":")
+		if rs.Primary.Attributes["access_key"] == key[0] {
+			return fmt.Errorf("Token access key has not changed")
+		}
+		if rs.Primary.Attributes["secret_key"] == key[1] {
+			return fmt.Errorf("Token secret key has not changed")
+		}
 
 		return nil
 	}

--- a/rancher2/schema_user.go
+++ b/rancher2/schema_user.go
@@ -1,10 +1,43 @@
 package rancher2
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+var (
+	userTokenFieldsList = []string{"token_id", "token_name", "token_enabled", "token_expired", "auth_token", "access_key", "secret_key"}
+)
+
 //Schemas
+
+func userTokenConfigFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"cluster_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Cluster ID for scoped token",
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Token description",
+		},
+		"ttl": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Default:     0,
+			Description: "Token time to live in seconds",
+		},
+		"renew": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Renew expired or disabled token",
+		},
+	}
+	return s
+}
 
 func userFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
@@ -34,6 +67,65 @@ func userFields() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
+		"temp_token": {
+			Type:      schema.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+		"temp_token_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"login_role_binding_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"token_config": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "",
+			Elem: &schema.Resource{
+				Schema: userTokenConfigFields(),
+			},
+		},
+		"token_id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Token ID",
+		},
+		"token_name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Token name",
+		},
+		"token_enabled": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Token enabled",
+		},
+		"token_expired": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Token expired",
+		},
+		"auth_token": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Sensitive:   true,
+			Description: "Token value",
+		},
+		"access_key": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Token access key",
+		},
+		"secret_key": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Sensitive:   true,
+			Description: "Token secret key",
+		},
 	}
 
 	for k, v := range commonAnnotationLabelFields() {
@@ -41,4 +133,39 @@ func userFields() map[string]*schema.Schema {
 	}
 
 	return s
+}
+
+// Diffs
+func userTokenComputedIf(keys []string) schema.CustomizeDiffFunc {
+	diffs := make([]schema.CustomizeDiffFunc, 0, 7)
+	for _, k := range keys {
+		diffs = append(diffs, customdiff.ComputedIf(k, userTokenComputedConditionFunc()))
+	}
+	return customdiff.All(diffs...)
+}
+
+func userTokenComputedConditionFunc() customdiff.ResourceConditionFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) bool {
+		if v, ok := d.Get("token_config").([]interface{}); ok && len(v) == 0 {
+			return false
+		}
+
+		if d.HasChange("token_config") {
+			return true
+		}
+
+		if r, ok := d.Get("token_config.0.renew").(bool); ok && r {
+			if v, ok := d.Get("token_expired").(bool); ok && v {
+				return true
+			}
+		}
+
+		if v, ok := d.Get("token_config").([]interface{}); ok && len(v) > 0 {
+			if v, ok := d.Get("token_id").([]interface{}); ok && len(v) == 0 {
+				return true
+			}
+		}
+
+		return false
+	}
 }

--- a/rancher2/structure_user.go
+++ b/rancher2/structure_user.go
@@ -1,6 +1,9 @@
 package rancher2
 
 import (
+	"math"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 )
@@ -36,7 +39,47 @@ func flattenUser(d *schema.ResourceData, in *managementClient.User) error {
 	}
 
 	return nil
+}
 
+func flattenUserToken(d *schema.ResourceData, in *managementClient.Token, patch bool) error {
+	if in == nil {
+		return nil
+	}
+
+	d.Set("token_id", in.ID)
+
+	if len(in.ClusterID) > 0 {
+		d.Set("token_config.0.cluster_id", in.ClusterID)
+	}
+
+	if len(in.Description) > 0 {
+		d.Set("token_config.0.description", in.Description)
+	}
+
+	if in.Enabled != nil {
+		d.Set("token_enabled", *in.Enabled)
+	}
+
+	d.Set("token_expired", in.Expired)
+
+	if len(in.Name) > 0 {
+		d.Set("token_name", in.Name)
+	}
+
+	if len(in.Token) > 0 {
+		d.Set("auth_token", in.Token)
+		key := strings.Split(in.Token, ":")
+		d.Set("access_key", key[0])
+		d.Set("secret_key", key[1])
+	}
+
+	if in.TTLMillis >= 1000 {
+		if !patch {
+			d.Set("token_config.0.ttl", int(in.TTLMillis/1000))
+		}
+	}
+
+	return nil
 }
 
 // Expanders
@@ -73,4 +116,40 @@ func expandUser(in *schema.ResourceData) *managementClient.User {
 	}
 
 	return obj
+}
+
+func expandUserToken(in *schema.ResourceData, patch bool) *managementClient.Token {
+	if in == nil {
+		return nil
+	}
+
+	if v, ok := in.Get("token_config").([]interface{}); ok && len(v) > 0 {
+		obj := &managementClient.Token{}
+
+		if v, ok := in.Get("token_id").(string); ok && len(v) > 0 {
+			obj.ID = v
+		}
+
+		if v, ok := in.Get("token_config.0.cluster_id").(string); ok && len(v) > 0 {
+			obj.ClusterID = v
+		}
+
+		if v, ok := in.Get("token_config.0.description").(string); ok && len(v) > 0 {
+			obj.Description = v
+		}
+
+		if v, ok := in.Get("token_config.0.ttl").(int); ok && v > 0 {
+			if patch {
+				// Rancher v2.4.6 ttl is read in minutes from API
+				mins := math.Round(float64(v / 60))
+				obj.TTLMillis = int64(mins)
+			} else {
+				obj.TTLMillis = int64(v * 1000)
+			}
+		}
+
+		return obj
+	}
+
+	return nil
 }

--- a/rancher2/structure_user_test.go
+++ b/rancher2/structure_user_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	testUserConf      *managementClient.User
-	testUserInterface map[string]interface{}
+	testUserConf                                                                   *managementClient.User
+	testFlattenUserTokenConf, testExpandUserTokenConf                              *managementClient.Token
+	testUserInterface, testFlattenUserTokenInterface, testExpandUserTokenInterface map[string]interface{}
 )
 
 func init() {
@@ -23,6 +24,34 @@ func init() {
 		"name":     "name",
 		"username": "username",
 		"enabled":  true,
+	}
+	testFlattenUserTokenConf = &managementClient.Token{
+		Enabled: newTrue(),
+		Expired: false,
+		Name:    "token-99999",
+		Token:   "token-99999:very_secret_key",
+	}
+	testFlattenUserTokenInterface = map[string]interface{}{
+		"token_enabled": true,
+		"token_expired": false,
+		"token_name":    "token-99999",
+		"auth_token":    "token-99999:very_secret_key",
+		"access_key":    "token-99999",
+		"secret_key":    "very_secret_key",
+	}
+	testExpandUserTokenConf = &managementClient.Token{
+		Description: "foo",
+		TTLMillis:   60000,
+		ClusterID:   "c-99999",
+	}
+	testExpandUserTokenInterface = map[string]interface{}{
+		"token_config": []interface{}{
+			map[string]interface{}{
+				"ttl":         60,
+				"description": "foo",
+				"cluster_id":  "c-99999",
+			},
+		},
 	}
 }
 
@@ -70,6 +99,57 @@ func TestExpandUser(t *testing.T) {
 	for _, tc := range cases {
 		inputResourceData := schema.TestResourceDataRaw(t, userFields(), tc.Input)
 		output := expandUser(inputResourceData)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
+				tc.ExpectedOutput, output)
+		}
+	}
+}
+
+func TestFlattenUserToken(t *testing.T) {
+
+	cases := []struct {
+		Input          *managementClient.Token
+		ExpectedOutput map[string]interface{}
+	}{
+		{
+			testFlattenUserTokenConf,
+			testFlattenUserTokenInterface,
+		},
+	}
+
+	for _, tc := range cases {
+		output := schema.TestResourceDataRaw(t, userFields(), map[string]interface{}{})
+		err := flattenUserToken(output, tc.Input, false)
+		if err != nil {
+			t.Fatalf("[ERROR] on flattener: %#v", err)
+		}
+		expectedOutput := map[string]interface{}{}
+		for k := range tc.ExpectedOutput {
+			expectedOutput[k] = output.Get(k)
+		}
+		if !reflect.DeepEqual(expectedOutput, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
+				expectedOutput, output)
+		}
+	}
+}
+
+func TestExpandUserToken(t *testing.T) {
+
+	cases := []struct {
+		Input          map[string]interface{}
+		ExpectedOutput *managementClient.Token
+	}{
+		{
+			testExpandUserTokenInterface,
+			testExpandUserTokenConf,
+		},
+	}
+
+	for _, tc := range cases {
+		inputResourceData := schema.TestResourceDataRaw(t, userFields(), tc.Input)
+		output := expandUserToken(inputResourceData, false)
 		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
 			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
 				tc.ExpectedOutput, output)

--- a/rancher2/util.go
+++ b/rancher2/util.go
@@ -193,7 +193,7 @@ func DoUserLogin(url, user, pass, ttl, desc, cacert string, insecure bool) (stri
 	}
 
 	if loginResp["type"].(string) != "token" || loginResp["token"] == nil {
-		return "", "", fmt.Errorf("Doing  user logging: %s %s", loginResp["type"].(string), loginResp["code"].(string))
+		return "", "", fmt.Errorf("Doing user login: %s %s", loginResp["type"].(string), loginResp["code"].(string))
 	}
 
 	return loginResp["id"].(string), loginResp["token"].(string), nil
@@ -357,6 +357,16 @@ func IsForbidden(err error) bool {
 	}
 
 	return apiError.StatusCode == http.StatusForbidden
+}
+
+// IsUnauthorized checks if the given APIError is a Unauthorized HTTP statuscode
+func IsUnauthorized(err error) bool {
+	apiError, ok := err.(*clientbase.APIError)
+	if !ok {
+		return false
+	}
+
+	return apiError.StatusCode == http.StatusUnauthorized
 }
 
 // IsNotAllowed checks if the given APIError is a Method Not Allowed HTTP statuscode


### PR DESCRIPTION
See rancher/terraform-provider-rancher2#315 for different use-cases.

The rancher2_user resource has the username/password which are required to do a 'login' and get an initial token. The ttl of this token is set to the 'auth-user-session-ttl-minutes'' by Rancher, regardless of any ttl in thr login request. So the 'login' token is used temporarily to make an api call to the token endpoint to create the token returned by the resource with the defined ttl. This also allows to create cluster scoped tokens.

The rancher2_token resource can only generate tokens for the api account used to authenticate the tf provider. The tf provider does not accept username/password as authentication, but if it did generating tokens for multiple users would create a sprawl of providers.

fixes rancher/terraform-provider-rancher2#315

TODO:
- test cases