### PR TITLE
[Q3] Add script to build local binary

### DIFF
--- a/scripts/build_local_binary.sh
+++ b/scripts/build_local_binary.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+<<comment
+When you run a `make bin` in the terraform-provider-rancher2 repo, it
+downloads a binary into your local cache from the specified source. To
+tell Terraform to use a local binary, you need to overwrite the one in
+the cache.
+
+Add the following to your Terraform config file. This tells Terraform
+to use the local cache https://terraform.io/cli/config/config-file.
+
+terraform {
+required_providers {
+    rancher2 = {
+      source = "terraform.local/local/rancher2"
+      version = "1.0.0"
+    }
+  }
+}
+comment
+
+# Compile the local binary
+make bin
+
+opsys=windows
+if [[ "$OSTYPE" == linux* ]]; then
+  opsys=linux
+elif [[ "$OSTYPE" == darwin* ]]; then
+  opsys=darwin
+fi
+
+# Supported values of 'arch': amd64, arm64, ppc64le, s390x
+case $(uname -m) in
+x86_64)
+    arch=amd64
+    ;;
+arm64)
+    arch=arm64
+    ;;
+ppc64le)
+    arch=ppc64le
+    ;;
+s390x)
+    arch=s390x
+    ;;
+*)
+    arch=amd64
+    ;;
+esac
+
+LOCAL_BINARY_PATH=~/.terraform.d/plugins/terraform.local/local/rancher2/1.0.0/${opsys}_${arch}
+
+if [ ! -d $LOCAL_BINARY_PATH ]
+then
+  echo "Directory ${LOCAL_BINARY_PATH} does not exist. Creating..."
+  mkdir -p $LOCAL_BINARY_PATH
+fi
+
+# Overwrite the cached binary with your local one
+cp terraform-provider-rancher2 ${LOCAL_BINARY_PATH}/terraform-provider-rancher2
+
+# Check if user specified options for init or apply
+while getopts 'ia' OPTION; do
+  case "$OPTION" in
+    i)
+      rm -r .terraform.lock.hcl
+      terraform init
+      ;;
+    a)
+      rm -r .terraform.lock.hcl
+      terraform init
+      terraform apply
+      ;;
+    ?)
+      echo "script usage: $(basename \$0) [-i] [-a]" >&2
+      exit 1
+  esac
+done


### PR DESCRIPTION
Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1156

Devs and customers do _a lot_ of local testing with terraform. There's two ways to test locally: 1) configure Terraform to use a local binary that you've generated, or 2) use an `in-dev` version of the provider with `dev-overrides` [relevant article](https://nicovibert.com/2021/03/29/dev-overrides-terraform/), thank you @git-ival. This script is for automating the first option.

~~I only have the script configured to work with a Mac fs. Feel free to add to the script, add params, or configure it for where Terraform is installed on other systems.~~

I have the script configured to work with most operating sys compatible with Rancher, Mac/linux and win. The user can also specify -i for an additional `terraform init` and/or -a for a `terraform apply` which I've found greatly increases the efficiency of local testing.

## Manual Testing

Tested script to make sure all possible usages run correctly. Example:

```
./scripts/build_local_binary -i -a
```