### PR TITLE
Adding the uuid to the global role datasource

### DIFF
--- a/docs/data-sources/global_role.md
+++ b/docs/data-sources/global_role.md
@@ -29,5 +29,6 @@ The following attributes are exported:
 * `description` - (Computed) Global role description (string)
 * `new_user_default` - (Computed) Whether or not this role should be added to new users (bool)
 * `rules` - (Computed) Global role policy rules (list)
+* `uuid` - (Computed) Global role uuid (string)
 * `annotations` - (Computed) Annotations for global role object (map)
 * `labels` - (Computed) Labels for global role object (map)

--- a/rancher2/data_source_rancher2_global_role.go
+++ b/rancher2/data_source_rancher2_global_role.go
@@ -38,6 +38,11 @@ func dataSourceRancher2GlobalRole() *schema.Resource {
 					Schema: policyRuleFields(),
 				},
 			},
+			"uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Global role uuid",
+			},
 			"annotations": {
 				Type:        schema.TypeMap,
 				Computed:    true,

--- a/rancher2/schema_global_role.go
+++ b/rancher2/schema_global_role.go
@@ -39,6 +39,11 @@ func globalRoleFields() map[string]*schema.Schema {
 				Schema: policyRuleFields(),
 			},
 		},
+		"uuid": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Global role uuid",
+		},
 	}
 
 	for k, v := range commonAnnotationLabelFields() {

--- a/rancher2/structure_global_role.go
+++ b/rancher2/structure_global_role.go
@@ -28,6 +28,8 @@ func flattenGlobalRole(d *schema.ResourceData, in *managementClient.GlobalRole) 
 		return err
 	}
 
+	d.Set("uuid", in.UUID)
+
 	err = d.Set("annotations", toMapInterface(in.Annotations))
 	if err != nil {
 		return err
@@ -71,6 +73,8 @@ func expandGlobalRole(in *schema.ResourceData) *managementClient.GlobalRole {
 	if v, ok := in.Get("labels").(map[string]interface{}); ok && len(v) > 0 {
 		obj.Labels = toMapString(v)
 	}
+
+	obj.UUID = in.Get("uuid").(string)
 
 	return obj
 }


### PR DESCRIPTION
This is related to https://github.com/rancher/rancher/issues/39742
Exporting the global role uuid allows api calls to update the built-in global roles.