### PR TITLE
fix(docs): add 'annotations' property

### DIFF
--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -477,6 +477,7 @@ The following attributes are exported:
 * `unhealthy_range` - (Optional) Range of unhealthy nodes for automated replacement to be allowed (string)
 * `machine_labels` - (Optional) Labels for Machine pool nodes (map)
 * `labels` - (Optional) Labels for Machine Deployment Resource (map)
+* `annotations` - (Optional) Annotations for Machine Deployment Resource (map) 
 
 ##### `machine_config`
 


### PR DESCRIPTION
The machine_pools object supports adding annotations (required, for example, when using the rancher provider in the cluster autoscaler) but the documentation does not show this. We had to goto the source code to find this and figured others would have the same issue, adding it into the documentation can make it easier for those who do know know Go or are not programmers to find how to annotate the Machine Deployment object when doing tasks like this easily.