### PR TITLE
[release/v2] Harvester vmAffinity feature revert

### DIFF
--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -6,7 +6,7 @@ page_title: "rancher2_machine_config_v2 Resource"
 
 Provides a Rancher v2 Machine config v2 resource. This can be used to create Machine Config v2 for Rancher v2 and retrieve their information. This resource is available from Rancher v2.6.0 and above.
 
-`amazonec2`, `azure`, `digitalocean`, `harvester`, `linode`, `openstack`, and `vsphere` cloud providers are supported for machine config V2
+`amazonec2`, `azure`, `digitalocean`, `linode`, `openstack`, and `vsphere` cloud providers are supported for machine config V2
 
 **Note** This resource is used by 
 
@@ -196,7 +196,6 @@ The following attributes are exported:
 * `network_model` - (Optional) Network model, Default `virtio` (string)
 * `user_data` - (Optional) UserData content of cloud-init, base64 is supported (string)
 * `network_data` - (Optional) NetworkData content of cloud-init, base64 is supported (string)
-* `vm_affinity` - (Optional) Virtual machine affinity, base64 is supported. For Rancher v2.6.7 or above (string)
 
 ### `linode_config`
 

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -264,7 +264,6 @@ The following attributes are exported:
 * `network_model` - (Optional) Network model, Default `virtio` (string)
 * `user_data` - (Optional) UserData content of cloud-init, base64 is supported (string)
 * `network_data` - (Optional) NetworkData content of cloud-init, base64 is supported (string)
-* `vm_affinity` - (Optional) Virtual machine affinity, base64 is supported. For Rancher v2.6.7 or above (string)
 
 ### `hetzner_config`
 

--- a/rancher2/schema_machine_config_v2_harvester.go
+++ b/rancher2/schema_machine_config_v2_harvester.go
@@ -14,11 +14,6 @@ func machineConfigV2HarvesterFields() map[string]*schema.Schema {
 			Required:    true,
 			Description: "Virtual machine namespace",
 		},
-		"vm_affinity": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "VM affinity, base64 is supported",
-		},
 		"cpu_count": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/rancher2/schema_node_template_harvester.go
+++ b/rancher2/schema_node_template_harvester.go
@@ -24,7 +24,6 @@ const (
 
 type harvesterConfig struct {
 	VMNamespace  string `json:"vmNamespace,omitempty" yaml:"vmNamespace,omitempty"`
-	VMAffinity   string `json:"vmAffinity,omitempty" yaml:"vmAffinity,omitempty"`
 	CPUCount     string `json:"cpuCount,omitempty" yaml:"cpuCount,omitempty"`
 	MemorySize   string `json:"memorySize,omitempty" yaml:"memorySize,omitempty"`
 	DiskSize     string `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
@@ -46,11 +45,6 @@ func harvesterConfigFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "Virtual machine namespace",
-		},
-		"vm_affinity": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "VM affinity, base64 is supported",
 		},
 		"cpu_count": {
 			Type:        schema.TypeString,

--- a/rancher2/structure_machine_config_v2_harvester.go
+++ b/rancher2/structure_machine_config_v2_harvester.go
@@ -18,7 +18,6 @@ type machineConfigV2Harvester struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	VMNamespace       string `json:"vmNamespace,omitempty" yaml:"vmNamespace,omitempty"`
-	VMAffinity        string `json:"vmAffinity,omitempty" yaml:"vmAffinity,omitempty"`
 	CPUCount          string `json:"cpuCount,omitempty" yaml:"cpuCount,omitempty"`
 	MemorySize        string `json:"memorySize,omitempty" yaml:"memorySize,omitempty"`
 	DiskSize          string `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
@@ -48,10 +47,6 @@ func flattenMachineConfigV2Harvester(in *MachineConfigV2Harvester) []interface{}
 
 	if len(in.VMNamespace) > 0 {
 		obj["vm_namespace"] = in.VMNamespace
-	}
-
-	if len(in.VMAffinity) > 0 {
-		obj["vm_affinity"] = in.VMAffinity
 	}
 
 	if len(in.CPUCount) > 0 {
@@ -121,10 +116,6 @@ func expandMachineConfigV2Harvester(p []interface{}, source *MachineConfigV2) *M
 
 	if v, ok := in["vm_namespace"].(string); ok && len(v) > 0 {
 		obj.VMNamespace = v
-	}
-
-	if v, ok := in["vm_affinity"].(string); ok && len(v) > 0 {
-		obj.VMAffinity = v
 	}
 
 	if v, ok := in["cpu_count"].(string); ok && len(v) > 0 {

--- a/rancher2/structure_node_template_harvester.go
+++ b/rancher2/structure_node_template_harvester.go
@@ -12,10 +12,6 @@ func flattenHarvesterConfig(in *harvesterConfig) []interface{} {
 		obj["vm_namespace"] = in.VMNamespace
 	}
 
-	if len(in.VMAffinity) > 0 {
-		obj["vm_affinity"] = in.VMAffinity
-	}
-
 	if len(in.CPUCount) > 0 {
 		obj["cpu_count"] = in.CPUCount
 	}
@@ -74,10 +70,6 @@ func expandHarvestercloudConfig(p []interface{}) *harvesterConfig {
 
 	if v, ok := in["vm_namespace"].(string); ok && len(v) > 0 {
 		obj.VMNamespace = v
-	}
-
-	if v, ok := in["vm_affinity"].(string); ok && len(v) > 0 {
-		obj.VMAffinity = v
 	}
 
 	if v, ok := in["cpu_count"].(string); ok && len(v) > 0 {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

https://github.com/rancher/terraform-provider-rancher2/issues/1069
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
This is to fix an oversight. vmAffinity was a community PR that is a _feature_ and we are only releasing new TF features in `master` which is the Rancher 2.7 line. After this is merged and a new rc is cut, we can release TF 2.0.0 for 2.6.11 and users should not use vmAffinity on Rancher 2.6 via tf because it is not supported.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->