### PR TITLE
Add new field for computed values in App v2 resource

### DIFF
--- a/rancher2/schema_app_v2.go
+++ b/rancher2/schema_app_v2.go
@@ -91,10 +91,12 @@ func appV2Fields() map[string]*schema.Schema {
 			DiffSuppressFunc: suppressAppDiff,
 		},
 		"deployment_values": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Sensitive:   false,
-			Description: "App v2 computed values YAML file",
+			Type:      schema.TypeString,
+			Computed:  true,
+			Sensitive: false,
+			Description: "Values YAML file including computed values. This field prevents incorrect discrepancies from " +
+				"showing in the terraform plan output when files change but values stay the same, due to additional " +
+				"computed values included by the provider itself.",
 		},
 		"cleanup_on_fail": {
 			Type:        schema.TypeBool,
@@ -142,7 +144,7 @@ func validateAppSchema(val interface{}, key string) (warns []string, errs []erro
 	}
 	_, err := ghodssyamlToMapInterface(v)
 	if err != nil {
-		errs = append(errs, fmt.Errorf("%q must be in yaml format, error: %v", key, err))
+		errs = append(errs, fmt.Errorf("[ERROR] %q must be in YAML format, error: %v", key, err))
 		return
 	}
 	return

--- a/rancher2/structure_app_v2.go
+++ b/rancher2/structure_app_v2.go
@@ -71,7 +71,7 @@ func expandChartInstallV2(in *schema.ResourceData, chartInfo *types.ChartInfo) (
 	globalInfo := generateGlobalInfoMap(in)
 	valuesData := v3.MapStringInterface{}
 	if v, ok := in.Get("values").(string); ok {
-		values, err := unmarshallValuesContent(v)
+		values, err := unmarshalValuesContent(v)
 		if err != nil {
 			return "", nil, err
 		}
@@ -201,7 +201,7 @@ func expandChartUpgradeV2(in *schema.ResourceData, chartInfo *types.ChartInfo) (
 	globalInfo := generateGlobalInfoMap(in)
 	valuesData := v3.MapStringInterface{}
 	if v, ok := in.Get("values").(string); ok {
-		values, err := unmarshallValuesContent(v)
+		values, err := unmarshalValuesContent(v)
 		if err != nil {
 			return "", nil, err
 		}
@@ -257,10 +257,10 @@ func expandChartUpgradeV2(in *schema.ResourceData, chartInfo *types.ChartInfo) (
 	return namespace, out, nil
 }
 
-func unmarshallValuesContent(v string) (map[string]interface{}, error) {
+func unmarshalValuesContent(v string) (map[string]interface{}, error) {
 	values, err := ghodssyamlToMapInterface(v)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal chart install values yaml: %#v", err)
+		return nil, fmt.Errorf("[ERROR] failed to unmarshal chart install values YAML: %#v", err)
 	}
 	if values == nil {
 		values = map[string]interface{}{}


### PR DESCRIPTION
# Issue: rancher/terraform-provider-rancher2#576
  
# Problem

The rancher2 Terraform provider always shows differences for the values field upon re-plans or re-applies of an App v2 resource. This happens because the content of this field is marshalled/unmarshalled and new fields are added to it during the flow of execution of the provider.
  
# Solution

* Add a new, computed field for the computed Helm chart deployment values called `deployment_values`.
* Assign the new `deployment_values` field with the content provided via `values` plus other required computed values.
* Use `deployment_values` to install the Helm chart in lieu of `values`, in order to prevent configuration drift upon re-plans/re-applies.
  
# Testing

## Reproduction steps
1. Create a Terraform template that installs a Helm chart to an existing Rancher cluster.
    <details><summary>Sample Terraform template</summary>

    ```terraform
    terraform {
      required_providers {
        rancher2 = {
          source  = "rancher/rancher2"
          version = "~> 1.24.0"
        }
      }
    }

    variable "api_url" {}
    variable "token_key" {}
    variable "cluster_id" {}

    provider "rancher2" {
      api_url     = var.api_url
      token_key   = var.token_key
      insecure    = true
      timeout     = "25s"
    }

    resource "rancher2_app_v2" "dev_monitoring" {
      cluster_id    = var.cluster_id
      name          = "rancher-monitoring"
      namespace     = "cattle-monitoring-system"
      repo_name     = "rancher-charts"
      chart_name    = "rancher-monitoring"
      chart_version = "100.1.2+up19.0.3"
      values        = file("values.yaml")
    }
    ```

    </details>
    <details><summary>Sample values file</summary>

    ```yaml
    defaultRules:
      create: true
      rules:
        alertmanager: true
        etcd: true
        general: true
    additionalPrometheusRules: []
    rkeScheduler:
      enabled: true
    ```

    </details>
2. Install the chart in the cluster:
    ```shell
    terraform init
    terraform plan -out=tfplan \
      -var=cluster_id="<cluster_id>" \
      -var=api_url="<api_url>" \
      -var=token_key="<token_key>"
    terraform apply tfplan
    ```
3. Change the chart version to `100.1.3+up19.0.3`.
4. Re-plan:
    ```shell
    terraform plan -out=tfplan \
      -var=cluster_id="<cluster_id>" \
      -var=api_url="<api_url>" \
      -var=token_key="<token_key>"
    ```
5. The output will show changes in the values field, even though no changes were applied to it.
 
## Engineering Testing
### Manual Testing
* Re-built the provider and installed as a plugin locally, then ran the replication flow as described above.
    _Results_: upon execution of the replication flow, no changes appeared for the values field.
 
### Automated Testing
* No new test cases added.
 
## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test -->
* It's worth testing with different combinations of keys for the values file.
  
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
