### PR TITLE
[Docs] Add example for multiple machine pools

### DIFF
--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -61,7 +61,7 @@ resource "rancher2_machine_config_v2" "foo" {
 # Create a new rancher v2 Cluster with multiple machine pools
 resource "rancher2_cluster_v2" "foo-rke2" {
   name = "foo-rke2"
-  kubernetes_version = "v1.21.4+rke2r2"
+  kubernetes_version = "<RANCHER_KUBERNETES_VERSION>"
   enable_network_policy = false
   default_cluster_role_for_project_members = "user"
   rke_config {
@@ -78,7 +78,7 @@ resource "rancher2_cluster_v2" "foo-rke2" {
         name = rancher2_machine_config_v2.foo.name
       }
     }
-    # Must be passed as individual each desired machine pool
+    # Each machine pool must be passed separately
     machine_pools {
       name = "pool2"
       cloud_credential_secret_name = rancher2_cloud_credential.foo.id
@@ -94,7 +94,6 @@ resource "rancher2_cluster_v2" "foo-rke2" {
     }
   }
 }
-
 
 # Create a new rancher v2 amazonec2 RKE2 Cluster v2
 resource "rancher2_cluster_v2" "foo-rke2" {

--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -58,6 +58,44 @@ resource "rancher2_machine_config_v2" "foo" {
   }
 }
 
+# Create a new rancher v2 Cluster with multiple machine pools
+resource "rancher2_cluster_v2" "foo-rke2" {
+  name = "foo-rke2"
+  kubernetes_version = "v1.21.4+rke2r2"
+  enable_network_policy = false
+  default_cluster_role_for_project_members = "user"
+  rke_config {
+    machine_pools {
+      name = "pool1"
+      cloud_credential_secret_name = rancher2_cloud_credential.foo.id
+      control_plane_role = true
+      etcd_role = true
+      worker_role = false
+      quantity = 1
+      drain_before_delete = true
+      machine_config {
+        kind = rancher2_machine_config_v2.foo.kind
+        name = rancher2_machine_config_v2.foo.name
+      }
+    }
+    # Must be passed as individual each desired machine pool
+    machine_pools {
+      name = "pool2"
+      cloud_credential_secret_name = rancher2_cloud_credential.foo.id
+      control_plane_role = false
+      etcd_role = false
+      worker_role = true
+      quantity = 2
+      drain_before_delete = true
+      machine_config {
+        kind = rancher2_machine_config_v2.foo.kind
+        name = rancher2_machine_config_v2.foo.name
+      }
+    }
+  }
+}
+
+
 # Create a new rancher v2 amazonec2 RKE2 Cluster v2
 resource "rancher2_cluster_v2" "foo-rke2" {
   name = "foo-rke2"


### PR DESCRIPTION
Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1186

This adds example for adding multiple machine pools, in the docs it says that it is a list, but after a few tests i realized that this is the right way. So would be good to have example in the official docs. 