### PR TITLE
Revert "Add admission_configuration configuration"

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1228,41 +1228,6 @@ The following attributes are exported:
 * `service_cluster_ip_range` - (Optional/Computed) Service Cluster IP Range option for kube API service (string)
 * `service_node_port_range` - (Optional/Computed) Service Node Port Range option for kube API service (string)
 
-
-###### `admission_configuration`
-
-###### Arguments
-
-* `api_version` - (Optional) Admission configuration ApiVersion. Default: `apiserver.config.k8s.io/v1` (string)
-* `kind` - (Optional) Admission configuration Kind. Default: `AdmissionConfiguration` (string)
-* `plugins` - (Optional) Admission configuration plugins. (list `plugin`)
-
-###### `plugin`
-
-###### Arguments
-
-* `name` - (Optional) Plugin name. (string)
-* `path` - (Optional) Plugin path. Default: `""` (string)
-* `configuration` - (Optional) Plugin configuration. (string) Ex:
-
-```
-configuration = <<EOF
-apiVersion: pod-security.admission.config.k8s.io/v1alpha1
-kind: PodSecurityConfiguration
-defaults:
-  enforce: restricted
-  enforce-version: latest
-  audit: restricted
-  audit-version: latest
-  warn: restricted
-  warn-version: latest
-exemptions:
-  usernames: []
-  runtimeClasses: []
-  namespaces: []
-EOF
-
-
 ###### `audit_log`
 
 ###### Arguments

--- a/rancher2/schema_cluster_rke_config_services_kube_api.go
+++ b/rancher2/schema_cluster_rke_config_services_kube_api.go
@@ -15,11 +15,9 @@ const (
 	clusterRKEConfigServicesKubeAPIAuditLogConfigPolicyAPIDefault  = "audit.k8s.io/v1"
 	clusterRKEConfigServicesKubeAPIEventRateLimitConfigAPIDefault  = "eventratelimit.admission.k8s.io/v1alpha1"
 	clusterRKEConfigServicesKubeAPIEncryptionConfigAPIDefault      = "apiserver.config.k8s.io/v1"
-	clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault       = "apiserver.config.k8s.io/v1"
 	clusterRKEConfigServicesKubeAPIAuditLogConfigPolicyKindDefault = "Policy"
 	clusterRKEConfigServicesKubeAPIEventRateLimitConfigKindDefault = "Configuration"
 	clusterRKEConfigServicesKubeAPIEncryptionConfigKindDefault     = "EncryptionConfiguration"
-	clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault      = "AdmissionConfiguration"
 )
 
 var (
@@ -120,127 +118,6 @@ func clusterRKEConfigServicesKubeAPIAuditLogFields() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
-		},
-	}
-	return s
-}
-
-func clusterRKEConfigServicesKubeAPIAdmissionConfigurationFieldsV0() map[string]*schema.Schema {
-	s := map[string]*schema.Schema{
-		"api_version": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault,
-			Description: "Admission configuration ApiVersion",
-		},
-		"kind": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault,
-			Description: "Admission configuration Kind",
-		},
-		"plugins": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFieldsV0(),
-			},
-			Description: "Admission configuration plugins",
-		},
-	}
-	return s
-}
-
-func clusterRKEConfigServicesKubeAPIAdmissionConfigurationFields() map[string]*schema.Schema {
-	s := map[string]*schema.Schema{
-		"api_version": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault,
-			Description: "Admission configuration ApiVersion",
-		},
-		"kind": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault,
-			Description: "Admission configuration Kind",
-		},
-		"plugins": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFields(),
-			},
-			Description: "Admission configuration plugins",
-		},
-	}
-	return s
-}
-
-func clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFieldsV0() map[string]*schema.Schema {
-	s := map[string]*schema.Schema{
-		"name": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Computed:    true,
-			Description: "Plugin name",
-		},
-		"path": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     "",
-			Description: "Plugin path",
-		},
-		"configuration": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Computed:    true,
-			Description: "Plugin configuration",
-		},
-	}
-	return s
-}
-func clusterRKEConfigServicesKubeAPIAdmissionConfigPluginsFields() map[string]*schema.Schema {
-	s := map[string]*schema.Schema{
-		"name": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Computed:    true,
-			Description: "Plugin name",
-		},
-		"path": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     "",
-			Description: "Plugin path",
-		},
-		"configuration": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-				v, ok := val.(string)
-				if !ok || len(v) == 0 {
-					return
-				}
-				_, err := ghodssyamlToMapInterface(v)
-				if err != nil {
-					errs = append(errs, fmt.Errorf("%q must be in yaml format, error: %v", key, err))
-					return
-				}
-				return
-			},
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				if old == "" || new == "" {
-					return false
-				}
-				oldMap, _ := ghodssyamlToMapInterface(old)
-				newMap, _ := ghodssyamlToMapInterface(new)
-				return reflect.DeepEqual(oldMap, newMap)
-			},
-			Description: "Plugin configuration",
 		},
 	}
 	return s
@@ -406,13 +283,8 @@ func clusterRKEConfigServicesKubeAPISecretsEncryptionConfigFieldsData() map[stri
 func clusterRKEConfigServicesKubeAPIFieldsV0() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"admission_configuration": {
-			Type:     schema.TypeList,
-			MaxItems: 1,
+			Type:     schema.TypeMap,
 			Optional: true,
-			Elem: &schema.Resource{
-				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigurationFieldsV0(),
-			},
-			Description: "Cluster admission configuration",
 		},
 		"always_pull_images": {
 			Type:     schema.TypeBool,
@@ -489,13 +361,8 @@ func clusterRKEConfigServicesKubeAPIFieldsV0() map[string]*schema.Schema {
 func clusterRKEConfigServicesKubeAPIFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"admission_configuration": {
-			Type:     schema.TypeList,
-			MaxItems: 1,
+			Type:     schema.TypeMap,
 			Optional: true,
-			Elem: &schema.Resource{
-				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigurationFields(),
-			},
-			Description: "Cluster admission configuration",
 		},
 		"always_pull_images": {
 			Type:     schema.TypeBool,
@@ -573,13 +440,8 @@ func clusterRKEConfigServicesKubeAPIFields() map[string]*schema.Schema {
 func clusterRKEConfigServicesKubeAPIFieldsData() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"admission_configuration": {
-			Type:     schema.TypeList,
-			MaxItems: 1,
+			Type:     schema.TypeMap,
 			Optional: true,
-			Elem: &schema.Resource{
-				Schema: clusterRKEConfigServicesKubeAPIAdmissionConfigurationFields(),
-			},
-			Description: "Cluster admission configuration",
 		},
 		"always_pull_images": {
 			Type:     schema.TypeBool,

--- a/rancher2/structure_cluster_rke_config_services_kube_api.go
+++ b/rancher2/structure_cluster_rke_config_services_kube_api.go
@@ -86,54 +86,6 @@ func flattenClusterRKEConfigServicesKubeAPISecretsEncryptionConfig(in *managemen
 	return []interface{}{obj}, nil
 }
 
-func flattenClusterRKEConfigServicesKubeAPIAdmissionConfigurationPlugins(in []interface{}) ([]interface{}, error) {
-	obj := []interface{}{}
-	if len(in) == 0 {
-		return []interface{}{}, nil
-	}
-
-	for _, plugin := range in {
-		pluginMap, ok := plugin.(map[string]interface{})
-		if !ok || len(pluginMap) == 0 {
-			continue // or return, if this is an error condition
-		}
-		var newObj = map[string]interface{}{}
-		newObj["name"] = pluginMap["name"].(string)
-		newObj["path"] = pluginMap["path"].(string)
-		configurationStr, err := mapInterfaceToYAML(pluginMap["configuration"].(map[string]interface{}))
-		if err != nil {
-			return []interface{}{}, fmt.Errorf("Marshalling plugin configuration to yaml for %v: %v", pluginMap["name"], err)
-		}
-		newObj["configuration"] = configurationStr
-		obj = append(obj, newObj)
-	}
-	return obj, nil
-}
-
-func flattenClusterRKEConfigServicesKubeAPIAdmissionConfiguration(in map[string]interface{}) ([]interface{}, error) {
-	obj := make(map[string]interface{})
-	if in == nil {
-		return []interface{}{}, nil
-	}
-
-	if v, ok := in["apiVersion"].(string); ok {
-		obj["api_version"] = v
-	}
-
-	if v, ok := in["kind"].(string); ok {
-		obj["kind"] = v
-	}
-
-	if v, ok := in["plugins"].([]interface{}); ok {
-		plugins, err := flattenClusterRKEConfigServicesKubeAPIAdmissionConfigurationPlugins(v)
-		if err != nil {
-			return []interface{}{}, err
-		}
-		obj["plugins"] = plugins
-	}
-	return []interface{}{obj}, nil
-}
-
 func flattenClusterRKEConfigServicesKubeAPI(in *managementClient.KubeAPIService) ([]interface{}, error) {
 	obj := make(map[string]interface{})
 	if in == nil {
@@ -141,12 +93,7 @@ func flattenClusterRKEConfigServicesKubeAPI(in *managementClient.KubeAPIService)
 	}
 
 	if len(in.AdmissionConfiguration) > 0 {
-		admissionConfig, err := flattenClusterRKEConfigServicesKubeAPIAdmissionConfiguration(in.AdmissionConfiguration)
-		if err != nil {
-			return []interface{}{}, err
-		}
-
-		obj["admission_configuration"] = admissionConfig
+		obj["admission_configuration"] = in.AdmissionConfiguration
 	}
 
 	obj["always_pull_images"] = in.AlwaysPullImages
@@ -263,55 +210,6 @@ func expandClusterRKEConfigServicesKubeAPIAuditLog(p []interface{}) (*management
 	return obj, nil
 }
 
-func expandClusterRKEConfigServicesKubeAPIAdmissionConfigurationPlugins(p []interface{}) ([]interface{}, error) {
-	obj := []interface{}{}
-	if len(p) == 0 || p[0] == nil {
-		return obj, nil
-	}
-	for _, plugin := range p {
-		pluginMap, ok := plugin.(map[string]interface{})
-		if !ok || len(pluginMap) == 0 {
-			continue // or return, if this is an error condition
-		}
-		var newObj = map[string]interface{}{}
-		newObj["name"] = pluginMap["name"].(string)
-		newObj["path"] = pluginMap["path"].(string)
-		configuration, err := ghodssyamlToMapInterface(pluginMap["configuration"].(string))
-		if err != nil {
-			return obj, fmt.Errorf("Unmarshalling plugin configuration from yaml for %v: %v", pluginMap["name"], err)
-		}
-		newObj["configuration"] = configuration
-		obj = append(obj, newObj)
-	}
-	return obj, nil
-}
-
-func expandClusterRKEConfigServicesKubeAPIAdmissionConfiguration(p []interface{}) (map[string]interface{}, error) {
-	obj := make(map[string]interface{})
-	if len(p) == 0 || p[0] == nil {
-		return obj, nil
-	}
-	in := p[0].(map[string]interface{})
-
-	if v, ok := in["api_version"].(string); ok && len(v) > 0 {
-		obj["apiVersion"] = v
-	}
-
-	if v, ok := in["kind"].(string); ok && len(v) > 0 {
-		obj["kind"] = v
-	}
-
-	if v, ok := in["plugins"].([]interface{}); ok && len(v) > 0 {
-		plugins, err := expandClusterRKEConfigServicesKubeAPIAdmissionConfigurationPlugins(v)
-		if err != nil {
-			return nil, err
-		}
-		obj["plugins"] = plugins
-	}
-
-	return obj, nil
-}
-
 func expandClusterRKEConfigServicesKubeAPIEventRateLimit(p []interface{}) *managementClient.EventRateLimit {
 	obj := &managementClient.EventRateLimit{}
 	if len(p) == 0 || p[0] == nil {
@@ -364,12 +262,8 @@ func expandClusterRKEConfigServicesKubeAPI(p []interface{}) (*managementClient.K
 	}
 	in := p[0].(map[string]interface{})
 
-	if v, ok := in["admission_configuration"].([]interface{}); ok && len(v) > 0 {
-		admissionConfig, err := expandClusterRKEConfigServicesKubeAPIAdmissionConfiguration(v)
-		if err != nil {
-			return nil, err
-		}
-		obj.AdmissionConfiguration = admissionConfig
+	if v, ok := in["admission_configuration"].(map[string]interface{}); ok && len(v) > 0 {
+		obj.AdmissionConfiguration = v
 	}
 
 	if v, ok := in["always_pull_images"].(bool); ok {

--- a/rancher2/structure_cluster_rke_config_services_kube_api_test.go
+++ b/rancher2/structure_cluster_rke_config_services_kube_api_test.go
@@ -8,20 +8,16 @@ import (
 )
 
 var (
-	testClusterRKEConfigServicesKubeAPIAuditLogConfigConf                     *managementClient.AuditLogConfig
-	testClusterRKEConfigServicesKubeAPIAuditLogConfigInterface                []interface{}
-	testClusterRKEConfigServicesKubeAPIAuditLogConf                           *managementClient.AuditLog
-	testClusterRKEConfigServicesKubeAPIAuditLogInterface                      []interface{}
-	testClusterRKEConfigServicesKubeAPIEventRateLimitConf                     *managementClient.EventRateLimit
-	testClusterRKEConfigServicesKubeAPIEventRateLimitInterface                []interface{}
-	testClusterRKEConfigServicesKubeAPISecretsEncryptionConfigConf            *managementClient.SecretsEncryptionConfig
-	testClusterRKEConfigServicesKubeAPISecretsEncryptionConfigInterface       []interface{}
-	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationConf             map[string]interface{}
-	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationInterface        []interface{}
-	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsConf      []interface{}
-	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsInterface []interface{}
-	testClusterRKEConfigServicesKubeAPIConf                                   *managementClient.KubeAPIService
-	testClusterRKEConfigServicesKubeAPIInterface                              []interface{}
+	testClusterRKEConfigServicesKubeAPIAuditLogConfigConf               *managementClient.AuditLogConfig
+	testClusterRKEConfigServicesKubeAPIAuditLogConfigInterface          []interface{}
+	testClusterRKEConfigServicesKubeAPIAuditLogConf                     *managementClient.AuditLog
+	testClusterRKEConfigServicesKubeAPIAuditLogInterface                []interface{}
+	testClusterRKEConfigServicesKubeAPIEventRateLimitConf               *managementClient.EventRateLimit
+	testClusterRKEConfigServicesKubeAPIEventRateLimitInterface          []interface{}
+	testClusterRKEConfigServicesKubeAPISecretsEncryptionConfigConf      *managementClient.SecretsEncryptionConfig
+	testClusterRKEConfigServicesKubeAPISecretsEncryptionConfigInterface []interface{}
+	testClusterRKEConfigServicesKubeAPIConf                             *managementClient.KubeAPIService
+	testClusterRKEConfigServicesKubeAPIInterface                        []interface{}
 )
 
 func init() {
@@ -85,43 +81,10 @@ func init() {
 			"custom_config": "apiVersion: " + clusterRKEConfigServicesKubeAPIEncryptionConfigAPIDefault + "\nkind: " + clusterRKEConfigServicesKubeAPIEncryptionConfigKindDefault + "\nresources:\n- {}\n",
 		},
 	}
-	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsConf = []interface{}{
-		map[string]interface{}{
-			"name": "EventRateLimit",
-			"path": "",
-			"configuration": map[string]interface{}{
-				"apiVersion": clusterRKEConfigServicesKubeAPIEventRateLimitConfigAPIDefault,
-				"kind":       clusterRKEConfigServicesKubeAPIEventRateLimitConfigKindDefault,
-				"limits": []interface{}{
-					map[string]interface{}{},
-				},
-			},
-		},
-	}
-	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsInterface = []interface{}{
-		map[string]interface{}{
-			"name":          "EventRateLimit",
-			"path":          "",
-			"configuration": "apiVersion: " + clusterRKEConfigServicesKubeAPIEventRateLimitConfigAPIDefault + "\nkind: " + clusterRKEConfigServicesKubeAPIEventRateLimitConfigKindDefault + "\nlimits:\n- {}\n",
-		},
-	}
-	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationConf = map[string]interface{}{
-		"apiVersion": clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault,
-		"kind":       clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault,
-		"plugins":    testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsConf,
-	}
-	testClusterRKEConfigServicesKubeAPIAdmissionConfigurationInterface = []interface{}{
-		map[string]interface{}{
-			"api_version": clusterRKEConfigServicesKubeAPIAdmissionConfigAPIDefault,
-			"kind":        clusterRKEConfigServicesKubeAPIAdmissionConfigKindDefault,
-			"plugins":     testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsInterface,
-		},
-	}
 	testClusterRKEConfigServicesKubeAPIConf = &managementClient.KubeAPIService{
-		AlwaysPullImages:       true,
-		AuditLog:               testClusterRKEConfigServicesKubeAPIAuditLogConf,
-		EventRateLimit:         testClusterRKEConfigServicesKubeAPIEventRateLimitConf,
-		AdmissionConfiguration: testClusterRKEConfigServicesKubeAPIAdmissionConfigurationConf,
+		AlwaysPullImages: true,
+		AuditLog:         testClusterRKEConfigServicesKubeAPIAuditLogConf,
+		EventRateLimit:   testClusterRKEConfigServicesKubeAPIEventRateLimitConf,
 		ExtraArgs: map[string]string{
 			"arg_one": "one",
 			"arg_two": "two",
@@ -136,10 +99,9 @@ func init() {
 	}
 	testClusterRKEConfigServicesKubeAPIInterface = []interface{}{
 		map[string]interface{}{
-			"always_pull_images":      true,
-			"admission_configuration": testClusterRKEConfigServicesKubeAPIAdmissionConfigurationInterface,
-			"audit_log":               testClusterRKEConfigServicesKubeAPIAuditLogInterface,
-			"event_rate_limit":        testClusterRKEConfigServicesKubeAPIEventRateLimitInterface,
+			"always_pull_images": true,
+			"audit_log":          testClusterRKEConfigServicesKubeAPIAuditLogInterface,
+			"event_rate_limit":   testClusterRKEConfigServicesKubeAPIEventRateLimitInterface,
 			"extra_args": map[string]interface{}{
 				"arg_one": "one",
 				"arg_two": "two",
@@ -272,54 +234,6 @@ func TestFlattenClusterRKEConfigServicesKubeAPI(t *testing.T) {
 	}
 }
 
-func TestFlattenClusterRKEConfigServicesKubeAPIAdmissionConfigurationPlugins(t *testing.T) {
-
-	cases := []struct {
-		Input          []interface{}
-		ExpectedOutput []interface{}
-	}{
-		{
-			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsConf,
-			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsInterface,
-		},
-	}
-
-	for _, tc := range cases {
-		output, err := flattenClusterRKEConfigServicesKubeAPIAdmissionConfigurationPlugins(tc.Input)
-		if err != nil {
-			t.Fatalf("[ERROR] on flattener: %#v", err)
-		}
-		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
-			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
-				tc.ExpectedOutput, output)
-		}
-	}
-}
-
-func TestFlattenClusterRKEConfigServicesKubeAPIAdmissionConfiguration(t *testing.T) {
-
-	cases := []struct {
-		Input          map[string]interface{}
-		ExpectedOutput []interface{}
-	}{
-		{
-			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationConf,
-			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationInterface,
-		},
-	}
-
-	for _, tc := range cases {
-		output, err := flattenClusterRKEConfigServicesKubeAPIAdmissionConfiguration(tc.Input)
-		if err != nil {
-			t.Fatalf("[ERROR] on flattener: %#v", err)
-		}
-		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
-			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
-				tc.ExpectedOutput, output)
-		}
-	}
-}
-
 func TestExpandClusterRKEConfigServicesKubeAPIAuditLogConfig(t *testing.T) {
 
 	cases := []struct {
@@ -429,54 +343,6 @@ func TestExpandClusterRKEConfigServicesKubeAPI(t *testing.T) {
 		}
 		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
 			t.Fatalf("Unexpected output from expander.\nExpected: %#v\nGiven:    %#v",
-				tc.ExpectedOutput, output)
-		}
-	}
-}
-
-func TestExpandClusterRKEConfigServicesKubeAPIAdmissionConfigurationPlugins(t *testing.T) {
-
-	cases := []struct {
-		Input          []interface{}
-		ExpectedOutput []interface{}
-	}{
-		{
-			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsInterface,
-			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationPluginsConf,
-		},
-	}
-
-	for _, tc := range cases {
-		output, err := expandClusterRKEConfigServicesKubeAPIAdmissionConfigurationPlugins(tc.Input)
-		if err != nil {
-			t.Fatalf("[ERROR] on flattener: %#v", err)
-		}
-		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
-			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
-				tc.ExpectedOutput, output)
-		}
-	}
-}
-
-func TestExpandClusterRKEConfigServicesKubeAPIAdmissionConfiguration(t *testing.T) {
-
-	cases := []struct {
-		Input          []interface{}
-		ExpectedOutput map[string]interface{}
-	}{
-		{
-			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationInterface,
-			testClusterRKEConfigServicesKubeAPIAdmissionConfigurationConf,
-		},
-	}
-
-	for _, tc := range cases {
-		output, err := expandClusterRKEConfigServicesKubeAPIAdmissionConfiguration(tc.Input)
-		if err != nil {
-			t.Fatalf("[ERROR] on flattener: %#v", err)
-		}
-		if !reflect.DeepEqual(output, tc.ExpectedOutput) {
-			t.Fatalf("Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
 				tc.ExpectedOutput, output)
 		}
 	}


### PR DESCRIPTION
Reverts rancher/terraform-provider-rancher2#909

Issue: rancher/terraform-provider-rancher2#1011 

Unfortunately rancher/terraform-provider-rancher2#909 introduced breaking changes to existing users who created clusters prior to v1.24.2. This PR reverts those changes and brings the provider back to the initial schema and implementation, wherein the field is simply a map and not a more structured resource. 