### PR TITLE
Consider all possible cluster states before passing them to StateChangeConf

### DIFF
--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -129,14 +129,14 @@ func resourceRancher2ClusterCreate(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[INFO] Creating Cluster %s", cluster.Name)
 
-	expectedState := "active"
+	expectedState := []string{"active"}
 
 	if cluster.Driver == clusterDriverImported || (cluster.Driver == clusterDriverEKSV2 && cluster.EKSConfig.Imported) {
-		expectedState = "pending"
+		expectedState = append(expectedState, "pending")
 	}
 
 	if cluster.Driver == clusterDriverRKE || cluster.Driver == clusterDriverK3S || cluster.Driver == clusterDriverRKE2 {
-		expectedState = "provisioning"
+		expectedState = append(expectedState, "provisioning")
 	}
 
 	// Creating cluster with monitoring disabled
@@ -164,7 +164,7 @@ func resourceRancher2ClusterCreate(d *schema.ResourceData, meta interface{}) err
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{},
-		Target:     []string{expectedState},
+		Target:     expectedState,
 		Refresh:    clusterStateRefreshFunc(client, newCluster.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
 		Delay:      1 * time.Second,


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

https://github.com/rancher/terraform-provider-rancher2/issues/1003
https://github.com/rancher/eks-operator/issues/84
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
When importing an EKS cluster using the terraform provider, sometimes rancher cluster reconciliation loop can be fast and go ahead with cluster creation (going from `"pending"` to `"active"` too fast) and the provider can miss it, resulting on provider waiting for the cluster to be in the "pending" state even though it went pass that state long before and provider simply missed that
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
Instead of predefining the `expectedState` beforehand and overwriting it later if need to be, define it as slice literal with keeping the same state ("active") and append the new states later if need to be (i.e.` if cluster.Driver == clusterDriverImported || (cluster.Driver == clusterDriverEKSV2 && cluster.EKSConfig.Imported)` == `True`) and pass it to   
`StateChangeConf` struct. Anyways, StateChangeConf struct expects `Target` to be `[]string` so nothing is changed behaviour wise but just all possible cluster states are considered before passing them.
