### PR TITLE
Update Harvester node driver to support multi nics and disks

### DIFF
--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -280,6 +280,17 @@ resource "rancher2_machine_config_v2" "foo-harvester-v2" {
     }
     EOF
     ssh_user = "ubuntu"
+    user_data = <<EOF
+    package_update: true
+    packages:
+      - qemu-guest-agent
+      - iptables
+    runcmd:
+      - - systemctl
+        - enable
+        - '--now'
+        - qemu-guest-agent.service
+    EOF
   }
 }
 
@@ -379,6 +390,17 @@ resource "rancher2_machine_config_v2" "foo-harvester-v2-cloud-provider" {
     }
     EOF
     ssh_user = "ubuntu"
+    user_data = <<EOF
+    package_update: true
+    packages:
+      - qemu-guest-agent
+      - iptables
+    runcmd:
+      - - systemctl
+        - enable
+        - '--now'
+        - qemu-guest-agent.service
+    EOF
   }
 }
 

--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -285,7 +285,7 @@ resource "rancher2_machine_config_v2" "foo-harvester-v2" {
 
 resource "rancher2_cluster_v2" "foo-harvester-v2" {
   name = "foo-harvester-v2"
-  kubernetes_version = "v1.22.6+rke2r1"
+  kubernetes_version = "v1.24.10+rke2r1"
   rke_config {
     machine_pools {
       name = "pool1"
@@ -385,7 +385,7 @@ resource "rancher2_machine_config_v2" "foo-harvester-v2-cloud-provider" {
 # Create a new harvester rke2 cluster with harvester cloud provider
 resource "rancher2_cluster_v2" "foo-harvester-v2-cloud-provider" {
   name = "foo-harvester-v2-cloud-provider"
-  kubernetes_version = "v1.22.6+rke2r1"
+  kubernetes_version = "v1.24.10+rke2r1"
   rke_config {
     machine_pools {
       name = "pool1"

--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -262,9 +262,23 @@ resource "rancher2_machine_config_v2" "foo-harvester-v2" {
     vm_namespace = "default"
     cpu_count = "2"
     memory_size = "4"
-    disk_size = "40"
-    network_name = "harvester-public/vlan1"
-    image_name = "harvester-public/image-57hzg"
+    disk_info = <<EOF
+    {
+        "disks": [{
+            "imageName": "harvester-public/image-57hzg",
+            "size": 40,
+            "bootOrder": 1
+        }]
+    }
+    EOF
+    network_info = <<EOF
+    {
+        "interfaces": [{
+            "networkName": "harvester-public/vlan1",
+            "macAddress": ""
+        }]
+    }
+    EOF
     ssh_user = "ubuntu"
   }
 }
@@ -347,9 +361,23 @@ resource "rancher2_machine_config_v2" "foo-harvester-v2-cloud-provider" {
     vm_namespace = "default"
     cpu_count = "2"
     memory_size = "4"
-    disk_size = "40"
-    network_name = "harvester-public/vlan1"
-    image_name = "harvester-public/image-57hzg"
+    disk_info = <<EOF
+    {
+        "disks": [{
+            "imageName": "harvester-public/image-57hzg",
+            "size": 40,
+            "bootOrder": 1
+        }]
+    }
+    EOF
+    network_info = <<EOF
+    {
+        "interfaces": [{
+            "networkName": "harvester-public/vlan1",
+            "macAddress": ""
+        }]
+    }
+    EOF
     ssh_user = "ubuntu"
   }
 }

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -69,6 +69,17 @@ resource "rancher2_machine_config_v2" "foo-harvester-v2" {
     }
     EOF
     ssh_user = "ubuntu"
+    user_data = <<EOF
+    package_update: true
+    packages:
+      - qemu-guest-agent
+      - iptables
+    runcmd:
+      - - systemctl
+        - enable
+        - '--now'
+        - qemu-guest-agent.service
+    EOF
   }
 }
 ```
@@ -210,7 +221,7 @@ The following attributes are exported:
 * `network_name` - (Deprecated) Use `network_info` instead
 * `network_model` - (Deprecated) Use `network_info` instead
 * `network_info` - (Required) A JSON string specifying info for the networks e.g. `{\"interfaces\":[{\"networkName\":\"harvester-public/vlan1\",\"macAddress\":\"\"},{\"networkName\":\"harvester-public/vlan2\",\"macAddress\":\"5a:e7:c5:24:5b:44\"}]}` (string)
-* `user_data` - (Optional) UserData content of cloud-init, base64 is supported (string)
+* `user_data` - (Optional) UserData content of cloud-init, base64 is supported. If the image does not contain the qemu-guest-agent package, you must install and start qemu-guest-agent using userdata (string)
 * `network_data` - (Optional) NetworkData content of cloud-init, base64 is supported (string)
 * `vm_affinity` - (Optional) Virtual machine affinity, base64 is supported. For Rancher v2.6.7 or above (string)
 

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -51,9 +51,23 @@ resource "rancher2_machine_config_v2" "foo-harvester-v2" {
     vm_namespace = "default"
     cpu_count = "2"
     memory_size = "4"
-    disk_size = "40"
-    network_name = "harvester-public/vlan1"
-    image_name = "harvester-public/image-57hzg"
+    disk_info = <<EOF
+    {
+        "disks": [{
+            "imageName": "harvester-public/image-57hzg",
+            "size": 40,
+            "bootOrder": 1
+        }]
+    }
+    EOF
+    network_info = <<EOF
+    {
+        "interfaces": [{
+            "networkName": "harvester-public/vlan1",
+            "macAddress": ""
+        }]
+    }
+    EOF
     ssh_user = "ubuntu"
   }
 }
@@ -187,13 +201,15 @@ The following attributes are exported:
 * `vm_namespace` - (Required) Virtual machine namespace e.g. `default` (string)
 * `cpu_count` - (Optional) CPU count, Default `2` (string)
 * `memory_size` - (Optional) Memory size (in GiB), Default `4` (string)
-* `disk_size` - (Optional) Disk size (in GiB), Default `40` (string)
-* `disk_bus` - (Optional) Disk bus, Default `virtio` (string)
-* `image_name` - (Required) Image name e.g. `harvester-public/image-57hzg` (string)
+* `disk_size` - (Deprecated) Use `disk_info` instead
+* `disk_bus` - (Deprecated) Use `disk_info` instead
+* `image_name` - (Deprecated) Use `disk_info` instead
+* `disk_info` - (Required) A JSON string specifying info for the disks e.g. `{\"disks\":[{\"imageName\":\"harvester-public/image-57hzg\",\"bootOrder\":1,\"size\":40},{\"storageClassName\":\"node-driver-test\",\"bootOrder\":2,\"size\":1}]}` (string)
 * `ssh_user` - (Required) SSH username e.g. `ubuntu` (string)
 * `ssh_password` - (Optional/Sensitive) SSH password (string)
-* `network_name` - (Required) Network name e.g. `harvester-public/vlan1` (string)
-* `network_model` - (Optional) Network model, Default `virtio` (string)
+* `network_name` - (Deprecated) Use `network_info` instead
+* `network_model` - (Deprecated) Use `network_info` instead
+* `network_info` - (Required) A JSON string specifying info for the networks e.g. `{\"interfaces\":[{\"networkName\":\"harvester-public/vlan1\",\"macAddress\":\"\"},{\"networkName\":\"harvester-public/vlan2\",\"macAddress\":\"5a:e7:c5:24:5b:44\"}]}` (string)
 * `user_data` - (Optional) UserData content of cloud-init, base64 is supported (string)
 * `network_data` - (Optional) NetworkData content of cloud-init, base64 is supported (string)
 * `vm_affinity` - (Optional) Virtual machine affinity, base64 is supported. For Rancher v2.6.7 or above (string)

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -100,6 +100,17 @@ resource "rancher2_node_template" "foo-harvester" {
     }
     EOF
     ssh_user = "ubuntu"
+    user_data = <<EOF
+    package_update: true
+    packages:
+      - qemu-guest-agent
+      - iptables
+    runcmd:
+      - - systemctl
+        - enable
+        - '--now'
+        - qemu-guest-agent.service
+    EOF
   }
 }
 ```
@@ -278,7 +289,7 @@ The following attributes are exported:
 * `network_name` - (Deprecated) Use `network_info` instead
 * `network_model` - (Deprecated) Use `network_info` instead
 * `network_info` - (Required) A JSON string specifying info for the networks e.g. `{\"interfaces\":[{\"networkName\":\"harvester-public/vlan1\",\"macAddress\":\"\"},{\"networkName\":\"harvester-public/vlan2\",\"macAddress\":\"5a:e7:c5:24:5b:44\"}]}` (string)
-* `user_data` - (Optional) UserData content of cloud-init, base64 is supported (string)
+* `user_data` - (Optional) UserData content of cloud-init, base64 is supported. If the image does not contain the qemu-guest-agent package, you must install and start qemu-guest-agent using userdata (string)
 * `network_data` - (Optional) NetworkData content of cloud-init, base64 is supported (string)
 * `vm_affinity` - (Optional) Virtual machine affinity, base64 is supported. For Rancher v2.6.7 or above (string)
 

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -82,9 +82,23 @@ resource "rancher2_node_template" "foo-harvester" {
     vm_namespace = "default"
     cpu_count = "2"
     memory_size = "4"
-    disk_size = "40"
-    network_name = "harvester-public/vlan1"
-    image_name = "harvester-public/image-57hzg"
+    disk_info = <<EOF
+    {
+        "disks": [{
+            "imageName": "harvester-public/image-57hzg",
+            "size": 40,
+            "bootOrder": 1
+        }]
+    }
+    EOF
+    network_info = <<EOF
+    {
+        "interfaces": [{
+            "networkName": "harvester-public/vlan1",
+            "macAddress": ""
+        }]
+    }
+    EOF
     ssh_user = "ubuntu"
   }
 }
@@ -255,13 +269,15 @@ The following attributes are exported:
 * `vm_namespace` - (Required) Virtual machine namespace e.g. `default` (string)
 * `cpu_count` - (Optional) CPU count, Default `2` (string)
 * `memory_size` - (Optional) Memory size (in GiB), Default `4` (string)
-* `disk_size` - (Optional) Disk size (in GiB), Default `40` (string)
-* `disk_bus` - (Optional) Disk bus, Default `virtio` (string)
-* `image_name` - (Required) Image name e.g. `harvester-public/image-57hzg` (string)
+* `disk_size` - (Deprecated) Use `disk_info` instead
+* `disk_bus` - (Deprecated) Use `disk_info` instead
+* `image_name` - (Deprecated) Use `disk_info` instead
+* `disk_info` - (Required) A JSON string specifying info for the disks e.g. `{\"disks\":[{\"imageName\":\"harvester-public/image-57hzg\",\"bootOrder\":1,\"size\":40},{\"storageClassName\":\"node-driver-test\",\"bootOrder\":2,\"size\":1}]}` (string)
 * `ssh_user` - (Required) SSH username e.g. `ubuntu` (string)
 * `ssh_password` - (Optional/Sensitive) SSH password (string)
-* `network_name` - (Required) Network name e.g. `harvester-public/vlan1` (string)
-* `network_model` - (Optional) Network model, Default `virtio` (string)
+* `network_name` - (Deprecated) Use `network_info` instead
+* `network_model` - (Deprecated) Use `network_info` instead
+* `network_info` - (Required) A JSON string specifying info for the networks e.g. `{\"interfaces\":[{\"networkName\":\"harvester-public/vlan1\",\"macAddress\":\"\"},{\"networkName\":\"harvester-public/vlan2\",\"macAddress\":\"5a:e7:c5:24:5b:44\"}]}` (string)
 * `user_data` - (Optional) UserData content of cloud-init, base64 is supported (string)
 * `network_data` - (Optional) NetworkData content of cloud-init, base64 is supported (string)
 * `vm_affinity` - (Optional) Virtual machine affinity, base64 is supported. For Rancher v2.6.7 or above (string)

--- a/rancher2/resource_rancher2_node_template_test.go
+++ b/rancher2/resource_rancher2_node_template_test.go
@@ -120,6 +120,17 @@ resource "` + testAccRancher2NodeTemplateType + `" "foo-harvester" {
     EOF
 	ssh_user = "ubuntu"
 	vm_namespace = "test"
+    user_data = <<EOF
+    package_update: true
+    packages:
+      - qemu-guest-agent
+      - iptables
+    runcmd:
+      - - systemctl
+        - enable
+        - '--now'
+        - qemu-guest-agent.service
+    EOF
   }
 }
 `
@@ -150,6 +161,17 @@ resource "` + testAccRancher2NodeTemplateType + `" "foo-harvester" {
     EOF
 	ssh_user = "ubuntu"
 	vm_namespace = "test"
+    user_data = <<EOF
+    package_update: true
+    packages:
+      - qemu-guest-agent
+      - iptables
+    runcmd:
+      - - systemctl
+        - enable
+        - '--now'
+        - qemu-guest-agent.service
+    EOF
   }
 }
 `

--- a/rancher2/resource_rancher2_node_template_test.go
+++ b/rancher2/resource_rancher2_node_template_test.go
@@ -101,8 +101,23 @@ resource "` + testAccRancher2NodeTemplateType + `" "foo-harvester" {
   harvester_config {
     cpu_count = "2"
     memory_size = "4"
-	image_name = "foo"
-	network_name = "test-net"
+    disk_info = <<EOF
+    {
+        "disks": [{
+            "imageName": "foo",
+            "size": 40,
+            "bootOrder": 1
+        }]
+    }
+    EOF
+    network_info = <<EOF
+    {
+        "interfaces": [{
+            "networkName": "test-net",
+            "macAddress": ""
+        }]
+    }
+    EOF
 	ssh_user = "ubuntu"
 	vm_namespace = "test"
   }
@@ -116,8 +131,23 @@ resource "` + testAccRancher2NodeTemplateType + `" "foo-harvester" {
   harvester_config {
     cpu_count = "4"
     memory_size = "8"
-	image_name = "foo"
-	network_name = "test-net"
+    disk_info = <<EOF
+    {
+        "disks": [{
+            "imageName": "foo",
+            "size": 40,
+            "bootOrder": 1
+        }]
+    }
+    EOF
+    network_info = <<EOF
+    {
+        "interfaces": [{
+            "networkName": "test-net",
+            "macAddress": ""
+        }]
+    }
+    EOF
 	ssh_user = "ubuntu"
 	vm_namespace = "test"
   }

--- a/rancher2/schema_machine_config_v2_harvester.go
+++ b/rancher2/schema_machine_config_v2_harvester.go
@@ -2,7 +2,6 @@ package rancher2
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 //Schemas
@@ -34,24 +33,25 @@ func machineConfigV2HarvesterFields() map[string]*schema.Schema {
 		"disk_size": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "40",
 			Description: "Disk size (in GiB)",
+			Deprecated:  "Use disk_info instead",
 		},
 		"disk_bus": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  harvesterDiskBusVIRTIO,
-			ValidateFunc: validation.StringInSlice([]string{
-				harvesterDiskBusVIRTIO,
-				harvesterDiskBusSATA,
-				harvesterDiskBusSCSI,
-			}, false),
+			Type:        schema.TypeString,
+			Optional:    true,
 			Description: "Disk bus",
+			Deprecated:  "Use disk_info instead",
 		},
 		"image_name": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "Image name",
+			Deprecated:  "Use disk_info instead",
+		},
+		"disk_info": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "A JSON string specifying info for the disks e.g. `{\"disks\":[{\"imageName\":\"harvester-public/image-57hzg\",\"bootOrder\":1,\"size\":40},{\"storageClassName\":\"node-driver-test\",\"bootOrder\":2,\"size\":1}]}`",
 		},
 		"ssh_user": {
 			Type:        schema.TypeString,
@@ -66,22 +66,20 @@ func machineConfigV2HarvesterFields() map[string]*schema.Schema {
 		},
 		"network_name": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "Network name",
+			Deprecated:  "Use network_info instead",
 		},
 		"network_model": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  harvesterNetworkModelVIRTIO,
-			ValidateFunc: validation.StringInSlice([]string{
-				harvesterNetworkModelVIRTIO,
-				harvesterNetworkModelE1000,
-				harvesterNetworkModelE1000E,
-				harvesterNetworkModelNE2KPCO,
-				harvesterNetworkModelPCNET,
-				harvesterNetworkModelRTL8139,
-			}, false),
+			Type:        schema.TypeString,
+			Optional:    true,
 			Description: "Network model",
+			Deprecated:  "Use network_info instead",
+		},
+		"network_info": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "A JSON string specifying info for the networks e.g. `{\"interfaces\":[{\"networkName\":\"harvester-public/vlan1\",\"macAddress\":\"\"},{\"networkName\":\"harvester-public/vlan2\",\"macAddress\":\"5a:e7:c5:24:5b:44\"}]}`",
 		},
 		"user_data": {
 			Type:        schema.TypeString,

--- a/rancher2/schema_machine_config_v2_harvester.go
+++ b/rancher2/schema_machine_config_v2_harvester.go
@@ -84,7 +84,7 @@ func machineConfigV2HarvesterFields() map[string]*schema.Schema {
 		"user_data": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "UserData content of cloud-init, base64 is supported",
+			Description: "UserData content of cloud-init, base64 is supported. If the image does not contain the qemu-guest-agent package, you must install and start qemu-guest-agent using userdata",
 		},
 		"network_data": {
 			Type:        schema.TypeString,

--- a/rancher2/schema_node_template_harvester.go
+++ b/rancher2/schema_node_template_harvester.go
@@ -2,7 +2,6 @@ package rancher2
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 const (
@@ -30,10 +29,12 @@ type harvesterConfig struct {
 	DiskSize     string `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
 	DiskBus      string `json:"diskBus,omitempty" yaml:"diskBus,omitempty"`
 	ImageName    string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
+	DiskInfo     string `json:"diskInfo,omitempty" yaml:"diskInfo,omitempty"`
 	SSHUser      string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
 	SSHPassword  string `json:"sshPassword,omitempty" yaml:"sshPassword,omitempty"`
 	NetworkName  string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
 	NetworkModel string `json:"networkModel,omitempty" yaml:"networkModel,omitempty"`
+	NetworkInfo  string `json:"networkInfo,omitempty" yaml:"networkInfo,omitempty"`
 	UserData     string `json:"userData,omitempty" yaml:"userData,omitempty"`
 	NetworkData  string `json:"networkData,omitempty" yaml:"networkData,omitempty"`
 }
@@ -67,24 +68,25 @@ func harvesterConfigFields() map[string]*schema.Schema {
 		"disk_size": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "40",
 			Description: "Disk size (in GiB)",
+			Deprecated:  "Use disk_info instead",
 		},
 		"disk_bus": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  harvesterDiskBusVIRTIO,
-			ValidateFunc: validation.StringInSlice([]string{
-				harvesterDiskBusVIRTIO,
-				harvesterDiskBusSATA,
-				harvesterDiskBusSCSI,
-			}, false),
+			Type:        schema.TypeString,
+			Optional:    true,
 			Description: "Disk bus",
+			Deprecated:  "Use disk_info instead",
 		},
 		"image_name": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "Image name",
+			Deprecated:  "Use disk_info instead",
+		},
+		"disk_info": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "A JSON string specifying info for the disks e.g. `{\"disks\":[{\"imageName\":\"harvester-public/image-57hzg\",\"bootOrder\":1,\"size\":40},{\"storageClassName\":\"node-driver-test\",\"bootOrder\":2,\"size\":1}]}`",
 		},
 		"ssh_user": {
 			Type:        schema.TypeString,
@@ -99,22 +101,20 @@ func harvesterConfigFields() map[string]*schema.Schema {
 		},
 		"network_name": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "Network name",
+			Deprecated:  "Use network_info instead",
 		},
 		"network_model": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  harvesterNetworkModelVIRTIO,
-			ValidateFunc: validation.StringInSlice([]string{
-				harvesterNetworkModelVIRTIO,
-				harvesterNetworkModelE1000,
-				harvesterNetworkModelE1000E,
-				harvesterNetworkModelNE2KPCO,
-				harvesterNetworkModelPCNET,
-				harvesterNetworkModelRTL8139,
-			}, false),
+			Type:        schema.TypeString,
+			Optional:    true,
 			Description: "Network model",
+			Deprecated:  "Use network_info instead",
+		},
+		"network_info": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "A JSON string specifying info for the networks e.g. `{\"interfaces\":[{\"networkName\":\"harvester-public/vlan1\",\"macAddress\":\"\"},{\"networkName\":\"harvester-public/vlan2\",\"macAddress\":\"5a:e7:c5:24:5b:44\"}]}`",
 		},
 		"user_data": {
 			Type:        schema.TypeString,

--- a/rancher2/schema_node_template_harvester.go
+++ b/rancher2/schema_node_template_harvester.go
@@ -119,7 +119,7 @@ func harvesterConfigFields() map[string]*schema.Schema {
 		"user_data": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "UserData content of cloud-init, base64 is supported",
+			Description: "UserData content of cloud-init, base64 is supported. If the image does not contain the qemu-guest-agent package, you must install and start qemu-guest-agent using userdata",
 		},
 		"network_data": {
 			Type:        schema.TypeString,

--- a/rancher2/structure_machine_config_v2_harvester.go
+++ b/rancher2/structure_machine_config_v2_harvester.go
@@ -24,10 +24,12 @@ type machineConfigV2Harvester struct {
 	DiskSize          string `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
 	DiskBus           string `json:"diskBus,omitempty" yaml:"diskBus,omitempty"`
 	ImageName         string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
+	DiskInfo          string `json:"diskInfo,omitempty" yaml:"diskInfo,omitempty"`
 	SSHUser           string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
 	SSHPassword       string `json:"sshPassword,omitempty" yaml:"sshPassword,omitempty"`
 	NetworkName       string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
 	NetworkModel      string `json:"networkModel,omitempty" yaml:"networkModel,omitempty"`
+	NetworkInfo       string `json:"networkInfo,omitempty" yaml:"networkInfo,omitempty"`
 	UserData          string `json:"userData,omitempty" yaml:"userData,omitempty"`
 	NetworkData       string `json:"networkData,omitempty" yaml:"networkData,omitempty"`
 }
@@ -74,6 +76,10 @@ func flattenMachineConfigV2Harvester(in *MachineConfigV2Harvester) []interface{}
 		obj["image_name"] = in.ImageName
 	}
 
+	if len(in.DiskInfo) > 0 {
+		obj["disk_info"] = in.DiskInfo
+	}
+
 	if len(in.SSHUser) > 0 {
 		obj["ssh_user"] = in.SSHUser
 	}
@@ -88,6 +94,10 @@ func flattenMachineConfigV2Harvester(in *MachineConfigV2Harvester) []interface{}
 
 	if len(in.NetworkModel) > 0 {
 		obj["network_model"] = in.NetworkModel
+	}
+
+	if len(in.NetworkInfo) > 0 {
+		obj["network_info"] = in.NetworkInfo
 	}
 
 	if len(in.UserData) > 0 {
@@ -147,6 +157,10 @@ func expandMachineConfigV2Harvester(p []interface{}, source *MachineConfigV2) *M
 		obj.ImageName = v
 	}
 
+	if v, ok := in["disk_info"].(string); ok && len(v) > 0 {
+		obj.DiskInfo = v
+	}
+
 	if v, ok := in["ssh_user"].(string); ok && len(v) > 0 {
 		obj.SSHUser = v
 	}
@@ -161,6 +175,10 @@ func expandMachineConfigV2Harvester(p []interface{}, source *MachineConfigV2) *M
 
 	if v, ok := in["network_model"].(string); ok && len(v) > 0 {
 		obj.NetworkModel = v
+	}
+
+	if v, ok := in["network_info"].(string); ok && len(v) > 0 {
+		obj.NetworkInfo = v
 	}
 
 	if v, ok := in["user_data"].(string); ok && len(v) > 0 {

--- a/rancher2/structure_node_template_harvester.go
+++ b/rancher2/structure_node_template_harvester.go
@@ -36,6 +36,10 @@ func flattenHarvesterConfig(in *harvesterConfig) []interface{} {
 		obj["image_name"] = in.ImageName
 	}
 
+	if len(in.DiskInfo) > 0 {
+		obj["disk_info"] = in.DiskInfo
+	}
+
 	if len(in.SSHUser) > 0 {
 		obj["ssh_user"] = in.SSHUser
 	}
@@ -50,6 +54,10 @@ func flattenHarvesterConfig(in *harvesterConfig) []interface{} {
 
 	if len(in.NetworkModel) > 0 {
 		obj["network_model"] = in.NetworkModel
+	}
+
+	if len(in.NetworkInfo) > 0 {
+		obj["network_info"] = in.NetworkInfo
 	}
 
 	if len(in.UserData) > 0 {
@@ -100,6 +108,10 @@ func expandHarvestercloudConfig(p []interface{}) *harvesterConfig {
 		obj.ImageName = v
 	}
 
+	if v, ok := in["disk_info"].(string); ok && len(v) > 0 {
+		obj.DiskInfo = v
+	}
+
 	if v, ok := in["ssh_user"].(string); ok && len(v) > 0 {
 		obj.SSHUser = v
 	}
@@ -114,6 +126,10 @@ func expandHarvestercloudConfig(p []interface{}) *harvesterConfig {
 
 	if v, ok := in["network_model"].(string); ok && len(v) > 0 {
 		obj.NetworkModel = v
+	}
+
+	if v, ok := in["network_info"].(string); ok && len(v) > 0 {
+		obj.NetworkInfo = v
 	}
 
 	if v, ok := in["user_data"].(string); ok && len(v) > 0 {


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

need harvester node driver v0.6.1
rancher [v2.6.11-rc4](https://github.com/rancher/rancher/releases/tag/v2.6.11-rc4)  and rancher [v2.7.2-rc2](https://github.com/rancher/rancher/releases/tag/v2.7.2-rc2) already include the new Harvester node driver


**API changes**
Harvester node driver add two new fields `disk_info` and `network_info` to support multi nics and disks in 
https://github.com/harvester/docker-machine-driver-harvester/commit/37b5b3759c706f6e0f13d20a002664a0af82941a#diff-1a5e9ad2c9efb72d85e174ec77c9a20a65c98f9f702d72ef615b1b552d1af7c0

In terraform-provider-rancher2, we need to remind the user that the old field is deprecated because we want the user to use the new field (The new field is an extensible field that supports single or multiple disks and networks).


* `disk_size` - (Deprecated) Use `disk_info` instead
* `disk_bus` - (Deprecated) Use `disk_info` instead
* `image_name` - (Deprecated) Use `disk_info` instead
* `disk_info` - (Required) A JSON string specifying info for the disks e.g. `{\"disks\":[{\"imageName\":\"harvester-public/image-57hzg\",\"bootOrder\":1,\"size\":40},{\"storageClassName\":\"node-driver-test\",\"bootOrder\":2,\"size\":1}]}` (string)
* `network_name` - (Deprecated) Use `network_info` instead
* `network_model` - (Deprecated) Use `network_info` instead
* `network_info` - (Required) A JSON string specifying info for the networks e.g. `{\"interfaces\":[{\"networkName\":\"harvester-public/vlan1\",\"macAddress\":\"\"},{\"networkName\":\"harvester-public/vlan2\",\"macAddress\":\"5a:e7:c5:24:5b:44\"}]}` (string)

**Related issues**
https://github.com/harvester/harvester/issues/2733
https://github.com/rancher/terraform-provider-rancher2/issues/985
https://github.com/rancher/terraform-provider-rancher2/issues/984


**Depend PRs**
https://github.com/rancher/rancher/pull/40172
https://github.com/rancher/rancher/pull/40171


**Test Plan**
1. Setup a Harvester v1.1.1 cluster, refer to https://docs.harvesterhci.io/v1.1/install/iso-install
2. Add a cloud image a  a vlan network to the Harvester by using the following terraform config:
```hcl
terraform {
  required_version = ">= 0.13"
  required_providers {
    harvester = {
      source  = "harvester/harvester"
      version = "0.6.1"
    }
  }
}

provider "harvester" {
 kubeconfig = "<the kubeconfig file path of the harvester cluster>"
}

resource "harvester_image" "focal-server" {
  name      = "focal-server"
  namespace = "harvester-public"

  display_name = "focal-server-cloudimg-amd64.img"
  source_type  = "download"
  url          = "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
}

data "harvester_clusternetwork" "mgmt" {
  name = "mgmt"
}

resource "harvester_network" "mgmt-vlan1" {
  name      = "mgmt-vlan1"
  namespace = "harvester-public"

  vlan_id = 1

  route_mode           = "auto"
  route_dhcp_server_ip = ""

  cluster_network_name = data.harvester_clusternetwork.mgmt.name
}
```
```bash
terraform init
terraform apply
```
3. Setup a Rancher v2.6-head/v2.7-head cluster
4. Import Harvester cluster to the Rancher cluster in `Virtualization Management` use cluster name `foo-harvester`
![1676562316085](https://user-images.githubusercontent.com/15064560/219416018-5e87ea79-1684-4346-841b-8f18f85195b5.png)
5. Build terraform-provider-rancher2 from the PR branch
```bash
CGO_ENABLED=0 go build -mod=vendor .
```
6. install the custom provider as version `0.0.0-master`:
```bash
REPO="rancher"
NAME="rancher2"
VERSION="0.0.0-master"
PROVIDERS_DIR=$HOME/.terraform.d/plugins/registry.terraform.io/${REPO}/${NAME}
PROVIDER_DIR=${PROVIDERS_DIR}/${VERSION}/linux_amd64
mkdir -p ${PROVIDER_DIR}
cp ./terraform-provider-${NAME} ${PROVIDER_DIR}/terraform-provider-${NAME}_v${VERSION}
```
7. Use the following test config
```hcl
terraform {
  required_providers {
    rancher2 = {
      source = "rancher/rancher2"
      version = "0.0.0-master"
    }
  }
}


provider "rancher2" {
  api_url    = "<>"
  access_key = "<>"
  secret_key = "<>"
  insecure = true
}


data "rancher2_cluster_v2" "foo-harvester" {
  name = "foo-harvester"
}

# Create a new Cloud Credential for an imported Harvester cluster
resource "rancher2_cloud_credential" "foo-harvester" {
  name = "foo-harvester"
  harvester_credential_config {
    cluster_id = data.rancher2_cluster_v2.foo-harvester.cluster_v1_id
    cluster_type = "imported"
    kubeconfig_content = data.rancher2_cluster_v2.foo-harvester.kube_config
  }
}

# Create a new rancher2 machine config v2 using harvester node_driver
resource "rancher2_machine_config_v2" "foo-harvester-v2" {
  generate_name = "foo-harvester-v2"
  harvester_config {
    vm_namespace = "default"
    cpu_count = "2"
    memory_size = "4"
    disk_info = <<EOF
    {
        "disks": [{
            "imageName": "harvester-public/focal-server",
            "size": 40,
            "bootOrder": 1
        }]
    }
    EOF
    network_info = <<EOF
    {
        "interfaces": [{
            "networkName": "harvester-public/mgmt-vlan1",
            "macAddress": ""
        }]
    }
    EOF
    ssh_user = "ubuntu"
    user_data = "I2Nsb3VkLWNvbmZpZwpwYWNrYWdlX3VwZGF0ZTogdHJ1ZQpwYWNrYWdlczoKICAtIHFlbXUtZ3Vlc3QtYWdlbnQKICAtIGlwdGFibGVzCnJ1bmNtZDoKICAtIC0gc3lzdGVtY3RsCiAgICAtIGVuYWJsZQogICAgLSAnLS1ub3cnCiAgICAtIHFlbXUtZ3Vlc3QtYWdlbnQuc2VydmljZQo="
  }
}

resource "rancher2_cluster_v2" "foo-harvester-v2" {
  name = "foo-harvester-v2"
  kubernetes_version = "v1.24.10+rke2r1"
  rke_config {
    machine_pools {
      name = "pool1"
      cloud_credential_secret_name = rancher2_cloud_credential.foo-harvester.id
      control_plane_role = true
      etcd_role = true
      worker_role = true
      quantity = 1
      machine_config {
        kind = rancher2_machine_config_v2.foo-harvester-v2.kind
        name = rancher2_machine_config_v2.foo-harvester-v2.name
      }
    }
    machine_selector_config {
      config = {
        cloud-provider-name = ""
      }
    }
    machine_global_config = <<EOF
cni: "calico"
disable-kube-proxy: false
etcd-expose-metrics: false
EOF
    upgrade_strategy {
      control_plane_concurrency = "10%"
      worker_concurrency = "10%"
    }
    etcd {
      snapshot_schedule_cron = "0 */5 * * *"
      snapshot_retention = 5
    }
    chart_values = ""
  }
}
```
```bash
terraform init
terraform apply
```

When I apply for the first time, such an error will occur, but it is OK to apply again. Is there anything wrong in my configuration file? Or is it a known problem?
```
rancher2_cloud_credential.foo-harvester: Creation complete after 2s [id=cattle-global-data:cc-rqgkh]
╷
│ Error: Provider produced inconsistent final plan
│
│ When expanding the plan for rancher2_cluster_v2.foo-harvester-v2 to include new values learned so far during apply,
│ provider "registry.terraform.io/rancher/rancher2" produced an invalid new value for
│ .rke_config[0].machine_pools[0].cloud_credential_secret_name: was cty.StringVal(""), but now
│ cty.StringVal("cattle-global-data:cc-rqgkh").
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

8. clean resources
```bash
terraform destroy
```
9. clean the custom provider
```bash
rm -r ~/.terraform.d/plugins/
```

