### PR TITLE
Allow setting labels on nodes with rke2

### DIFF
--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -475,7 +475,8 @@ The following attributes are exported:
 * `unhealthy_node_timeout_seconds` - (Optional) Seconds an unhealthy node has to become active before it is replaced (int)
 * `max_unhealthy` - (Optional) Max unhealthy nodes for automated replacement to be allowed (string)
 * `unhealthy_range` - (Optional) Range of unhealthy nodes for automated replacement to be allowed (string)
-* `machine_labels` - (Optional) Machine pool labels. Node labels (list)
+* `machine_labels` - (Optional) Labels for Machine pool nodes (map)
+* `labels` - (Optional) Labels for Machine Deployment Resource (map)
 
 ##### `machine_config`
 

--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -475,6 +475,7 @@ The following attributes are exported:
 * `unhealthy_node_timeout_seconds` - (Optional) Seconds an unhealthy node has to become active before it is replaced (int)
 * `max_unhealthy` - (Optional) Max unhealthy nodes for automated replacement to be allowed (string)
 * `unhealthy_range` - (Optional) Range of unhealthy nodes for automated replacement to be allowed (string)
+* `machine_labels` - (Optional) Machine pool labels. Node labels (list)
 
 ##### `machine_config`
 

--- a/rancher2/schema_cluster_v2_rke_config_machine_pool.go
+++ b/rancher2/schema_cluster_v2_rke_config_machine_pool.go
@@ -1,6 +1,8 @@
 package rancher2
 
 import (
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -137,6 +139,19 @@ func clusterV2RKEConfigMachinePoolFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "range of unhealthy nodes for automated replacement to be allowed",
+		},
+		"machine_labels": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Description: "Labels of the machine",
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				// Supressing diff for labels containing cattle.io/
+				if (strings.Contains(k, commonAnnotationLabelCattle) || strings.Contains(k, commonAnnotationLabelRancher)) && new == "" {
+					return true
+				}
+				return false
+			},
 		},
 	}
 

--- a/rancher2/structure_cluster_v2_rke_config_machine_pool.go
+++ b/rancher2/structure_cluster_v2_rke_config_machine_pool.go
@@ -1,11 +1,12 @@
 package rancher2
 
 import (
+	"time"
+
 	provisionv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"time"
 )
 
 // Flatteners
@@ -64,6 +65,9 @@ func flattenClusterV2RKEConfigMachinePools(p []provisionv1.RKEMachinePool) []int
 		}
 		if len(in.MachineDeploymentLabels) > 0 {
 			obj["labels"] = toMapInterface(in.MachineDeploymentLabels)
+		}
+		if len(in.Labels) > 0 {
+			obj["machine_labels"] = toMapInterface(in.Labels)
 		}
 		obj["paused"] = in.Paused
 		if in.Quantity != nil {
@@ -174,6 +178,9 @@ func expandClusterV2RKEConfigMachinePools(p []interface{}) []provisionv1.RKEMach
 		}
 		if v, ok := in["labels"].(map[string]interface{}); ok && len(v) > 0 {
 			obj.MachineDeploymentLabels = toMapString(v)
+		}
+		if v, ok := in["machine_labels"].(map[string]interface{}); ok && len(v) > 0 {
+			obj.Labels = toMapString(v)
 		}
 		if v, ok := in["paused"].(bool); ok {
 			obj.Paused = v

--- a/rancher2/structure_cluster_v2_rke_config_machine_pool_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_machine_pool_test.go
@@ -1,12 +1,14 @@
 package rancher2
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	provisionv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -62,6 +64,12 @@ func init() {
 				"label_one": "one",
 				"label_two": "two",
 			},
+			RKECommonNodeConfig: rkev1.RKECommonNodeConfig{
+				Labels: map[string]string{
+					"machine_label_one": "one",
+					"machine_label_two": "two",
+				},
+			},
 			Quantity:             &quantity,
 			Paused:               true,
 			RollingUpdate:        testClusterV2RKEConfigMachinePoolRollingUpdateConf,
@@ -96,6 +104,10 @@ func init() {
 			"labels": map[string]interface{}{
 				"label_one": "one",
 				"label_two": "two",
+			},
+			"machine_labels": map[string]interface{}{
+				"machine_label_one": "one",
+				"machine_label_two": "two",
 			},
 			"quantity":       10,
 			"paused":         true,


### PR DESCRIPTION
See https://github.com/rancher/terraform-provider-rancher2/issues/949#issuecomment-1163236185 for a detailed writeup.

This is to allow setting labels on nodes with rke2.

The implemented solution creates a new variable `machine_labels` that can be set inside `machine_pools` resource.
The existing `labels` of `machine_pools` is applied to the DeploymentMachine Resource directly (not the eventual nodes through the spec)

addresses rancher/terraform-provider-rancher2#949 