### PR TITLE
[Backport release/v2] Remove sort from v2 mirror endpoints

### DIFF
--- a/rancher2/structure_cluster_v2_rke_config_registry.go
+++ b/rancher2/structure_cluster_v2_rke_config_registry.go
@@ -61,7 +61,7 @@ func flattenClusterV2RKEConfigRegistryMirrors(p map[string]rkev1.Mirror) []inter
 		obj["hostname"] = k
 
 		if len(in.Endpoints) > 0 {
-			obj["endpoints"] = toArrayInterfaceSorted(in.Endpoints)
+			obj["endpoints"] = toArrayInterface(in.Endpoints)
 		}
 		if len(in.Rewrites) > 0 {
 			obj["rewrites"] = toMapInterface(in.Rewrites)
@@ -129,7 +129,7 @@ func expandClusterV2RKEConfigRegistryMirrors(p []interface{}) map[string]rkev1.M
 		obj := rkev1.Mirror{}
 
 		if v, ok := in["endpoints"].([]interface{}); ok && len(v) > 0 {
-			obj.Endpoints = toArrayStringSorted(v)
+			obj.Endpoints = toArrayString(v)
 		}
 		if v, ok := in["rewrites"].(map[string]interface{}); ok && len(v) > 0 {
 			obj.Rewrites = toMapString(v)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
https://github.com/rancher/terraform-provider-rancher2/issues/1072

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Users can't decide the order that Terraform should try mirrors in, as stated by @gregsidelinger in [the original issue](https://github.com/rancher/terraform-provider-rancher2/issues/1028) here.
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

Remove sort from v2 mirror endpoints, backport for v2.6.11.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->