### PR TITLE
[Backport release/v2] Add vm node affinity support for rancher 2.6

### DIFF
--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -6,7 +6,7 @@ page_title: "rancher2_machine_config_v2 Resource"
 
 Provides a Rancher v2 Machine config v2 resource. This can be used to create Machine Config v2 for Rancher v2 and retrieve their information. This resource is available from Rancher v2.6.0 and above.
 
-`amazonec2`, `azure`, `digitalocean`, `linode`, `openstack`, and `vsphere` cloud providers are supported for machine config V2
+`amazonec2`, `azure`, `digitalocean`, `harvester`, `linode`, `openstack`, and `vsphere` cloud providers are supported for machine config V2
 
 **Note** This resource is used by 
 
@@ -196,6 +196,7 @@ The following attributes are exported:
 * `network_model` - (Optional) Network model, Default `virtio` (string)
 * `user_data` - (Optional) UserData content of cloud-init, base64 is supported (string)
 * `network_data` - (Optional) NetworkData content of cloud-init, base64 is supported (string)
+* `vm_affinity` - (Optional) Virtual machine affinity, base64 is supported. For Rancher v2.6.7 or above (string)
 
 ### `linode_config`
 

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -264,6 +264,7 @@ The following attributes are exported:
 * `network_model` - (Optional) Network model, Default `virtio` (string)
 * `user_data` - (Optional) UserData content of cloud-init, base64 is supported (string)
 * `network_data` - (Optional) NetworkData content of cloud-init, base64 is supported (string)
+* `vm_affinity` - (Optional) Virtual machine affinity, base64 is supported. For Rancher v2.6.7 or above (string)
 
 ### `hetzner_config`
 

--- a/rancher2/schema_machine_config_v2_harvester.go
+++ b/rancher2/schema_machine_config_v2_harvester.go
@@ -14,6 +14,11 @@ func machineConfigV2HarvesterFields() map[string]*schema.Schema {
 			Required:    true,
 			Description: "Virtual machine namespace",
 		},
+		"vm_affinity": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "VM affinity, base64 is supported",
+		},
 		"cpu_count": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/rancher2/schema_node_template_harvester.go
+++ b/rancher2/schema_node_template_harvester.go
@@ -24,6 +24,7 @@ const (
 
 type harvesterConfig struct {
 	VMNamespace  string `json:"vmNamespace,omitempty" yaml:"vmNamespace,omitempty"`
+	VMAffinity   string `json:"vmAffinity,omitempty" yaml:"vmAffinity,omitempty"`
 	CPUCount     string `json:"cpuCount,omitempty" yaml:"cpuCount,omitempty"`
 	MemorySize   string `json:"memorySize,omitempty" yaml:"memorySize,omitempty"`
 	DiskSize     string `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
@@ -45,6 +46,11 @@ func harvesterConfigFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "Virtual machine namespace",
+		},
+		"vm_affinity": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "VM affinity, base64 is supported",
 		},
 		"cpu_count": {
 			Type:        schema.TypeString,

--- a/rancher2/structure_machine_config_v2_harvester.go
+++ b/rancher2/structure_machine_config_v2_harvester.go
@@ -18,6 +18,7 @@ type machineConfigV2Harvester struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	VMNamespace       string `json:"vmNamespace,omitempty" yaml:"vmNamespace,omitempty"`
+	VMAffinity        string `json:"vmAffinity,omitempty" yaml:"vmAffinity,omitempty"`
 	CPUCount          string `json:"cpuCount,omitempty" yaml:"cpuCount,omitempty"`
 	MemorySize        string `json:"memorySize,omitempty" yaml:"memorySize,omitempty"`
 	DiskSize          string `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
@@ -47,6 +48,10 @@ func flattenMachineConfigV2Harvester(in *MachineConfigV2Harvester) []interface{}
 
 	if len(in.VMNamespace) > 0 {
 		obj["vm_namespace"] = in.VMNamespace
+	}
+
+	if len(in.VMAffinity) > 0 {
+		obj["vm_affinity"] = in.VMAffinity
 	}
 
 	if len(in.CPUCount) > 0 {
@@ -116,6 +121,10 @@ func expandMachineConfigV2Harvester(p []interface{}, source *MachineConfigV2) *M
 
 	if v, ok := in["vm_namespace"].(string); ok && len(v) > 0 {
 		obj.VMNamespace = v
+	}
+
+	if v, ok := in["vm_affinity"].(string); ok && len(v) > 0 {
+		obj.VMAffinity = v
 	}
 
 	if v, ok := in["cpu_count"].(string); ok && len(v) > 0 {

--- a/rancher2/structure_node_template_harvester.go
+++ b/rancher2/structure_node_template_harvester.go
@@ -12,6 +12,10 @@ func flattenHarvesterConfig(in *harvesterConfig) []interface{} {
 		obj["vm_namespace"] = in.VMNamespace
 	}
 
+	if len(in.VMAffinity) > 0 {
+		obj["vm_affinity"] = in.VMAffinity
+	}
+
 	if len(in.CPUCount) > 0 {
 		obj["cpu_count"] = in.CPUCount
 	}
@@ -70,6 +74,10 @@ func expandHarvestercloudConfig(p []interface{}) *harvesterConfig {
 
 	if v, ok := in["vm_namespace"].(string); ok && len(v) > 0 {
 		obj.VMNamespace = v
+	}
+
+	if v, ok := in["vm_affinity"].(string); ok && len(v) > 0 {
+		obj.VMAffinity = v
 	}
 
 	if v, ok := in["cpu_count"].(string); ok && len(v) > 0 {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

https://github.com/rancher/terraform-provider-rancher2/issues/1069

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
No support for VM node affinity on harvester clusters.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

Add VM node affinity support to the Terraform provider rancher2 for Rancher 2.6 harvester clusters. This is backported onto the `release/v2` branch.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Backport, already tested