### PR TITLE
doc: Change attribute name for resource ID

### DIFF
--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -674,7 +674,7 @@ The following attributes are exported:
 
 #### Attributes
 
-* `cluster_id` - (Computed) Cluster ID (string)
+* `id` - (Computed) Cluster ID (string)
 * `name` - (Computed) Name of cluster registration token (string)
 * `command` - (Computed) Command to execute in a imported k8s cluster (string)
 * `insecure_command` - (Computed) Insecure command to execute in a imported k8s cluster (string)


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

https://github.com/rancher/terraform-provider-rancher2/issues/1104
 
## Problem

I tried to use the attribute `cluster_id`, but the provider complained it didn't exists.
 
## Solution

I tried with `id`, and it worked as expected.
 
## Testing

I think it's possible to update the TestCase for the resource, but I don't have any knowledge about it.

## Engineering Testing
### Manual Testing

Change `rancher2_cluster_v2.resource.cluster_id` to `rancher2_cluster_v2.resource.id`
Run `terraform validate`

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->