### PR TITLE
[Docs] Remove keypair_name for amazonec2_config

### DIFF
--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -265,7 +265,6 @@ The following attributes are exported:
 * `image_name` - (Required+) OpenStack image name to use for the instance. Conflicts with `image_id` (string)
 * `insecure` - (Optional) Disable TLS credential checking. Default `false` (bool)
 * `ip_version` - (Optional) OpenStack version of IP address assigned for the machine Default `4` (string)
-* `keypair_name` - (Optional) OpenStack keypair to use to SSH to the instance (string)
 * `net_id` - (Required+) OpenStack network id the machine will be connected on. Conflicts with `net_name` (string)
 * `net_name` - (Required+) OpenStack network name the machine will be connected on. Conflicts with `net_id` (string)
 * `nova_network` - (Optional) Use the nova networking services instead of neutron (string)

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -131,7 +131,6 @@ The following attributes are exported:
 * `iam_instance_profile` - (Optional) AWS IAM Instance Profile (string)
 * `insecure_transport` - (Optional) Disable SSL when sending requests (bool)
 * `instance_type` - (Optional) AWS instance type. Default `t3a.medium` (string)
-* `keypair_name` - (Optional) AWS keypair to use; requires --amazonec2-ssh-keypath (string)
 * `kms_key` - (Optional) Custom KMS key ID using the AWS Managed CMK (string)
 * `monitoring` - (Optional) Set this flag to enable CloudWatch monitoring. Deafult `false` (bool)
 * `open_port` - (Optional) Make the specified port number accessible from the Internet. (list)

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -385,7 +385,6 @@ The following attributes are exported:
 * `image_name` - (Required*) OpenStack image name to use for the instance. Conflicts with `image_id` (string)
 * `insecure` - (Optional) Disable TLS credential checking. Default `false` (bool)
 * `ip_version` - (Optional) OpenStack version of IP address assigned for the machine Default `4` (string)
-* `keypair_name` - (Optional) OpenStack keypair to use to SSH to the instance (string)
 * `net_id` - (Required*) OpenStack network id the machine will be connected on. Conflicts with `net_name` (string)
 * `net_name` - (Required*) OpenStack network name the machine will be connected on. Conflicts with `net_id` (string)
 * `nova_network` - (Optional) Use the nova networking services instead of neutron (string)

--- a/rancher2/schema_machine_config_v2_amazonec2.go
+++ b/rancher2/schema_machine_config_v2_amazonec2.go
@@ -96,11 +96,6 @@ func machineConfigV2Amazonec2Fields() map[string]*schema.Schema {
 			Default:     "t3a.medium",
 			Description: "AWS instance type",
 		},
-		"keypair_name": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "AWS keypair to use; requires --amazonec2-ssh-keypath",
-		},
 		"kms_key": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/rancher2/schema_machine_config_v2_openstack.go
+++ b/rancher2/schema_machine_config_v2_openstack.go
@@ -80,10 +80,6 @@ func machineConfigV2OpenstackFields() map[string]*schema.Schema {
 			Optional: true,
 			Default:  "4",
 		},
-		"keypair_name": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
 		"net_id": {
 			Type:     schema.TypeString,
 			Optional: true,

--- a/rancher2/schema_node_template_amazonec2.go
+++ b/rancher2/schema_node_template_amazonec2.go
@@ -22,7 +22,6 @@ type amazonec2Config struct {
 	IamInstanceProfile      string   `json:"iamInstanceProfile,omitempty" yaml:"iamInstanceProfile,omitempty"`
 	InsecureTransport       bool     `json:"insecureTransport,omitempty" yaml:"insecureTransport,omitempty"`
 	InstanceType            string   `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
-	KeypairName             string   `json:"keypairName,omitempty" yaml:"keypairName,omitempty"`
 	KmsKey                  string   `json:"kmsKey,omitempty" yaml:"kmsKey,omitempty"`
 	Monitoring              bool     `json:"monitoring,omitempty" yaml:"monitoring,omitempty"`
 	OpenPort                []string `json:"openPort,omitempty" yaml:"openPort,omitempty"`
@@ -140,11 +139,6 @@ func amazonec2ConfigFields() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     "t2.micro",
 			Description: "AWS instance type",
-		},
-		"keypair_name": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "AWS keypair to use; requires --amazonec2-ssh-keypath",
 		},
 		"kms_key": {
 			Type:        schema.TypeString,

--- a/rancher2/schema_node_template_openstack.go
+++ b/rancher2/schema_node_template_openstack.go
@@ -127,10 +127,6 @@ func openstackConfigFields() map[string]*schema.Schema {
 			Optional: true,
 			Default:  "4",
 		},
-		"keypair_name": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
 		"net_id": {
 			Type:     schema.TypeString,
 			Optional: true,

--- a/rancher2/structure_machine_config_v2_amazonec2.go
+++ b/rancher2/structure_machine_config_v2_amazonec2.go
@@ -28,7 +28,6 @@ type machineConfigV2Amazonec2 struct {
 	IamInstanceProfile      string   `json:"iamInstanceProfile,omitempty" yaml:"iamInstanceProfile,omitempty"`
 	InsecureTransport       bool     `json:"insecureTransport,omitempty" yaml:"insecureTransport,omitempty"`
 	InstanceType            string   `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
-	KeypairName             string   `json:"keypairName,omitempty" yaml:"keypairName,omitempty"`
 	KmsKey                  string   `json:"kmsKey,omitempty" yaml:"kmsKey,omitempty"`
 	Monitoring              bool     `json:"monitoring,omitempty" yaml:"monitoring,omitempty"`
 	OpenPort                []string `json:"openPort,omitempty" yaml:"openPort,omitempty"`
@@ -100,10 +99,6 @@ func flattenMachineConfigV2Amazonec2(in *MachineConfigV2Amazonec2) []interface{}
 
 	if len(in.InstanceType) > 0 {
 		obj["instance_type"] = in.InstanceType
-	}
-
-	if len(in.KeypairName) > 0 {
-		obj["keypair_name"] = in.KeypairName
 	}
 
 	if len(in.KmsKey) > 0 {
@@ -239,10 +234,6 @@ func expandMachineConfigV2Amazonec2(p []interface{}, source *MachineConfigV2) *M
 
 	if v, ok := in["instance_type"].(string); ok && len(v) > 0 {
 		obj.InstanceType = v
-	}
-
-	if v, ok := in["keypair_name"].(string); ok && len(v) > 0 {
-		obj.KeypairName = v
 	}
 
 	if v, ok := in["kms_key"].(string); ok && len(v) > 0 {

--- a/rancher2/structure_machine_config_v2_openstack.go
+++ b/rancher2/structure_machine_config_v2_openstack.go
@@ -90,7 +90,6 @@ func flattenMachineConfigV2Openstack(in *MachineConfigV2Openstack) []interface{}
 	obj["image_name"] = in.ImageName
 	obj["insecure"] = in.Insecure
 	obj["ip_version"] = in.IPVersion
-	obj["keypair_name"] = in.KeypairName
 	obj["net_id"] = in.NetID
 	obj["net_name"] = in.NetName
 	obj["nova_network"] = in.NovaNetwork
@@ -186,9 +185,6 @@ func expandMachineConfigV2Openstack(p []interface{}, source *MachineConfigV2) *M
 	}
 	if v, ok := in["ip_version"].(string); ok && len(v) > 0 {
 		obj.IPVersion = v
-	}
-	if v, ok := in["keypair_name"].(string); ok && len(v) > 0 {
-		obj.KeypairName = v
 	}
 	if v, ok := in["net_id"].(string); ok && len(v) > 0 {
 		obj.NetID = v

--- a/rancher2/structure_node_template_amazonec2.go
+++ b/rancher2/structure_node_template_amazonec2.go
@@ -48,10 +48,6 @@ func flattenAmazonec2Config(in *amazonec2Config) []interface{} {
 		obj["instance_type"] = in.InstanceType
 	}
 
-	if len(in.KeypairName) > 0 {
-		obj["keypair_name"] = in.KeypairName
-	}
-
 	if len(in.KmsKey) > 0 {
 		obj["kms_key"] = in.KmsKey
 	}
@@ -186,10 +182,6 @@ func expandAmazonec2Config(p []interface{}) *amazonec2Config {
 
 	if v, ok := in["instance_type"].(string); ok && len(v) > 0 {
 		obj.InstanceType = v
-	}
-
-	if v, ok := in["keypair_name"].(string); ok && len(v) > 0 {
-		obj.KeypairName = v
 	}
 
 	if v, ok := in["kms_key"].(string); ok && len(v) > 0 {

--- a/rancher2/structure_node_template_openstack.go
+++ b/rancher2/structure_node_template_openstack.go
@@ -23,7 +23,6 @@ func flattenOpenstackConfig(in *openstackConfig) []interface{} {
 	obj["image_name"] = in.ImageName
 	obj["insecure"] = in.Insecure
 	obj["ip_version"] = in.IPVersion
-	obj["keypair_name"] = in.KeypairName
 	obj["net_id"] = in.NetID
 	obj["net_name"] = in.NetName
 	obj["nova_network"] = in.NovaNetwork
@@ -106,9 +105,6 @@ func expandOpenstackConfig(p []interface{}) *openstackConfig {
 	}
 	if v, ok := in["ip_version"].(string); ok && len(v) > 0 {
 		obj.IPVersion = v
-	}
-	if v, ok := in["keypair_name"].(string); ok && len(v) > 0 {
-		obj.KeypairName = v
 	}
 	if v, ok := in["net_id"].(string); ok && len(v) > 0 {
 		obj.NetID = v


### PR DESCRIPTION
Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1192

It appears this cannot be used due to a local file path (via `--amazonec2-ssh-keypath`) being required.
If this is possible to pass the key a doc example would be great.