### PR TITLE
Add terraform node group node role

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -357,7 +357,7 @@ resource "rancher2_cluster" "foo" {
   eks_config_v2 {
     cloud_credential_id = rancher2_cloud_credential.foo.id
     region = "<EKS_REGION>"
-    kubernetes_version = "1.17"
+    kubernetes_version = "1.24"
     logging_types = ["audit", "api"]
     node_groups {
       name = "node_group1"
@@ -370,6 +370,7 @@ resource "rancher2_cluster" "foo" {
       instance_type = "m5.xlarge"
       desired_size = 2
       max_size = 3
+      node_role = "arn:aws:iam::role/test-NodeInstanceRole"
     }
     private_access = true
     public_access = false
@@ -394,7 +395,7 @@ resource "rancher2_cluster" "foo" {
   eks_config_v2 {
     cloud_credential_id = rancher2_cloud_credential.foo.id
     region = "<EKS_REGION>"
-    kubernetes_version = "1.17"
+    kubernetes_version = "1.24"
     logging_types = ["audit", "api"]
     node_groups {
       desired_size = 3
@@ -514,7 +515,7 @@ resource "rancher2_cluster" "foo" {
     resource_group = "<RESOURCE_GROUP>"
     resource_location = "<RESOURCE_LOCATION>"
     dns_prefix = "<DNS_PREFIX>"
-    kubernetes_version = "1.21.2"
+    kubernetes_version = "1.24.6"
     network_plugin = "<NETWORK_PLUGIN>"
     node_pools {
       availability_zones = ["1", "2", "3"]
@@ -1525,7 +1526,7 @@ The following arguments are supported:
 * `launch_template` - (Optional) The EKS node groups launch template (list Maxitem: 1)
 * `max_size` - (Optional) The EKS node group maximum size. Default `2` (int)
 * `min_size` - (Optional) The EKS node group maximum size. Default `2` (int)
-* `node_role` - (Optional) The EKS node group node role. Default `""` (string)
+* `node_role` - (Optional) The EKS node group node role ARN. Default `""` (string)
 * `request_spot_instances` - (Optional) Enable EKS node group request spot instances (bool)
 * `resource_tags` - (Optional) The EKS node group resource tags (map)
 * `spot_instance_types` - (Optional) The EKS node group sport instace types (list string)

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1525,6 +1525,7 @@ The following arguments are supported:
 * `launch_template` - (Optional) The EKS node groups launch template (list Maxitem: 1)
 * `max_size` - (Optional) The EKS node group maximum size. Default `2` (int)
 * `min_size` - (Optional) The EKS node group maximum size. Default `2` (int)
+* `node_role` - (Optional) The EKS node group node role. Default `""` (string)
 * `request_spot_instances` - (Optional) Enable EKS node group request spot instances (bool)
 * `resource_tags` - (Optional) The EKS node group resource tags (map)
 * `spot_instance_types` - (Optional) The EKS node group sport instace types (list string)

--- a/rancher2/schema_cluster_eks_config_v2.go
+++ b/rancher2/schema_cluster_eks_config_v2.go
@@ -110,7 +110,7 @@ func clusterEKSConfigV2NodeGroupsFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Default:     "",
-			Description: "The EKS node group node role",
+			Description: "The EKS node group node role ARN",
 		},
 		"request_spot_instances": {
 			Type:        schema.TypeBool,

--- a/rancher2/schema_cluster_eks_config_v2.go
+++ b/rancher2/schema_cluster_eks_config_v2.go
@@ -126,7 +126,7 @@ func clusterEKSConfigV2NodeGroupsFields() map[string]*schema.Schema {
 		"spot_instance_types": {
 			Type:        schema.TypeList,
 			Optional:    true,
-			Description: "The EKS node group spot instace types",
+			Description: "The EKS node group spot instance types",
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},

--- a/rancher2/schema_cluster_eks_config_v2.go
+++ b/rancher2/schema_cluster_eks_config_v2.go
@@ -106,6 +106,12 @@ func clusterEKSConfigV2NodeGroupsFields() map[string]*schema.Schema {
 			Default:     2,
 			Description: "The EKS node group minimum size",
 		},
+		"node_role": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "",
+			Description: "The EKS node group node role",
+		},
 		"request_spot_instances": {
 			Type:        schema.TypeBool,
 			Optional:    true,

--- a/rancher2/structure_cluster_eks_config_v2.go
+++ b/rancher2/structure_cluster_eks_config_v2.go
@@ -75,6 +75,9 @@ func flattenClusterEKSConfigV2NodeGroups(input []managementClient.NodeGroup, p [
 		if in.MinSize != nil {
 			obj["min_size"] = int(*in.MinSize)
 		}
+		if in.NodeRole != nil && len(*in.NodeRole) > 0 {
+			obj["node_role"] = *in.NodeRole
+		}
 		if in.RequestSpotInstances != nil {
 			obj["request_spot_instances"] = *in.RequestSpotInstances
 		}
@@ -206,7 +209,6 @@ func expandClusterEKSConfigV2NodeGroups(p []interface{}, subnets []string, versi
 		if v, ok := in["instance_type"].(string); ok {
 			obj.InstanceType = &v
 		}
-
 		if v, ok := in["desired_size"].(int); ok {
 			size := int64(v)
 			obj.DesiredSize = &size
@@ -238,6 +240,9 @@ func expandClusterEKSConfigV2NodeGroups(p []interface{}, subnets []string, versi
 		if v, ok := in["min_size"].(int); ok {
 			size := int64(v)
 			obj.MinSize = &size
+		}
+		if v, ok := in["node_role"].(string); ok {
+			obj.NodeRole = &v
 		}
 		if v, ok := in["request_spot_instances"].(bool); ok {
 			obj.RequestSpotInstances = &v

--- a/rancher2/structure_cluster_eks_config_v2_test.go
+++ b/rancher2/structure_cluster_eks_config_v2_test.go
@@ -47,6 +47,7 @@ func init() {
 			LaunchTemplate:       testClusterEKSConfigV2NodeGroupLaunchTemplateConf,
 			MaxSize:              &size,
 			MinSize:              &size,
+			NodeRole:             newString(""),
 			RequestSpotInstances: newTrue(),
 			ResourceTags: map[string]string{
 				"rstag1": "one",
@@ -78,6 +79,7 @@ func init() {
 			"launch_template":        testClusterEKSConfigV2NodeGroupLaunchTemplateInterface,
 			"max_size":               3,
 			"min_size":               3,
+			"node_role":              "",
 			"request_spot_instances": true,
 			"resource_tags": map[string]interface{}{
 				"rstag1": "one",


### PR DESCRIPTION
Issue: Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1047
<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Add Terraform support for node group node role feature in EKS.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The following things have been added in this PR
* Terraform rancher2 `eks_config_v2.node_role` field where you can specify the EKS node group node role ARN (it will not work with just the name that is selectable from the rancher ui)
* Terraform docs update for `node_role`
* Terraform docs update Kubernetes versions
* Add `node_role` to tests

## Testing

### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

I tested this issue using [this test plan](https://github.com/rancher/terraform-provider-rancher2/issues/1047#issuecomment-1403670632) on three EKS clusters provisioned via a local version of my Terraform provider with node role support.