### PR TITLE
Remove no_public_ip argument from azure machine_config

### DIFF
--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -143,7 +143,6 @@ The following attributes are exported:
 * `image` - (Optional) Azure virtual machine OS image. Default `canonical:UbuntuServer:18.04-LTS:latest` (string)
 * `location` - (Optional) Azure region to create the virtual machine. Default `westus` (string)
 * `managed_disks` - (Optional) Configures VM and availability set for managed disks. Just for Rancher v2.3.x and above. Default `false` (bool)
-* `no_public_ip` - (Optional) Do not create a public IP address for the machine. Default `false` (bool)
 * `nsg` - (Optional) Azure Network Security Group to assign this node to (accepts either a name or resource ID, default is to create a new NSG for each machine). Default `docker-machine-nsg` (string)
 * `open_port` - (Optional) Make the specified port number accessible from the Internet. (list)
 * `private_address_only` - (Optional) Only use a private IP address. Default `false` (bool)

--- a/rancher2/schema_machine_config_v2_azure.go
+++ b/rancher2/schema_machine_config_v2_azure.go
@@ -78,12 +78,6 @@ func machineConfigV2AzureFields() map[string]*schema.Schema {
 			Default:     false,
 			Description: "Configures VM and availability set for managed disks",
 		},
-		"no_public_ip": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "Do not create a public IP address for the machine",
-		},
 		"nsg": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/rancher2/structure_machine_config_v2_azure.go
+++ b/rancher2/structure_machine_config_v2_azure.go
@@ -28,7 +28,6 @@ type machineConfigV2Azure struct {
 	Image              string   `json:"image,omitempty" yaml:"image,omitempty"`
 	Location           string   `json:"location,omitempty" yaml:"location,omitempty"`
 	ManagedDisks       bool     `json:"managedDisks,omitempty" yaml:"managedDisks,omitempty"`
-	NoPublicIP         bool     `json:"noPublicIp,omitempty" yaml:"noPublicIp,omitempty"`
 	NSG                string   `json:"nsg,omitempty" yaml:"nsg,omitempty"`
 	OpenPort           []string `json:"openPort,omitempty" yaml:"openPort,omitempty"`
 	PrivateAddressOnly bool     `json:"privateAddressOnly,omitempty" yaml:"privateAddressOnly,omitempty"`

--- a/rancher2/structure_machine_config_v2_azure.go
+++ b/rancher2/structure_machine_config_v2_azure.go
@@ -102,7 +102,6 @@ func flattenMachineConfigV2Azure(in *MachineConfigV2Azure) []interface{} {
 	}
 
 	obj["managed_disks"] = in.ManagedDisks
-	obj["no_public_ip"] = in.NoPublicIP
 
 	if len(in.NSG) > 0 {
 		obj["nsg"] = in.NSG
@@ -225,10 +224,6 @@ func expandMachineConfigV2Azure(p []interface{}, source *MachineConfigV2) *Machi
 
 	if v, ok := in["managed_disks"].(bool); ok {
 		obj.ManagedDisks = v
-	}
-
-	if v, ok := in["no_public_ip"].(bool); ok {
-		obj.NoPublicIP = v
 	}
 
 	if v, ok := in["nsg"].(string); ok && len(v) > 0 {


### PR DESCRIPTION
This addresses and solves https://github.com/rancher/terraform-provider-rancher2/issues/956
The argument `no_public_ip` and references have been removed from `schema_machine_config_v2_azure.go`, `structure_machine_config_v2_azure.go` and `machine_config_v2.md`.
