### PR TITLE
[2.7] Add missing implementation of Azure features for RKE2

### DIFF
--- a/rancher2/schema_node_template_azure.go
+++ b/rancher2/schema_node_template_azure.go
@@ -42,7 +42,7 @@ type azureConfig struct {
 	Tags                   string   `json:"tags,omitempty" yaml:"tags,omitempty"`
 	AcceleratedNetworking  bool     `json:"acceleratedNetworking,omitempty" yaml:"acceleratedNetworking,omitempty"`
 	AvailabilityZone       string   `json:"availabilityZone,omitempty" yaml:"availabilityZone,omitempty"`
-	UsePublicIPStandardSKU bool     `json:"usePublicIPStandardSKU,omitempty" yaml:"usePublicIPStandardSKU,omitempty"`
+	UsePublicIPStandardSKU bool     `json:"enablePublicIpStandardSku,omitempty" yaml:"enablePublicIpStandardSku,omitempty"`
 }
 
 //Schemas

--- a/rancher2/structure_machine_config_v2_azure.go
+++ b/rancher2/structure_machine_config_v2_azure.go
@@ -15,36 +15,40 @@ const (
 //Types
 
 type machineConfigV2Azure struct {
-	metav1.TypeMeta    `json:",inline"`
-	metav1.ObjectMeta  `json:"metadata,omitempty"`
-	AvailabilitySet    string   `json:"availabilitySet,omitempty" yaml:"availabilitySet,omitempty"`
-	ClientID           string   `json:"clientId,omitempty" yaml:"clientId,omitempty"`
-	ClientSecret       string   `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
-	CustomData         string   `json:"customData,omitempty" yaml:"customData,omitempty"`
-	DiskSize           string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
-	DNS                string   `json:"dns,omitempty" yaml:"dns,omitempty"`
-	Environment        string   `json:"environment,omitempty" yaml:"environment,omitempty"`
-	FaultDomainCount   string   `json:"faultDomainCount,omitempty" yaml:"faultDomainCount,omitempty"`
-	Image              string   `json:"image,omitempty" yaml:"image,omitempty"`
-	Location           string   `json:"location,omitempty" yaml:"location,omitempty"`
-	ManagedDisks       bool     `json:"managedDisks,omitempty" yaml:"managedDisks,omitempty"`
-	NoPublicIP         bool     `json:"noPublicIp,omitempty" yaml:"noPublicIp,omitempty"`
-	NSG                string   `json:"nsg,omitempty" yaml:"nsg,omitempty"`
-	OpenPort           []string `json:"openPort,omitempty" yaml:"openPort,omitempty"`
-	PrivateAddressOnly bool     `json:"privateAddressOnly,omitempty" yaml:"privateAddressOnly,omitempty"`
-	PrivateIPAddress   string   `json:"privateIpAddress,omitempty" yaml:"privateIpAddress,omitempty"`
-	ResourceGroup      string   `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
-	Size               string   `json:"size,omitempty" yaml:"size,omitempty"`
-	SSHUser            string   `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
-	StaticPublicIP     bool     `json:"staticPublicIp,omitempty" yaml:"staticPublicIp,omitempty"`
-	StorageType        string   `json:"storageType,omitempty" yaml:"storageType,omitempty"`
-	Subnet             string   `json:"subnet,omitempty" yaml:"subnet,omitempty"`
-	SubnetPrefix       string   `json:"subnetPrefix,omitempty" yaml:"subnetPrefix,omitempty"`
-	SubscriptionID     string   `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
-	TenantID           string   `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
-	UpdateDomainCount  string   `json:"updateDomainCount,omitempty" yaml:"updateDomainCount,omitempty"`
-	UsePrivateIP       bool     `json:"usePrivateIp,omitempty" yaml:"usePrivateIp,omitempty"`
-	Vnet               string   `json:"vnet,omitempty" yaml:"vnet,omitempty"`
+	metav1.TypeMeta        `json:",inline"`
+	metav1.ObjectMeta      `json:"metadata,omitempty"`
+	AvailabilitySet        string   `json:"availabilitySet,omitempty" yaml:"availabilitySet,omitempty"`
+	ClientID               string   `json:"clientId,omitempty" yaml:"clientId,omitempty"`
+	ClientSecret           string   `json:"clientSecret,omitempty" yaml:"clientSecret,omitempty"`
+	CustomData             string   `json:"customData,omitempty" yaml:"customData,omitempty"`
+	DiskSize               string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
+	DNS                    string   `json:"dns,omitempty" yaml:"dns,omitempty"`
+	Environment            string   `json:"environment,omitempty" yaml:"environment,omitempty"`
+	FaultDomainCount       string   `json:"faultDomainCount,omitempty" yaml:"faultDomainCount,omitempty"`
+	Image                  string   `json:"image,omitempty" yaml:"image,omitempty"`
+	Location               string   `json:"location,omitempty" yaml:"location,omitempty"`
+	ManagedDisks           bool     `json:"managedDisks,omitempty" yaml:"managedDisks,omitempty"`
+	NoPublicIP             bool     `json:"noPublicIp,omitempty" yaml:"noPublicIp,omitempty"`
+	NSG                    string   `json:"nsg,omitempty" yaml:"nsg,omitempty"`
+	OpenPort               []string `json:"openPort,omitempty" yaml:"openPort,omitempty"`
+	PrivateAddressOnly     bool     `json:"privateAddressOnly,omitempty" yaml:"privateAddressOnly,omitempty"`
+	PrivateIPAddress       string   `json:"privateIpAddress,omitempty" yaml:"privateIpAddress,omitempty"`
+	ResourceGroup          string   `json:"resourceGroup,omitempty" yaml:"resourceGroup,omitempty"`
+	Size                   string   `json:"size,omitempty" yaml:"size,omitempty"`
+	SSHUser                string   `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	StaticPublicIP         bool     `json:"staticPublicIp,omitempty" yaml:"staticPublicIp,omitempty"`
+	StorageType            string   `json:"storageType,omitempty" yaml:"storageType,omitempty"`
+	Subnet                 string   `json:"subnet,omitempty" yaml:"subnet,omitempty"`
+	SubnetPrefix           string   `json:"subnetPrefix,omitempty" yaml:"subnetPrefix,omitempty"`
+	SubscriptionID         string   `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
+	TenantID               string   `json:"tenantId,omitempty" yaml:"tenantId,omitempty"`
+	UpdateDomainCount      string   `json:"updateDomainCount,omitempty" yaml:"updateDomainCount,omitempty"`
+	UsePrivateIP           bool     `json:"usePrivateIp,omitempty" yaml:"usePrivateIp,omitempty"`
+	Vnet                   string   `json:"vnet,omitempty" yaml:"vnet,omitempty"`
+	Tags                   string   `json:"tags,omitempty" yaml:"tags,omitempty"`
+	AcceleratedNetworking  bool     `json:"acceleratedNetworking,omitempty" yaml:"acceleratedNetworking,omitempty"`
+	AvailabilityZone       string   `json:"availabilityZone,omitempty" yaml:"availabilityZone,omitempty"`
+	UsePublicIPStandardSKU bool     `json:"enablePublicIpStandardSku,omitempty" yaml:"enablePublicIpStandardSku,omitempty"`
 }
 
 type MachineConfigV2Azure struct {
@@ -157,11 +161,20 @@ func flattenMachineConfigV2Azure(in *MachineConfigV2Azure) []interface{} {
 	}
 
 	obj["use_private_ip"] = in.UsePrivateIP
+	obj["use_public_ip_standard_sku"] = in.UsePublicIPStandardSKU
+	obj["accelerated_networking"] = in.AcceleratedNetworking
 
 	if len(in.Vnet) > 0 {
 		obj["vnet"] = in.Vnet
 	}
 
+	if len(in.AvailabilityZone) > 0 {
+		obj["availability_zone"] = in.AvailabilityZone
+	}
+
+	if len(in.Tags) > 0 {
+		obj["tags"] = in.Tags
+	}
 	return []interface{}{obj}
 }
 
@@ -293,6 +306,22 @@ func expandMachineConfigV2Azure(p []interface{}, source *MachineConfigV2) *Machi
 
 	if v, ok := in["vnet"].(string); ok && len(v) > 0 {
 		obj.Vnet = v
+	}
+
+	if v, ok := in["use_public_ip_standard_sku"].(bool); ok {
+		obj.UsePublicIPStandardSKU = v
+	}
+
+	if v, ok := in["accelerated_networking"].(bool); ok {
+		obj.AcceleratedNetworking = v
+	}
+
+	if v, ok := in["availability_zone"].(string); ok && len(v) > 0 {
+		obj.AvailabilityZone = v
+	}
+
+	if v, ok := in["tags"].(string); ok && len(v) > 0 {
+		obj.Tags = v
 	}
 
 	return obj


### PR DESCRIPTION
### Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1071

### Problem:
This PR addresses two issues with the initial implementation of various Azure features within the provider.

1. The expanders and flatteners for the `v2` cluster were not implemented. The schema elements were added however they were not used when crafting API requests to the Rancher API. This has been fixed and smoke tested, so these features should work on RKE2 clusters now. RKE1 implementation is complete and not missing these expanders and flatteners. 

2. The JSON annotation used for the `UsePublicIpStandardSKU` fields have been modified to match the argument name expected by Rancher machine. Previously the JSON Annotation matched the field name, however this resulted in the Rancher API improperly converting this JSON annotation into an unexpected rancher-machine argument.  

### Solution

Add missing expanders and flatteners for v2 clusters

Modify the JSON annotation for the `UsePublicIPStandardSKU` field to match the expected argument name in rancher-machine. This was updated for both RKE1 and RKE2 clusters, as both distributions craft rancher-machine arguments in the same way. 

### Testing

+ Create an RKE2 cluster via terraform on Azure, ensure that the newly added fields are defined in the `azure_config`. 

### Engineer testing

I've created an RKE2 cluster with all of these properties enabled and confirmed that it provisioned properly and became active. I also confirmed that these features were enabled in the Azure Portal's UI. 

### QA considerations

1. When testing Availability Zones ensure you have the following three properties defined in your `azure_config`
   `use_public_ip_standard_sku = true`
   `static_public_ip = true`
   `managed_disks = true`
2. Azure does not allow tags to be prefixed with the following reserved keywords, `azure`, `microsoft`, and `windows`. 

