### PR TITLE
Clarify source of `image_name` for `harvester_config` blocks

### DIFF
--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -189,7 +189,7 @@ The following attributes are exported:
 * `memory_size` - (Optional) Memory size (in GiB), Default `4` (string)
 * `disk_size` - (Optional) Disk size (in GiB), Default `40` (string)
 * `disk_bus` - (Optional) Disk bus, Default `virtio` (string)
-* `image_name` - (Required) Image name e.g. `harvester-public/image-57hzg` (string)
+* `image_name` - (Required) Image name from the API `id` field, *not* the human provided name e.g. `harvester-public/image-57hzg` (string)
 * `ssh_user` - (Required) SSH username e.g. `ubuntu` (string)
 * `ssh_password` - (Optional/Sensitive) SSH password (string)
 * `network_name` - (Required) Network name e.g. `harvester-public/vlan1` (string)

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -256,7 +256,7 @@ The following attributes are exported:
 * `memory_size` - (Optional) Memory size (in GiB), Default `4` (string)
 * `disk_size` - (Optional) Disk size (in GiB), Default `40` (string)
 * `disk_bus` - (Optional) Disk bus, Default `virtio` (string)
-* `image_name` - (Required) Image name e.g. `harvester-public/image-57hzg` (string)
+* `image_name` - (Required) Image name from the API `id` field, *not* the human provided name e.g. `harvester-public/image-57hzg` (string)
 * `ssh_user` - (Required) SSH username e.g. `ubuntu` (string)
 * `ssh_password` - (Optional/Sensitive) SSH password (string)
 * `network_name` - (Required) Network name e.g. `harvester-public/vlan1` (string)


### PR DESCRIPTION
This one stumped me for a bit. Finding out that the `image_name` it wanted was the one in the API, `default/image-abcde` and *not* the one that I had created in harvester, `default/ubuntu-22.04-server-cloudimg-amd64.img`. 

It might not be an issue if you're using the harvester TF provider and the `harvester_image` data source, but the documentation could help point the user in the correct direction.