### PR TITLE
Azure Accelerated Networking

### DIFF
--- a/rancher2/schema_node_template_azure.go
+++ b/rancher2/schema_node_template_azure.go
@@ -11,34 +11,35 @@ const (
 //Types
 
 type azureConfig struct {
-	AvailabilitySet    string   `json:"availabilitySet,omitempty" yaml:"availabilitySet,omitempty"`
-	ClientID           string   `json:"clientId,omitempty" yaml:"clientId,omitempty"`
-	ClientSecret       string   `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
-	CustomData         string   `json:"customData,omitempty" yaml:"customData,omitempty"`
-	DiskSize           string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
-	DNS                string   `json:"dns,omitempty" yaml:"dns,omitempty"`
-	Environment        string   `json:"environment,omitempty" yaml:"environment,omitempty"`
-	FaultDomainCount   string   `json:"faultDomainCount,omitempty" yaml:"faultDomainCount,omitempty"`
-	Image              string   `json:"image,omitempty" yaml:"image,omitempty"`
-	Location           string   `json:"location,omitempty" yaml:"location,omitempty"`
-	ManagedDisks       bool     `json:"managedDisks,omitempty" yaml:"managedDisks,omitempty"`
-	NoPublicIP         bool     `json:"noPublicIp,omitempty" yaml:"noPublicIp,omitempty"`
-	NSG                string   `json:"nsg,omitempty" yaml:"nsg,omitempty"`
-	Plan               string   `json:"plan,omitempty" yaml:"plan,omitempty"`
-	OpenPort           []string `json:"openPort,omitempty" yaml:"openPort,omitempty"`
-	PrivateAddressOnly bool     `json:"privateAddressOnly,omitempty" yaml:"privateAddressOnly,omitempty"`
-	PrivateIPAddress   string   `json:"privateIpAddress,omitempty" yaml:"privateIpAddress,omitempty"`
-	ResourceGroup      string   `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
-	Size               string   `json:"size,omitempty" yaml:"size,omitempty"`
-	SSHUser            string   `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
-	StaticPublicIP     bool     `json:"staticPublicIp,omitempty" yaml:"staticPublicIp,omitempty"`
-	StorageType        string   `json:"storageType,omitempty" yaml:"storageType,omitempty"`
-	Subnet             string   `json:"subnet,omitempty" yaml:"subnet,omitempty"`
-	SubnetPrefix       string   `json:"subnetPrefix,omitempty" yaml:"subnetPrefix,omitempty"`
-	SubscriptionID     string   `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
-	UpdateDomainCount  string   `json:"updateDomainCount,omitempty" yaml:"updateDomainCount,omitempty"`
-	UsePrivateIP       bool     `json:"usePrivateIp,omitempty" yaml:"usePrivateIp,omitempty"`
-	Vnet               string   `json:"vnet,omitempty" yaml:"vnet,omitempty"`
+	AvailabilitySet       string   `json:"availabilitySet,omitempty" yaml:"availabilitySet,omitempty"`
+	ClientID              string   `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret          string   `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+	CustomData            string   `json:"customData,omitempty" yaml:"customData,omitempty"`
+	DiskSize              string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
+	DNS                   string   `json:"dns,omitempty" yaml:"dns,omitempty"`
+	Environment           string   `json:"environment,omitempty" yaml:"environment,omitempty"`
+	FaultDomainCount      string   `json:"faultDomainCount,omitempty" yaml:"faultDomainCount,omitempty"`
+	Image                 string   `json:"image,omitempty" yaml:"image,omitempty"`
+	Location              string   `json:"location,omitempty" yaml:"location,omitempty"`
+	ManagedDisks          bool     `json:"managedDisks,omitempty" yaml:"managedDisks,omitempty"`
+	NoPublicIP            bool     `json:"noPublicIp,omitempty" yaml:"noPublicIp,omitempty"`
+	NSG                   string   `json:"nsg,omitempty" yaml:"nsg,omitempty"`
+	Plan                  string   `json:"plan,omitempty" yaml:"plan,omitempty"`
+	OpenPort              []string `json:"openPort,omitempty" yaml:"openPort,omitempty"`
+	PrivateAddressOnly    bool     `json:"privateAddressOnly,omitempty" yaml:"privateAddressOnly,omitempty"`
+	PrivateIPAddress      string   `json:"privateIpAddress,omitempty" yaml:"privateIpAddress,omitempty"`
+	ResourceGroup         string   `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
+	Size                  string   `json:"size,omitempty" yaml:"size,omitempty"`
+	SSHUser               string   `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	StaticPublicIP        bool     `json:"staticPublicIp,omitempty" yaml:"staticPublicIp,omitempty"`
+	StorageType           string   `json:"storageType,omitempty" yaml:"storageType,omitempty"`
+	Subnet                string   `json:"subnet,omitempty" yaml:"subnet,omitempty"`
+	SubnetPrefix          string   `json:"subnetPrefix,omitempty" yaml:"subnetPrefix,omitempty"`
+	SubscriptionID        string   `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
+	UpdateDomainCount     string   `json:"updateDomainCount,omitempty" yaml:"updateDomainCount,omitempty"`
+	UsePrivateIP          bool     `json:"usePrivateIp,omitempty" yaml:"usePrivateIp,omitempty"`
+	Vnet                  string   `json:"vnet,omitempty" yaml:"vnet,omitempty"`
+	AcceleratedNetworking bool     `json:"acceleratedNetworking,omitempty" yaml:"acceleratedNetworking"`
 }
 
 //Schemas

--- a/rancher2/structure_machine_config_v2_azure.go
+++ b/rancher2/structure_machine_config_v2_azure.go
@@ -15,36 +15,37 @@ const (
 //Types
 
 type machineConfigV2Azure struct {
-	metav1.TypeMeta    `json:",inline"`
-	metav1.ObjectMeta  `json:"metadata,omitempty"`
-	AvailabilitySet    string   `json:"availabilitySet,omitempty" yaml:"availabilitySet,omitempty"`
-	ClientID           string   `json:"clientId,omitempty" yaml:"clientId,omitempty"`
-	ClientSecret       string   `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
-	CustomData         string   `json:"customData,omitempty" yaml:"customData,omitempty"`
-	DiskSize           string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
-	DNS                string   `json:"dns,omitempty" yaml:"dns,omitempty"`
-	Environment        string   `json:"environment,omitempty" yaml:"environment,omitempty"`
-	FaultDomainCount   string   `json:"faultDomainCount,omitempty" yaml:"faultDomainCount,omitempty"`
-	Image              string   `json:"image,omitempty" yaml:"image,omitempty"`
-	Location           string   `json:"location,omitempty" yaml:"location,omitempty"`
-	ManagedDisks       bool     `json:"managedDisks,omitempty" yaml:"managedDisks,omitempty"`
-	NoPublicIP         bool     `json:"noPublicIp,omitempty" yaml:"noPublicIp,omitempty"`
-	NSG                string   `json:"nsg,omitempty" yaml:"nsg,omitempty"`
-	OpenPort           []string `json:"openPort,omitempty" yaml:"openPort,omitempty"`
-	PrivateAddressOnly bool     `json:"privateAddressOnly,omitempty" yaml:"privateAddressOnly,omitempty"`
-	PrivateIPAddress   string   `json:"privateIpAddress,omitempty" yaml:"privateIpAddress,omitempty"`
-	ResourceGroup      string   `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
-	Size               string   `json:"size,omitempty" yaml:"size,omitempty"`
-	SSHUser            string   `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
-	StaticPublicIP     bool     `json:"staticPublicIp,omitempty" yaml:"staticPublicIp,omitempty"`
-	StorageType        string   `json:"storageType,omitempty" yaml:"storageType,omitempty"`
-	Subnet             string   `json:"subnet,omitempty" yaml:"subnet,omitempty"`
-	SubnetPrefix       string   `json:"subnetPrefix,omitempty" yaml:"subnetPrefix,omitempty"`
-	SubscriptionID     string   `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
-	TenantID           string   `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
-	UpdateDomainCount  string   `json:"updateDomainCount,omitempty" yaml:"updateDomainCount,omitempty"`
-	UsePrivateIP       bool     `json:"usePrivateIp,omitempty" yaml:"usePrivateIp,omitempty"`
-	Vnet               string   `json:"vnet,omitempty" yaml:"vnet,omitempty"`
+	metav1.TypeMeta       `json:",inline"`
+	metav1.ObjectMeta     `json:"metadata,omitempty"`
+	AvailabilitySet       string   `json:"availabilitySet,omitempty" yaml:"availabilitySet,omitempty"`
+	ClientID              string   `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret          string   `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+	CustomData            string   `json:"customData,omitempty" yaml:"customData,omitempty"`
+	DiskSize              string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
+	DNS                   string   `json:"dns,omitempty" yaml:"dns,omitempty"`
+	Environment           string   `json:"environment,omitempty" yaml:"environment,omitempty"`
+	FaultDomainCount      string   `json:"faultDomainCount,omitempty" yaml:"faultDomainCount,omitempty"`
+	Image                 string   `json:"image,omitempty" yaml:"image,omitempty"`
+	Location              string   `json:"location,omitempty" yaml:"location,omitempty"`
+	ManagedDisks          bool     `json:"managedDisks,omitempty" yaml:"managedDisks,omitempty"`
+	NoPublicIP            bool     `json:"noPublicIp,omitempty" yaml:"noPublicIp,omitempty"`
+	NSG                   string   `json:"nsg,omitempty" yaml:"nsg,omitempty"`
+	OpenPort              []string `json:"openPort,omitempty" yaml:"openPort,omitempty"`
+	PrivateAddressOnly    bool     `json:"privateAddressOnly,omitempty" yaml:"privateAddressOnly,omitempty"`
+	PrivateIPAddress      string   `json:"privateIpAddress,omitempty" yaml:"privateIpAddress,omitempty"`
+	ResourceGroup         string   `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
+	Size                  string   `json:"size,omitempty" yaml:"size,omitempty"`
+	SSHUser               string   `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	StaticPublicIP        bool     `json:"staticPublicIp,omitempty" yaml:"staticPublicIp,omitempty"`
+	StorageType           string   `json:"storageType,omitempty" yaml:"storageType,omitempty"`
+	Subnet                string   `json:"subnet,omitempty" yaml:"subnet,omitempty"`
+	SubnetPrefix          string   `json:"subnetPrefix,omitempty" yaml:"subnetPrefix,omitempty"`
+	SubscriptionID        string   `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
+	TenantID              string   `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
+	UpdateDomainCount     string   `json:"updateDomainCount,omitempty" yaml:"updateDomainCount,omitempty"`
+	UsePrivateIP          bool     `json:"usePrivateIp,omitempty" yaml:"usePrivateIp,omitempty"`
+	Vnet                  string   `json:"vnet,omitempty" yaml:"vnet,omitempty"`
+	AcceleratedNetworking bool     `json:"acceleratedNetworking,omitempty" yaml:"acceleratedNetworking"`
 }
 
 type MachineConfigV2Azure struct {
@@ -161,6 +162,8 @@ func flattenMachineConfigV2Azure(in *MachineConfigV2Azure) []interface{} {
 	if len(in.Vnet) > 0 {
 		obj["vnet"] = in.Vnet
 	}
+
+	obj["accelerated_networking"] = in.AcceleratedNetworking
 
 	return []interface{}{obj}
 }
@@ -293,6 +296,10 @@ func expandMachineConfigV2Azure(p []interface{}, source *MachineConfigV2) *Machi
 
 	if v, ok := in["vnet"].(string); ok && len(v) > 0 {
 		obj.Vnet = v
+	}
+
+	if v, ok := in["accelerated_networking"].(bool); ok {
+		obj.AcceleratedNetworking = v
 	}
 
 	return obj

--- a/rancher2/structure_node_template_azure.go
+++ b/rancher2/structure_node_template_azure.go
@@ -109,6 +109,8 @@ func flattenAzureConfig(in *azureConfig) []interface{} {
 		obj["vnet"] = in.Vnet
 	}
 
+	obj["acclerated_networking"] = in.AcceleratedNetworking
+
 	return []interface{}{obj}
 }
 
@@ -231,6 +233,10 @@ func expandAzureConfig(p []interface{}) *azureConfig {
 
 	if v, ok := in["vnet"].(string); ok && len(v) > 0 {
 		obj.Vnet = v
+	}
+
+	if v, ok := in["accelerated_networking"].(bool); ok {
+		obj.AcceleratedNetworking = v
 	}
 
 	return obj


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/37847

### Problem:
Azure offers Accelerated Networking NIC's. These are dedicated hardware units that offer superior performance and off-loads network related processing from the main CPU into a dedicated CPU located within the stand alone NIC. More information can be found [here](https://azure.microsoft.com/fr-fr/blog/maximize-your-vm-s-performance-with-accelerated-networking-now-generally-available-for-both-windows-and-linux/).

### Solution:
Allow users to specify if they want their new Azure cluster to use Accelerated Networking through terraform. This field can be set for both an RKE1 node template and an RKE2/K3s machine config. 

### Note:
This PR is opened as a draft as its test coverage is dependent upon another terraform PR, https://github.com/rancher/terraform-provider-rancher2/pull/1012