### PR TITLE
Don't mark certificates as sensitive

### DIFF
--- a/docs/resources/auth_config_activedirectory.md
+++ b/docs/resources/auth_config_activedirectory.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 * `user_search_base` - (Required) User search base DN (string)
 * `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted` (string)
 * `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `activedirectory_user://<DN>`  `activedirectory_group://<DN>`. The local admin (`local://<admin id>`) and the `test_username` must be added too. (list)
-* `certificate` - (Optional/Sensitive) CA certificate for TLS if selfsigned (string)
+* `certificate` - (Optional) CA certificate for TLS if selfsigned (string)
 * `connection_timeout` - (Optional) ActiveDirectory connection timeout. Default `5000` (int)
 * `default_login_domain` - (Optional) ActiveDirectory defult login domain (string)
 * `enabled` - (Optional) Enable auth config provider. Default `true` (bool)

--- a/docs/resources/auth_config_adfs.md
+++ b/docs/resources/auth_config_adfs.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `groups_field` - (Required) ADFS group field (string)
 * `idp_metadata_content` - (Required/Sensitive) ADFS IDP metadata content (string)
 * `rancher_api_host` - (Required) Rancher URL. URL scheme needs to be specified, `https://<RANCHER_API_HOST>` (string)
-* `sp_cert` - (Required/Sensitive) ADFS SP cert (string)
+* `sp_cert` - (Required) ADFS SP cert (string)
 * `sp_key` - (Required/Sensitive) ADFS SP key (string)
 * `uid_field` - (Required) ADFS UID field (string)
 * `user_name_field` - (Required) ADFS user name field (string)

--- a/docs/resources/auth_config_keycloak.md
+++ b/docs/resources/auth_config_keycloak.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `groups_field` - (Required) KeyCloak group field (string)
 * `idp_metadata_content` - (Required/Sensitive) KeyCloak IDP metadata content (string)
 * `rancher_api_host` - (Required) Rancher URL. URL scheme needs to be specified, `https://<RANCHER_API_HOST>` (string)
-* `sp_cert` - (Required/Sensitive) KeyCloak SP cert (string)
+* `sp_cert` - (Required) KeyCloak SP cert (string)
 * `sp_key` - (Required/Sensitive) KeyCloak SP key (string)
 * `uid_field` - (Required) KeyCloak UID field (string)
 * `user_name_field` - (Required) KeyCloak user name field (string)

--- a/docs/resources/auth_config_okta.md
+++ b/docs/resources/auth_config_okta.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `groups_field` - (Required) OKTA group field (string)
 * `idp_metadata_content` - (Required/Sensitive) OKTA IDP metadata content (string)
 * `rancher_api_host` - (Required) Rancher URL. URL scheme needs to be specified, `https://<RANCHER_API_HOST>` (string)
-* `sp_cert` - (Required/Sensitive) OKTA SP cert (string)
+* `sp_cert` - (Required) OKTA SP cert (string)
 * `sp_key` - (Required/Sensitive) OKTA SP key (string)
 * `uid_field` - (Required) OKTA UID field (string)
 * `user_name_field` - (Required) OKTA user name field (string)

--- a/docs/resources/auth_config_openldap.md
+++ b/docs/resources/auth_config_openldap.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 * `user_search_base` - (Required) User search base DN (string)
 * `access_mode` - (Optional) Access mode for auth. `required`, `restricted`, `unrestricted` are supported. Default `unrestricted` (string)
 * `allowed_principal_ids` - (Optional) Allowed principal ids for auth. Required if `access_mode` is `required` or `restricted`. Ex: `openldap_user://<DN>`  `openldap_group://<DN>` (list)
-* `certificate` - (Optional/Sensitive) Base64 encoded CA certificate for TLS if self-signed. Use filebase64(<FILE>) for encoding file (string)
+* `certificate` - (Optional) Base64 encoded CA certificate for TLS if self-signed. Use filebase64(<FILE>) for encoding file (string)
 * `connection_timeout` - (Optional) OpenLdap connection timeout. Default `5000` (int)
 * `enabled` - (Optional) Enable auth config provider. Default `true` (bool)
 * `group_dn_attribute` - (Optional/Computed) Group DN attribute. Default `entryDN` (string)

--- a/docs/resources/auth_config_ping.md
+++ b/docs/resources/auth_config_ping.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `groups_field` - (Required) Ping group field (string)
 * `idp_metadata_content` - (Required/Sensitive) Ping IDP metadata content (string)
 * `rancher_api_host` - (Required) Rancher URL. URL scheme needs to be specified, `https://<RANCHER_API_HOST>` (string)
-* `sp_cert` - (Required/Sensitive) Ping SP cert (string)
+* `sp_cert` - (Required) Ping SP cert (string)
 * `sp_key` - (Required/Sensitive) Ping SP key (string)
 * `uid_field` - (Required) Ping UID field (string)
 * `user_name_field` - (Required) Ping user name field (string)

--- a/docs/resources/cloud_credential.md
+++ b/docs/resources/cloud_credential.md
@@ -124,7 +124,7 @@ The following attributes are exported:
 * `secret_key` - (Required/Sensitive) AWS secret key (string)
 * `default_bucket` - (Optional) AWS default bucket (string)
 * `default_endpoint` - (Optional) AWS default endpoint (string)
-* `default_endpoint_ca` - (Optional/Sensitive) AWS default endpoint CA (string)
+* `default_endpoint_ca` - (Optional) AWS default endpoint CA (string)
 * `default_folder` - (Optional) AWS default folder (string)
 * `default_region` - (Optional) AWS default region (string)
 * `default_skip_ssl_verify` - (Optional) AWS default skip ssl verify. Default: `false` (bool)

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -617,7 +617,7 @@ The following attributes are exported:
 * `driver` - (Computed) The driver used for the Cluster. `imported`, `azurekubernetesservice`, `amazonelasticcontainerservice`, `googlekubernetesengine` and `rancherKubernetesEngine` are supported (string)
 * `istio_enabled` - (Computed) Is istio enabled at cluster? Just for Rancher v2.3.x and above (bool)
 * `kube_config` - (Computed/Sensitive) Kube Config generated for the cluster. Note: For Rancher 2.6.0 and above, when the cluster has `cluster_auth_endpoint` enabled, the kube_config will not be available until the cluster is `connected` (string)
-* `ca_cert` - (Computed/Sensitive) K8s cluster ca cert (string)
+* `ca_cert` - (Computed) K8s cluster ca cert (string)
 * `system_project_id` - (Computed) System project ID for the cluster (string)
 
 **Note** For Rancher 2.6.0 and above: if setting `kubeconfig-generate-token=false` then the generated `kube_config` will not contain any user token. `kubectl` will generate the user token executing the [rancher cli](https://github.com/rancher/cli/releases/tag/v2.6.0), so it should be installed previously.
@@ -1018,7 +1018,7 @@ The following attributes are exported:
 * `apic_refresh_ticker_adjust` - (Optional) APIC refresh ticker adjust amount (string)
 * `apic_refresh_time` - (Optional) APIC refresh time in seconds (string)
 * `apic_subscription_delay` - (Optional) APIC subscription delay amount (string)
-* `apic_user_crt` - (Required/Sensitive) APIC user certificate (string)
+* `apic_user_crt` - (Required) APIC user certificate (string)
 * `apic_user_key` - (Required/Sensitive) APIC user key (string)
 * `apic_user_name` - (Required) APIC user name (string)
 * `capic` - (Optional) cAPIC cloud (string)
@@ -1174,7 +1174,7 @@ The following attributes are exported:
 
 * `backup_config` - (Optional/Computed) Backup options for etcd service. Just for Rancher v2.2.x (list maxitems:1)
 * `ca_cert` - (Optional/Computed) TLS CA certificate for etcd service (string)
-* `cert` - (Optional/Computed/Sensitive) TLS certificate for etcd service (string)
+* `cert` - (Optional/Computed) TLS certificate for etcd service (string)
 * `creation` - (Optional/Computed) Creation option for etcd service (string)
 * `external_urls` - (Optional) External urls for etcd service (list)
 * `extra_args` - (Optional/Computed) Extra arguments for etcd service (map)

--- a/docs/resources/cluster_logging.md
+++ b/docs/resources/cluster_logging.md
@@ -56,8 +56,8 @@ The following attributes are exported:
 #### Arguments
 
 * `content` - (Required) Custom target config content (string)
-* `certificate` - (Required/Sensitive) SSL CA certificate for the custom target service (string)
-* `client_cert` - (Optional/Sensitive) SSL client certificate for the custom target service (string)
+* `certificate` - (Required) SSL CA certificate for the custom target service (string)
+* `client_cert` - (Optional) SSL client certificate for the custom target service (string)
 * `client_key` - (Optional/Sensitive) SSL client key for the custom target service (string)
 
 ### `elasticsearch_config`
@@ -67,8 +67,8 @@ The following attributes are exported:
 * `endpoint` - (Required) Endpoint of the elascticsearch service. Must include protocol, `http://` or `https://` (string)
 * `auth_password` - (Optional/Sensitive) User password for the elascticsearch service (string)
 * `auth_username` - (Optional/Sensitive) Username for the elascticsearch service (string)
-* `certificate` - (Optional/Sensitive) SSL certificate for the elascticsearch service (string)
-* `client_cert` - (Optional/Sensitive) SSL client certificate for the elascticsearch service (string)
+* `certificate` - (Optional) SSL certificate for the elascticsearch service (string)
+* `client_cert` - (Optional) SSL client certificate for the elascticsearch service (string)
 * `client_key` - (Optional/Sensitive) SSL client key for the elascticsearch service (string)
 * `client_key_pass` - (Optional/Sensitive) SSL client key password for the elascticsearch service (string)
 * `date_format` - (Optional) Date format for the elascticsearch logs. Default: `YYYY-MM-DD` (string)
@@ -81,7 +81,7 @@ The following attributes are exported:
 #### Arguments
 
 * `fluent_servers` - (Required) Servers for the fluentd service (list)
-* `certificate` - (Optional/Sensitive) SSL certificate for the fluentd service (string)
+* `certificate` - (Optional) SSL certificate for the fluentd service (string)
 * `compress` - (Optional) Compress data for the fluentd service (bool)
 * `enable_tls` - (Optional) Enable TLS for the fluentd service (bool)
 
@@ -103,8 +103,8 @@ The following attributes are exported:
 
 * `topic` - (Required) Topic to publish on the kafka service (string)
 * `broker_endpoints` - (Optional) Kafka endpoints for kafka service. Conflicts with `zookeeper_endpoint` (list)
-* `certificate` - (Optional/Sensitive) SSL certificate for the kafka service (string)
-* `client_cert` - (Optional/Sensitive) SSL client certificate for the kafka service (string)
+* `certificate` - (Optional) SSL certificate for the kafka service (string)
+* `client_cert` - (Optional) SSL client certificate for the kafka service (string)
 * `client_key` - (Optional/Sensitive) SSL client key for the kafka service (string)
 * `zookeeper_endpoint` - (Optional) Zookeeper endpoint for kafka service. Conflicts with `broker_endpoints` (string)
 
@@ -114,8 +114,8 @@ The following attributes are exported:
 
 * `endpoint` - (Required) Endpoint of the splunk service. Must include protocol, `http://` or `https://` (string)
 * `token` - (Required/Sensitive) Token for the splunk service (string)
-* `certificate` - (Optional/Sensitive) SSL certificate for the splunk service (string)
-* `client_cert` - (Optional/Sensitive) SSL client certificate for the splunk service (string)
+* `certificate` - (Optional) SSL certificate for the splunk service (string)
+* `client_cert` - (Optional) SSL client certificate for the splunk service (string)
 * `client_key` - (Optional/Sensitive) SSL client key for the splunk service (string)
 * `client_key_pass` - (Optional/Sensitive) SSL client key password for the splunk service (string)
 * `index` - (Optional) Index prefix for the splunk logs (string)
@@ -127,8 +127,8 @@ The following attributes are exported:
 #### Arguments
 
 * `endpoint` - (Required) Endpoint of the syslog service (string)
-* `certificate` - (Optional/Sensitive) SSL certificate for the syslog service (string)
-* `client_cert` - (Optional/Sensitive) SSL client certificate for the syslog service (string)
+* `certificate` - (Optional) SSL certificate for the syslog service (string)
+* `client_cert` - (Optional) SSL client certificate for the syslog service (string)
 * `client_key` - (Optional/Sensitive) SSL client key for the syslog service (string)
 * `program` - (Optional) Program for the syslog service (string)
 * `protocol` - (Optional) Protocol for the syslog service. `tcp` and `udp` are supported. Default: `udp` (string)

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -121,7 +121,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Node Template (string)
 * `amazonec2_config` - (Optional) AWS config for the Node Template (list maxitems:1)
-* `auth_certificate_authority` - (Optional/Sensitive) Auth certificate authority for the Node Template (string)
+* `auth_certificate_authority` - (Optional) Auth certificate authority for the Node Template (string)
 * `auth_key` - (Optional/Sensitive) Auth key for the Node Template (string)
 * `azure_config` - (Optional) Azure config for the Node Template (list maxitems:1)
 * `cloud_credential_id` - (Optional) Cloud credential ID for the Node Template. Required from Rancher v2.2.x (string)

--- a/docs/resources/project_logging.md
+++ b/docs/resources/project_logging.md
@@ -56,8 +56,8 @@ The following attributes are exported:
 #### Arguments
 
 * `content` - (Required) Custom target config content (string)
-* `certificate` - (Required/Sensitive) SSL CA certificate for the custom target service (string)
-* `client_cert` - (Optional/Sensitive) SSL client certificate for the custom target service (string)
+* `certificate` - (Required) SSL CA certificate for the custom target service (string)
+* `client_cert` - (Optional) SSL client certificate for the custom target service (string)
 * `client_key` - (Optional/Sensitive) SSL client key for the custom target service (string)
 
 ### `elasticsearch_config`
@@ -67,8 +67,8 @@ The following attributes are exported:
 * `endpoint` - (Required) Endpoint of the elascticsearch service. Must include protocol, `http://` or `https://` (string)
 * `auth_password` - (Optional/Sensitive) User password for the elascticsearch service (string)
 * `auth_username` - (Optional/Sensitive) Username for the elascticsearch service (string)
-* `certificate` - (Optional/Sensitive) SSL certificate for the elascticsearch service (string)
-* `client_cert` - (Optional/Sensitive) SSL client certificate for the elascticsearch service (string)
+* `certificate` - (Optional) SSL certificate for the elascticsearch service (string)
+* `client_cert` - (Optional) SSL client certificate for the elascticsearch service (string)
 * `client_key` - (Optional/Sensitive) SSL client key for the elascticsearch service (string)
 * `client_key_pass` - (Optional/Sensitive) SSL client key password for the elascticsearch service (string)
 * `date_format` - (Optional) Date format for the elascticsearch logs. Default: `YYYY-MM-DD` (string)
@@ -81,7 +81,7 @@ The following attributes are exported:
 #### Arguments
 
 * `fluent_servers` - (Required) Servers for the fluentd service (list)
-* `certificate` - (Optional/Sensitive) SSL certificate for the fluentd service (string)
+* `certificate` - (Optional) SSL certificate for the fluentd service (string)
 * `compress` - (Optional) Compress data for the fluentd service (bool)
 * `enable_tls` - (Optional) Enable TLS for the fluentd service (bool)
 
@@ -103,8 +103,8 @@ The following attributes are exported:
 
 * `topic` - (Required) Topic to publish on the kafka service (string)
 * `broker_endpoints` - (Optional) Kafka endpoints for kafka service. Conflicts with `zookeeper_endpoint` (list)
-* `certificate` - (Optional/Sensitive) SSL certificate for the kafka service (string)
-* `client_cert` - (Optional/Sensitive) SSL client certificate for the kafka service (string)
+* `certificate` - (Optional) SSL certificate for the kafka service (string)
+* `client_cert` - (Optional) SSL client certificate for the kafka service (string)
 * `client_key` - (Optional/Sensitive) SSL client key for the kafka service (string)
 * `zookeeper_endpoint` - (Optional) Zookeeper endpoint for kafka service. Conflicts with `broker_endpoints` (string)
 
@@ -114,8 +114,8 @@ The following attributes are exported:
 
 * `endpoint` - (Required) Endpoint of the splunk service. Must include protocol, `http://` or `https://` (string)
 * `token` - (Required/Sensitive) Token for the splunk service (string)
-* `certificate` - (Optional/Sensitive) SSL certificate for the splunk service (string)
-* `client_cert` - (Optional/Sensitive) SSL client certificate for the splunk service (string)
+* `certificate` - (Optional) SSL certificate for the splunk service (string)
+* `client_cert` - (Optional) SSL client certificate for the splunk service (string)
 * `client_key` - (Optional/Sensitive) SSL client key for the splunk service (string)
 * `client_key_pass` - (Optional/Sensitive) SSL client key password for the splunk service (string)
 * `index` - (Optional) Index prefix for the splunk logs (string)
@@ -127,8 +127,8 @@ The following attributes are exported:
 #### Arguments
 
 * `endpoint` - (Required) Endpoint of the syslog service (string)
-* `certificate` - (Optional/Sensitive) SSL certificate for the syslog service (string)
-* `client_cert` - (Optional/Sensitive) SSL client certificate for the syslog service (string)
+* `certificate` - (Optional) SSL certificate for the syslog service (string)
+* `client_cert` - (Optional) SSL client certificate for the syslog service (string)
 * `client_key` - (Optional/Sensitive) SSL client key for the syslog service (string)
 * `program` - (Optional) Program for the syslog service (string)
 * `protocol` - (Optional) Protocol for the syslog service. `tcp` and `udp` are supported. Default: `udp` (string)

--- a/rancher2/data_source_rancher2_cluster.go
+++ b/rancher2/data_source_rancher2_cluster.go
@@ -32,9 +32,8 @@ func dataSourceRancher2Cluster() *schema.Resource {
 				Computed: true,
 			},
 			"ca_cert": {
-				Type:      schema.TypeString,
-				Computed:  true,
-				Sensitive: true,
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"rke_config": {
 				Type:     schema.TypeList,

--- a/rancher2/schema_auth_config_activedirectory.go
+++ b/rancher2/schema_auth_config_activedirectory.go
@@ -43,7 +43,6 @@ func authConfigActiveDirectoryFields() map[string]*schema.Schema {
 		"certificate": {
 			Type:      schema.TypeString,
 			Optional:  true,
-			Sensitive: true,
 			StateFunc: TrimSpace,
 		},
 		"connection_timeout": {

--- a/rancher2/schema_auth_config_adfs.go
+++ b/rancher2/schema_auth_config_adfs.go
@@ -31,7 +31,6 @@ func authConfigADFSFields() map[string]*schema.Schema {
 		"sp_cert": {
 			Type:      schema.TypeString,
 			Required:  true,
-			Sensitive: true,
 			StateFunc: TrimSpace,
 		},
 		"sp_key": {

--- a/rancher2/schema_auth_config_keycloak.go
+++ b/rancher2/schema_auth_config_keycloak.go
@@ -31,7 +31,6 @@ func authConfigKeyCloakFields() map[string]*schema.Schema {
 		"sp_cert": {
 			Type:      schema.TypeString,
 			Required:  true,
-			Sensitive: true,
 			StateFunc: TrimSpace,
 		},
 		"sp_key": {

--- a/rancher2/schema_auth_config_ldap.go
+++ b/rancher2/schema_auth_config_ldap.go
@@ -42,7 +42,6 @@ func authConfigLdapFields() map[string]*schema.Schema {
 		"certificate": {
 			Type:         schema.TypeString,
 			Optional:     true,
-			Sensitive:    true,
 			ValidateFunc: validation.StringIsBase64,
 			StateFunc: func(val interface{}) string {
 				s, _ := Base64Decode(val.(string))

--- a/rancher2/schema_auth_config_okta.go
+++ b/rancher2/schema_auth_config_okta.go
@@ -31,7 +31,6 @@ func authConfigOKTAFields() map[string]*schema.Schema {
 		"sp_cert": {
 			Type:      schema.TypeString,
 			Required:  true,
-			Sensitive: true,
 			StateFunc: TrimSpace,
 		},
 		"sp_key": {

--- a/rancher2/schema_auth_config_ping.go
+++ b/rancher2/schema_auth_config_ping.go
@@ -31,7 +31,6 @@ func authConfigPingFields() map[string]*schema.Schema {
 		"sp_cert": {
 			Type:      schema.TypeString,
 			Required:  true,
-			Sensitive: true,
 			StateFunc: TrimSpace,
 		},
 		"sp_key": {

--- a/rancher2/schema_cloud_credential_s3.go
+++ b/rancher2/schema_cloud_credential_s3.go
@@ -33,7 +33,6 @@ func cloudCredentialS3Fields() map[string]*schema.Schema {
 		"default_endpoint_ca": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Sensitive:   true,
 			Description: "AWS default endpoint CA",
 		},
 		"default_folder": {

--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -500,9 +500,8 @@ func clusterFields() map[string]*schema.Schema {
 			Sensitive: true,
 		},
 		"ca_cert": {
-			Type:      schema.TypeString,
-			Computed:  true,
-			Sensitive: true,
+			Type:     schema.TypeString,
+			Computed: true,
 		},
 		"rke_config": {
 			Type:          schema.TypeList,

--- a/rancher2/schema_cluster_rke_config_services_etcd.go
+++ b/rancher2/schema_cluster_rke_config_services_etcd.go
@@ -98,10 +98,9 @@ func clusterRKEConfigServicesEtcdFields() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"cert": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Computed:  true,
-			Sensitive: true,
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
 		},
 		"creation": {
 			Type:     schema.TypeString,

--- a/rancher2/schema_logging_custom_target_config.go
+++ b/rancher2/schema_logging_custom_target_config.go
@@ -18,13 +18,11 @@ func loggingCustomTargetConfigFields() map[string]*schema.Schema {
 		"certificate": {
 			Type:      schema.TypeString,
 			Optional:  true,
-			Sensitive: true,
 			StateFunc: TrimSpace,
 		},
 		"client_cert": {
 			Type:      schema.TypeString,
 			Optional:  true,
-			Sensitive: true,
 			StateFunc: TrimSpace,
 		},
 		"client_key": {

--- a/rancher2/schema_logging_elasticsearch_config.go
+++ b/rancher2/schema_logging_elasticsearch_config.go
@@ -25,14 +25,12 @@ func loggingElasticsearchConfigFields() map[string]*schema.Schema {
 			Sensitive: true,
 		},
 		"certificate": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Sensitive: true,
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 		"client_cert": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Sensitive: true,
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 		"client_key": {
 			Type:      schema.TypeString,

--- a/rancher2/schema_logging_fluentd_config.go
+++ b/rancher2/schema_logging_fluentd_config.go
@@ -58,9 +58,8 @@ func loggingFluentdConfigFields() map[string]*schema.Schema {
 			},
 		},
 		"certificate": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Sensitive: true,
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 		"compress": {
 			Type:     schema.TypeBool,

--- a/rancher2/schema_logging_kafka_config.go
+++ b/rancher2/schema_logging_kafka_config.go
@@ -24,14 +24,12 @@ func loggingKafkaConfigFields() map[string]*schema.Schema {
 			},
 		},
 		"certificate": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Sensitive: true,
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 		"client_cert": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Sensitive: true,
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 		"client_key": {
 			Type:      schema.TypeString,

--- a/rancher2/schema_logging_splunk_config.go
+++ b/rancher2/schema_logging_splunk_config.go
@@ -22,14 +22,12 @@ func loggingSplunkConfigFields() map[string]*schema.Schema {
 			Sensitive: true,
 		},
 		"certificate": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Sensitive: true,
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 		"client_cert": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Sensitive: true,
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 		"client_key": {
 			Type:      schema.TypeString,

--- a/rancher2/schema_logging_syslog_config.go
+++ b/rancher2/schema_logging_syslog_config.go
@@ -23,14 +23,12 @@ func loggingSyslogConfigFields() map[string]*schema.Schema {
 			Required: true,
 		},
 		"certificate": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Sensitive: true,
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 		"client_cert": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Sensitive: true,
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 		"client_key": {
 			Type:      schema.TypeString,

--- a/rancher2/schema_node_template.go
+++ b/rancher2/schema_node_template.go
@@ -59,9 +59,8 @@ func nodeTemplateFields() map[string]*schema.Schema {
 			},
 		},
 		"auth_certificate_authority": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Sensitive: true,
+			Type:     schema.TypeString,
+			Optional: true,
 		},
 		"auth_key": {
 			Type:      schema.TypeString,


### PR DESCRIPTION
The certificates are not sensitive, only the certificate keys are.

My small annoyance came from the `rancher2_cluster` data source, but while at it, I tried to remove the sensitivity flag from all CA and normal certificates.

It looks like there are also many username/ID/etc. attributes marked as sensitive even though most shouldn't needed to be. But those I left for someone else for now. 🙂 