### PR TITLE
Update CHANGELOG.md with information regarding #909

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 FEATURES:
 
-* **New Resource:** `admission_configuration` - Admission configuration plugins. Available at Rancher v2.6.9 and above. See [#909](https://github.com/rancher/terraform-provider-rancher2/pull/909)
 * Add Outscale support for node driver. See [#962](https://github.com/rancher/terraform-provider-rancher2/pull/962)
 * Allow setting labels on nodes with RKE2. See [#951](https://github.com/rancher/terraform-provider-rancher2/pull/951)
 
@@ -15,6 +14,10 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * Use existing cluster registration token if conflict. See [#997](https://github.com/rancher/terraform-provider-rancher2/pull/997)
+
+KNOWN BUG:
+
+* An update to the `admission_configuration` field within the kube-api service performed in [#909](https://github.com/rancher/terraform-provider-rancher2/pull/909) prevents provider upgrades from v1.24.1 to v1.24.2 in cases where `admission_configuration` was previously defined due to a type mismatch. See [#1011](https://github.com/rancher/terraform-provider-rancher2/issues/1011)
 
 ## 1.24.1 (September 1, 2022)
 


### PR DESCRIPTION
Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1011


+ Adding a notice into the `CHANGELOG` denoting the inability to upgrade provider versions encountered by community members in issue 1011.
+ Remove the section mentioning that the `admission_configuration` is a new resource, as it should not be used in its current implementation.

This change is intended to indicate to new users of 1.24.2 that the `admission_configuration` field should not be considered stable for this release and will change in the next release (back to the implementation / schema seen in 1.24.1). 

Users who have created clusters prior to 1.24.2, but have not defined an admission configuration, will not encounter issues when using 1.24.2. Users who have defined admission configurations prior to v1.24.2 should wait to upgrade their provider version until v1.24.3 is released. In cases where an admission configuration has been defined in v1.24.2, the terraform state should be recreated upon upgrading to v1.24.3. 