### PR TITLE
[Docs] Remove tech preview reference for features that are already GA

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -503,7 +503,7 @@ resource "rancher2_cluster" "foo" {
 ```
 
 
-### Importing AKS cluster from Rancher v2, using `aks_config_v2`. For Rancher v2.6.0 or above (Tech preview)
+### Importing AKS cluster from Rancher v2, using `aks_config_v2`. For Rancher v2.6.0 or above.
 
 ```hcl
 resource "rancher2_cloud_credential" "foo-aks" {
@@ -527,7 +527,7 @@ resource "rancher2_cluster" "foo" {
 }
 ```
 
-### Creating AKS cluster from Rancher v2, using `aks_config_v2`. For Rancher v2.6.0 or above (Tech preview)
+### Creating AKS cluster from Rancher v2, using `aks_config_v2`. For Rancher v2.6.0 or above.
 
 ```hcl
 resource "rancher2_cloud_credential" "foo-aks" {

--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -4,7 +4,7 @@ page_title: "rancher2_cluster_v2 Resource"
 
 # rancher2\_cluster\_v2 Resource
 
-Provides a Rancher v2 Cluster v2 resource. This can be used to create RKE2 and K3S Clusters for Rancher v2 environments and retrieve their information. This resource is supported as tech preview from Rancher v2.6.0 and above.
+Provides a Rancher v2 Cluster v2 resource. This can be used to create RKE2 and K3S Clusters for Rancher v2 environments and retrieve their information. This resource is available from Rancher v2.6.0 and above.
 
 ## Example Usage
 

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -4,7 +4,7 @@ page_title: "rancher2_machine_config_v2 Resource"
 
 # rancher2\_machine\_config\_v2 Resource
 
-Provides a Rancher v2 Machine config v2 resource. This can be used to create Machine Config v2 for Rancher v2 and retrieve their information. This resource is supported as tech preview from Rancher v2.6.0 and above.
+Provides a Rancher v2 Machine config v2 resource. This can be used to create Machine Config v2 for Rancher v2 and retrieve their information. This resource is available from Rancher v2.6.0 and above.
 
 `amazonec2`, `azure`, `digitalocean`, `linode`, `openstack`, and `vsphere` cloud providers are supported for machine config V2
 


### PR DESCRIPTION
AKS v2 provisioning and RKE2 cluster provisioning have been GA for quite a while in Rancher. The terraform provider docs still document them as "tech preview". This remove this outdated information.

Fixes https://github.com/rancher/terraform-provider-rancher2/issues/999