### PR TITLE
Bump docker url version to 20.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 0.11.x
 - [Go](https://golang.org/doc/install) 1.13 to build the provider plugin
-- [Docker](https://docs.docker.com/install/) 17.03.x to run acceptance tests
+- [Docker](https://docs.docker.com/install/) 20.10.x to run acceptance tests
 
 Building The Provider
 ---------------------

--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ require (
 replace (
 	github.com/crewjam/saml => github.com/crewjam/saml v0.4.1
 	github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
-	github.com/docker/docker => github.com/docker/docker v20.10.6+incompatible
+	github.com/docker/docker => github.com/docker/docker v20.10.17+incompatible
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20220722231444-8b3c0513bc36
 	github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20220722085125-e464ea405677
 	github.com/spf13/afero => github.com/spf13/afero v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -453,7 +453,7 @@ github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyG
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.11+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v20.10.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.17+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=

--- a/scripts/gobuild_docker.sh
+++ b/scripts/gobuild_docker.sh
@@ -6,7 +6,7 @@ echo "==> Running dockerized build..."
 
 # Setting docker
 DOCKER_NAME=docker
-DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-20.10.14.tgz"
+DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-20.10.17.tgz"
 DOCKER_BIN=$(which ${DOCKER_NAME} || echo none)
 if [ "${DOCKER_BIN}" == "none" ] ; then
   export DOCKER_BIN=${TESTACC_TEMP_DIR}/${DOCKER_NAME}

--- a/scripts/gobuild_docker.sh
+++ b/scripts/gobuild_docker.sh
@@ -6,7 +6,7 @@ echo "==> Running dockerized build..."
 
 # Setting docker
 DOCKER_NAME=docker
-DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz"
+DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-20.10.14.tgz"
 DOCKER_BIN=$(which ${DOCKER_NAME} || echo none)
 if [ "${DOCKER_BIN}" == "none" ] ; then
   export DOCKER_BIN=${TESTACC_TEMP_DIR}/${DOCKER_NAME}

--- a/scripts/gotestacc_docker.sh
+++ b/scripts/gotestacc_docker.sh
@@ -6,7 +6,7 @@ echo "==> Running dockerized acceptance testing..."
 
 # Setting docker
 DOCKER_NAME=docker
-DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-20.10.14.tgz"
+DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-20.10.17.tgz"
 DOCKER_BIN=$(which ${DOCKER_NAME} || echo none)
 if [ "${DOCKER_BIN}" == "none" ] ; then
   export DOCKER_BIN=${TESTACC_TEMP_DIR}/${DOCKER_NAME}

--- a/scripts/gotestacc_docker.sh
+++ b/scripts/gotestacc_docker.sh
@@ -6,7 +6,7 @@ echo "==> Running dockerized acceptance testing..."
 
 # Setting docker
 DOCKER_NAME=docker
-DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz"
+DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-20.10.14.tgz"
 DOCKER_BIN=$(which ${DOCKER_NAME} || echo none)
 if [ "${DOCKER_BIN}" == "none" ] ; then
   export DOCKER_BIN=${TESTACC_TEMP_DIR}/${DOCKER_NAME}

--- a/scripts/gotestacc_vars.sh
+++ b/scripts/gotestacc_vars.sh
@@ -18,7 +18,7 @@ EXPOSE_HOST_PORTS=${EXPOSE_HOST_PORTS:-"false"}
 
 # Setting required software
 DOCKER_NAME=docker
-DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz"
+DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-20.10.14.tgz"
 DOCKER_BIN=$(which ${DOCKER_NAME} || echo none)
 if [ "${DOCKER_BIN}" == "none" ] ; then
   export DOCKER_BIN=${TEMP_DIR}/${DOCKER_NAME}

--- a/scripts/gotestacc_vars.sh
+++ b/scripts/gotestacc_vars.sh
@@ -18,7 +18,7 @@ EXPOSE_HOST_PORTS=${EXPOSE_HOST_PORTS:-"false"}
 
 # Setting required software
 DOCKER_NAME=docker
-DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-20.10.14.tgz"
+DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-20.10.17.tgz"
 DOCKER_BIN=$(which ${DOCKER_NAME} || echo none)
 if [ "${DOCKER_BIN}" == "none" ] ; then
   export DOCKER_BIN=${TEMP_DIR}/${DOCKER_NAME}

--- a/scripts/start_testacc.sh
+++ b/scripts/start_testacc.sh
@@ -52,7 +52,7 @@ if [ "${KUBECTL_BIN}" == "none" ] ; then
 fi
 ## docker
 DOCKER_NAME=docker
-DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-20.10.14.tgz"
+DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-20.10.17.tgz"
 DOCKER_BIN=$(which ${DOCKER_NAME} || echo none)
 if [ "${DOCKER_BIN}" == "none" ] ; then
   export DOCKER_BIN=${TESTACC_TEMP_DIR}/${DOCKER_NAME}

--- a/scripts/start_testacc.sh
+++ b/scripts/start_testacc.sh
@@ -52,7 +52,7 @@ if [ "${KUBECTL_BIN}" == "none" ] ; then
 fi
 ## docker
 DOCKER_NAME=docker
-DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz"
+DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-20.10.14.tgz"
 DOCKER_BIN=$(which ${DOCKER_NAME} || echo none)
 if [ "${DOCKER_BIN}" == "none" ] ; then
   export DOCKER_BIN=${TESTACC_TEMP_DIR}/${DOCKER_NAME}


### PR DESCRIPTION
Issue: https://github.com/rancher/terraform-provider-rancher2/issues/969

## Problem

@Josh-Diamond noticed during QA testing that the terraform rancher2 provider was still using docker 17.03.2 for builds and acceptance tests. This is an outdated version.

## Solution
Based on [this conversation](https://suse.slack.com/archives/C02PSP0VBLL/p1665694158807029), the docker 20.10.sh script installed docker 20.10.12, which is the current version installed on rke1 downstream nodes. That script will install 20.10.17 as of Monday 10/17. Rancher go.mod uses v10.17, so tf should specify the 20.10 script or 20.10.17 explicitly.

I updated docker to the latest version of 20.10 in both terraform and the `defaultEngineInstallURL` in rancher. This PR updates the version of docker being used for terraform builds and acceptance tests to 20.10.17. The version of docker installed on rke1 downstream nodes via the rke1 node driver is hardcoded [here](https://github.com/rancher/rancher/blob/76c98b4919ec2f7cf6dc8c55c3aae92ce694d74b/pkg/controllers/management/node/controller.go#L48). [This second PR](https://github.com/rancher/rancher/pull/39318) updates that docker version to the 20.10 script, which will install 20.10.17 as of 10/17. Now, when an rke1 cluster is provisioned on Amazon EC2 nodes via terraform without `engine_install_url` set, no install engine URL will be passed to rancher and docker 20.10 will be installed on the downstream nodes as default.

Note: If you pass `ignore_docker_version = false` to rancher via terraform, this enables docker version checking on the nodes. Terraform ignores this by default.

## Testing

- [x] RKE1 EC2 cluster via terraform, no AMI - rancher defaults to docker 20.10
- [x]  RKE1 EC2 cluster via terraform, AMI eli-kube-dock-server ami-0e3c799b78951f41b - rancher installs docker 20.10 on the nodes
- [x]  RKE1 EC2 cluster via terraform, no AMI, `engine_install_url = https://releases.rancher.com/install-docker/20.10.9.sh` - rancher installs docker 20.10.9 on the nodes 