### PR TITLE
Pass machine labels to kubernetes nodes

### DIFF
--- a/rancher2/structure_cluster_v2_rke_config_machine_pool.go
+++ b/rancher2/structure_cluster_v2_rke_config_machine_pool.go
@@ -174,6 +174,7 @@ func expandClusterV2RKEConfigMachinePools(p []interface{}) []provisionv1.RKEMach
 		}
 		if v, ok := in["labels"].(map[string]interface{}); ok && len(v) > 0 {
 			obj.MachineDeploymentLabels = toMapString(v)
+			obj.Labels = toMapString(v)
 		}
 		if v, ok := in["paused"].(bool); ok {
 			obj.Paused = v

--- a/rancher2/structure_cluster_v2_rke_config_machine_pool_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_machine_pool_test.go
@@ -73,6 +73,7 @@ func init() {
 		},
 	}
 	testClusterV2RKEConfigMachinePoolsConf[0].CloudCredentialSecretName = "cloud_credential_secret_name"
+	testClusterV2RKEConfigMachinePoolsConf[0].Labels = testClusterV2RKEConfigMachinePoolsConf[0].MachineDeploymentLabels
 	testClusterV2RKEConfigMachinePoolsConf[0].Taints = []corev1.Taint{
 		{
 			Key:    "key",


### PR DESCRIPTION
According to the [documentation](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/machine_config_v2#labels) the labels set on the machine configs are passed to the kubernetes nodes.
Currently this is not happening because the provider only sets `MachineDeploymentLabels` which is not propagated to the kubernetes nodes. The correct attribute would be `labels`.
 