### PR TITLE
[Docs] add missing codeblock end in cluster resource documentation

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1261,7 +1261,7 @@ exemptions:
   runtimeClasses: []
   namespaces: []
 EOF
-
+```
 
 ###### `audit_log`
 


### PR DESCRIPTION
Adding the missing code block end in the cluster resource documentation