### PR TITLE
Implement Azure Tags Support

### DIFF
--- a/rancher2/schema_machine_config_v2_azure.go
+++ b/rancher2/schema_machine_config_v2_azure.go
@@ -181,6 +181,12 @@ func machineConfigV2AzureFields() map[string]*schema.Schema {
 			Default:     "docker-machine-vnet",
 			Description: "Azure Virtual Network name to connect the virtual machine (in [resourcegroup:]name format)",
 		},
+		"tags": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "",
+			Description: "Azure VM Instance Tags",
+		},
 	}
 
 	return s

--- a/rancher2/schema_node_template_azure.go
+++ b/rancher2/schema_node_template_azure.go
@@ -39,6 +39,7 @@ type azureConfig struct {
 	UpdateDomainCount  string   `json:"updateDomainCount,omitempty" yaml:"updateDomainCount,omitempty"`
 	UsePrivateIP       bool     `json:"usePrivateIp,omitempty" yaml:"usePrivateIp,omitempty"`
 	Vnet               string   `json:"vnet,omitempty" yaml:"vnet,omitempty"`
+	Tags               string   `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 //Schemas
@@ -210,6 +211,12 @@ func azureConfigFields() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     "docker-machine-vnet",
 			Description: "Azure Virtual Network name to connect the virtual machine (in [resourcegroup:]name format)",
+		},
+		"tags": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "",
+			Description: "Azure VM instance tags",
 		},
 	}
 

--- a/rancher2/structure_cluster_rke_config_cloud_provider_azure.go
+++ b/rancher2/structure_cluster_rke_config_cloud_provider_azure.go
@@ -125,6 +125,10 @@ func flattenClusterRKEConfigCloudProviderAzure(in *managementClient.AzureCloudPr
 		obj["vnet_resource_group"] = in.VnetResourceGroup
 	}
 
+	if len(in.Tags) > 0 {
+		obj["tags"] = in.Tags
+	}
+
 	return []interface{}{obj}, nil
 }
 
@@ -251,6 +255,10 @@ func expandClusterRKEConfigCloudProviderAzure(p []interface{}) (*managementClien
 
 	if v, ok := in["vnet_resource_group"].(string); ok && len(v) > 0 {
 		obj.VnetResourceGroup = v
+	}
+
+	if v, ok := in["tags"].(string); ok && len(v) > 0 {
+		obj.Tags = v
 	}
 
 	return obj, nil

--- a/rancher2/structure_cluster_rke_config_cloud_provider_azure_test.go
+++ b/rancher2/structure_cluster_rke_config_cloud_provider_azure_test.go
@@ -43,6 +43,7 @@ func init() {
 		VMType:                       "vm_type",
 		VnetName:                     "vnet_name",
 		VnetResourceGroup:            "vnet_resource_group",
+		Tags:                         "key1,value1,key2,value2",
 	}
 	testClusterRKEConfigCloudProviderAzureInterface = []interface{}{
 		map[string]interface{}{
@@ -75,6 +76,7 @@ func init() {
 			"vm_type":                          "vm_type",
 			"vnet_name":                        "vnet_name",
 			"vnet_resource_group":              "vnet_resource_group",
+			"tags":                             "key1,value1,key2,value2",
 		},
 	}
 }

--- a/rancher2/structure_machine_config_v2_azure.go
+++ b/rancher2/structure_machine_config_v2_azure.go
@@ -45,6 +45,7 @@ type machineConfigV2Azure struct {
 	UpdateDomainCount  string   `json:"updateDomainCount,omitempty" yaml:"updateDomainCount,omitempty"`
 	UsePrivateIP       bool     `json:"usePrivateIp,omitempty" yaml:"usePrivateIp,omitempty"`
 	Vnet               string   `json:"vnet,omitempty" yaml:"vnet,omitempty"`
+	Tags               string   `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type MachineConfigV2Azure struct {
@@ -160,6 +161,10 @@ func flattenMachineConfigV2Azure(in *MachineConfigV2Azure) []interface{} {
 
 	if len(in.Vnet) > 0 {
 		obj["vnet"] = in.Vnet
+	}
+
+	if len(in.Tags) > 0 {
+		obj["tags"] = in.Tags
 	}
 
 	return []interface{}{obj}
@@ -293,6 +298,10 @@ func expandMachineConfigV2Azure(p []interface{}, source *MachineConfigV2) *Machi
 
 	if v, ok := in["vnet"].(string); ok && len(v) > 0 {
 		obj.Vnet = v
+	}
+
+	if v, ok := in["tags"].(string); ok && len(v) > 0 {
+		obj.Tags = v
 	}
 
 	return obj

--- a/rancher2/structure_node_template_amazonec2_test.go
+++ b/rancher2/structure_node_template_amazonec2_test.go
@@ -107,7 +107,7 @@ func init() {
 
 }
 
-func TestFlattenNodeTemplate(t *testing.T) {
+func TestFlattenAmazonEc2NodeTemplate(t *testing.T) {
 	cases := []struct {
 		Input          *NodeTemplate
 		ExpectedOutput map[string]interface{}
@@ -134,7 +134,7 @@ func TestFlattenNodeTemplate(t *testing.T) {
 	}
 }
 
-func TestExpandNodeTemplate(t *testing.T) {
+func TestExpandAmazonEc2NodeTemplate(t *testing.T) {
 	cases := []struct {
 		Input          map[string]interface{}
 		ExpectedOutput *NodeTemplate

--- a/rancher2/structure_node_template_azure.go
+++ b/rancher2/structure_node_template_azure.go
@@ -109,6 +109,10 @@ func flattenAzureConfig(in *azureConfig) []interface{} {
 		obj["vnet"] = in.Vnet
 	}
 
+	if len(in.Tags) > 0 {
+		obj["tags"] = in.Tags
+	}
+
 	return []interface{}{obj}
 }
 
@@ -231,6 +235,10 @@ func expandAzureConfig(p []interface{}) *azureConfig {
 
 	if v, ok := in["vnet"].(string); ok && len(v) > 0 {
 		obj.Vnet = v
+	}
+
+	if v, ok := in["tags"].(string); ok && len(v) > 0 {
+		obj.Tags = v
 	}
 
 	return obj

--- a/rancher2/structure_node_template_azure_test.go
+++ b/rancher2/structure_node_template_azure_test.go
@@ -1,0 +1,186 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
+	"reflect"
+	"testing"
+)
+
+var (
+	testAzureNodeTemplateNodeTaintsConf      []managementClient.Taint
+	testAzureNodeTemplateNodeTaintsInterface interface{}
+	testNodeTemplateAzureConf                azureConfig
+	testAzureNodeTemplateInterface           map[string]interface{}
+	testAzureNodeTemplateConf                *NodeTemplate
+	testNodeTemplateSquashAzureConfInterface map[string]interface{}
+	testNodeTemplateExpandAzureConfInterface map[string]interface{}
+)
+
+func init() {
+	testAzureNodeTemplateNodeTaintsConf = []managementClient.Taint{
+		{
+			Key:       "key",
+			Value:     "value",
+			Effect:    "recipient",
+			TimeAdded: "time_added",
+		},
+	}
+	testAzureNodeTemplateNodeTaintsInterface = []interface{}{
+		map[string]interface{}{
+			"key":        "key",
+			"value":      "value",
+			"effect":     "recipient",
+			"time_added": "time_added",
+		},
+	}
+	testNodeTemplateAzureConf = azureConfig{
+		AvailabilitySet:    "docker-machine",
+		ClientID:           "test-id",
+		ClientSecret:       "test-secret",
+		CustomData:         "test-data",
+		DiskSize:           "32gb",
+		DNS:                "1.1.1.1",
+		Environment:        "prod",
+		FaultDomainCount:   "3",
+		Image:              "ubuntu",
+		Location:           "us-east-1",
+		ManagedDisks:       false,
+		NoPublicIP:         false,
+		NSG:                "test-nsg",
+		Plan:               "test-plan",
+		OpenPort:           nil,
+		PrivateAddressOnly: false,
+		PrivateIPAddress:   "1.1.1.1",
+		ResourceGroup:      "test-rg",
+		Size:               "large",
+		SSHUser:            "user",
+		StaticPublicIP:     false,
+		StorageType:        "hdd",
+		Subnet:             "1.1.1.1",
+		SubnetPrefix:       "1.1.1.1",
+		SubscriptionID:     "sub-id",
+		UpdateDomainCount:  "3",
+		UsePrivateIP:       false,
+		Vnet:               "test-vnet",
+		Tags:               "key1,value1",
+	}
+	testAzureNodeTemplateInterface = map[string]interface{}{
+		"availability_set":     "docker-machine",
+		"client_id":            "test-id",
+		"client_secret":        "test-secret",
+		"custom_data":          "test-data",
+		"disk_size":            "32gb",
+		"dns":                  "1.1.1.1",
+		"environment":          "prod",
+		"fault_domain-count":   "3",
+		"image":                "ubuntu",
+		"location":             "us-east-1",
+		"managed_disks":        false,
+		"no_public_ip":         false,
+		"nsg":                  "test-nsg",
+		"plan":                 "test-plan",
+		"open_port":            nil,
+		"private_address_only": false,
+		"private_ip_address":   "1.1.1.1",
+		"resource_group":       "test-rg",
+		"size":                 "large",
+		"ssh_user":             "user",
+		"static_public_ip":     false,
+		"storage_type":         "hdd",
+		"subnet":               "1.1.1.1",
+		"subnet_prefix":        "1.1.1.1",
+		"subscription_id":      "sub-id",
+		"update_domain_count":  "3",
+		"use_private_ip":       false,
+		"vnet":                 "test-vnet",
+		"tags":                 "key1,value1",
+	}
+	testAzureNodeTemplateAnnotationsConf := map[string]string{
+		"key": "value",
+	}
+	testAzureNodeTemplateAnnotationsInterface := map[string]interface{}{
+		"key": "value",
+	}
+
+	useInternalIP := false
+	testAzureNodeTemplateConf = &NodeTemplate{
+		NodeTemplate: managementClient.NodeTemplate{
+			Driver:               "azure",
+			UseInternalIPAddress: &useInternalIP,
+			Annotations:          testAzureNodeTemplateAnnotationsConf,
+			CloudCredentialID:    "abc-test-123",
+			NodeTaints:           testAzureNodeTemplateNodeTaintsConf,
+			EngineInstallURL:     "http://fake.url",
+			Name:                 "test-node-template",
+		},
+		AzureConfig: &testNodeTemplateAzureConf,
+	}
+
+	testNodeTemplateSquashAzureConfInterface = map[string]interface{}{
+		"annotations":             testAzureNodeTemplateAnnotationsInterface,
+		"driver":                  "azure",
+		"cloud_credential_id":     "abc-test-123",
+		"use_internal_ip_address": useInternalIP,
+		"engine_install_url":      "http://fake.url",
+		"name":                    "test-node-template",
+	}
+
+	testNodeTemplateExpandAzureConfInterface = map[string]interface{}{
+		"annotations":             testAzureNodeTemplateAnnotationsInterface,
+		"node_taints":             testAzureNodeTemplateNodeTaintsInterface,
+		"driver":                  "azure",
+		"cloud_credential_id":     "abc-test-123",
+		"use_internal_ip_address": useInternalIP,
+		"engine_install_url":      "http://fake.url",
+		"name":                    "test-node-template",
+		"azure_config":            []interface{}{testAzureNodeTemplateInterface},
+	}
+}
+
+func TestFlattenAzureNodeTemplate(t *testing.T) {
+	cases := []struct {
+		Input          *NodeTemplate
+		ExpectedOutput map[string]interface{}
+	}{
+		{
+			testAzureNodeTemplateConf,
+			testNodeTemplateSquashAzureConfInterface,
+		},
+	}
+
+	for _, tc := range cases {
+		output := schema.TestResourceDataRaw(t, nodeTemplateFields(), map[string]interface{}{})
+		err := flattenNodeTemplate(output, tc.Input)
+		if err != nil {
+			t.Fatalf("[ERROR] on flattener: %#v", err)
+		}
+		expectedOutput := map[string]interface{}{}
+		for k := range tc.ExpectedOutput {
+			expectedOutput[k] = output.Get(k)
+		}
+		if !reflect.DeepEqual(expectedOutput, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from flattener. \nExpected: %#v\nGiven:::: %#v", expectedOutput, tc.ExpectedOutput)
+		}
+	}
+}
+
+func TestExpandAzureNodeTemplate(t *testing.T) {
+	cases := []struct {
+		Input          map[string]interface{}
+		ExpectedOutput *NodeTemplate
+	}{
+		{
+			Input:          testNodeTemplateExpandAzureConfInterface,
+			ExpectedOutput: testAzureNodeTemplateConf,
+		},
+	}
+
+	for _, tc := range cases {
+		inputData := schema.TestResourceDataRaw(t, nodeTemplateFields(), tc.Input)
+		output := expandNodeTemplate(inputData)
+		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
+			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:::: %#v", tc.ExpectedOutput, output)
+		}
+	}
+}


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/26955

This PR adds the `tags` field to the node template, machine config, and cloud provider for Azure. This allows tags to be specified for particular VM instances using either the node template or machine config, as well as adding tags to supporting infrastructure via the tags field within the Azure cloud provider. 

Testing: 
Manual testing is in progress, however I've added unit tests for the Azure node template and improved prior unit tests for the AmazonEC2 node template. 

I'm raising this PR as a draft as the `tags` field within the Azure Cloud Provider needs to be generated in rancher/rancher for this PR to work. Because of this dependency the build will fail