### PR TITLE
Only set namespace `container_resource_limit` when it is not nil and empty

### DIFF
--- a/rancher2/structure_namespace.go
+++ b/rancher2/structure_namespace.go
@@ -120,14 +120,17 @@ func flattenNamespace(d *schema.ResourceData, in *clusterClient.Namespace) error
 	d.Set("name", in.Name)
 	d.Set("description", in.Description)
 
-	containerLimit := flattenNamespaceContainerResourceLimit(in.ContainerDefaultResourceLimit)
-	err := d.Set("container_resource_limit", containerLimit)
-	if err != nil {
-		return err
+	emptyContainerResourceLimit := clusterClient.ContainerResourceLimit{}
+	if in.ContainerDefaultResourceLimit != nil && *in.ContainerDefaultResourceLimit != emptyContainerResourceLimit {
+		containerLimit := flattenNamespaceContainerResourceLimit(in.ContainerDefaultResourceLimit)
+		err := d.Set("container_resource_limit", containerLimit)
+		if err != nil {
+			return err
+		}
 	}
 
 	resourceQuota := flattenNamespaceResourceQuota(in.ResourceQuota)
-	err = d.Set("resource_quota", resourceQuota)
+	err := d.Set("resource_quota", resourceQuota)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Like **[structure_project/flattenProject](https://github.com/rancher/terraform-provider-rancher2/blob/master/rancher2/structure_project.go#L123-L129)** func, **[structure_namespace/flattenNamespace](https://github.com/rancher/terraform-provider-rancher2/blob/master/rancher2/structure_namespace.go#L123-L127)** should only set `container_resource_limit` if `ContainerDefaultResourceLimit` return from Rancher API is **not nil** and **not empty**

This resolves issue https://github.com/rancher/terraform-provider-rancher2/issues/347 ([`container_resource_limit` block is empty](https://github.com/rancher/terraform-provider-rancher2/issues/347#issuecomment-632556721))