### PR TITLE
feat: add PSACT to cluster_v2 resource and data-source

### DIFF
--- a/docs/data-sources/cluster_v2.md
+++ b/docs/data-sources/cluster_v2.md
@@ -36,5 +36,6 @@ The following attributes are exported:
 * `rke_config` - (Computed) The RKE configuration for `k3s` and `rke2` Clusters v2. (list maxitems:1)
 * `cloud_credential_secret_name` - (Computed) Cluster V2 cloud credential secret name (string)
 * `default_pod_security_policy_template_name` - (Computed) Cluster V2 default pod security policy template name (string)
+* `default_pod_security_admission_configuration_template_name` - (Computed) Cluster V2 default pod security admission configuration template name (string)
 * `default_cluster_role_for_project_members` - (Computed) Cluster V2 default cluster role for project members (string)
 * `enable_network_policy` - (Computed) Enable k8s network policy at Cluster V2 (bool)

--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -459,6 +459,7 @@ The following arguments are supported:
 * `local_auth_endpoint` - (Optional) Cluster V2 local auth endpoint (list maxitems:1)
 * `cloud_credential_secret_name` - (Optional) Cluster V2 cloud credential secret name (string)
 * `default_pod_security_policy_template_name` - (Optional) Cluster V2 default pod security policy template name (string)
+* `default_pod_security_admission_configuration_template_name` - (Optional) Cluster V2 default pod security admission configuration template name (string)
 * `default_cluster_role_for_project_members` - (Optional) Cluster V2 default cluster role for project members (string)
 * `enable_network_policy` - (Optional) Enable k8s network policy at Cluster V2 (bool)
 * `annotations` - (Optional/Computed) Annotations for the Cluster V2 (map)

--- a/rancher2/data_source_rancher2_cluster_v2.go
+++ b/rancher2/data_source_rancher2_cluster_v2.go
@@ -51,6 +51,11 @@ func dataSourceRancher2ClusterV2() *schema.Resource {
 				Computed:    true,
 				Description: "Cluster V2 default pod security policy template name",
 			},
+			"default_pod_security_admission_configuration_template_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Cluster V2 default pod security admission configuration template name",
+			},
 			"default_cluster_role_for_project_members": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/rancher2/schema_cluster_v2.go
+++ b/rancher2/schema_cluster_v2.go
@@ -76,6 +76,11 @@ func clusterV2Fields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Cluster V2 default pod security policy template name",
 		},
+		"default_pod_security_admission_configuration_template_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Cluster V2 default pod security admission configuration template name",
+		},
 		"default_cluster_role_for_project_members": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/rancher2/structure_cluster_v2.go
+++ b/rancher2/structure_cluster_v2.go
@@ -68,6 +68,9 @@ func flattenClusterV2(d *schema.ResourceData, in *ClusterV2) error {
 	if len(in.Spec.DefaultPodSecurityPolicyTemplateName) > 0 {
 		d.Set("default_pod_security_policy_template_name", in.Spec.DefaultPodSecurityPolicyTemplateName)
 	}
+	if len(in.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName) > 0 {
+		d.Set("default_pod_security_admission_configuration_template_name", in.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName)
+	}
 	if len(in.Spec.DefaultClusterRoleForProjectMembers) > 0 {
 		d.Set("default_cluster_role_for_project_members", in.Spec.DefaultClusterRoleForProjectMembers)
 	}
@@ -141,6 +144,9 @@ func expandClusterV2(in *schema.ResourceData) (*ClusterV2, error) {
 	}
 	if v, ok := in.Get("default_pod_security_policy_template_name").(string); ok && len(v) > 0 {
 		obj.Spec.DefaultPodSecurityPolicyTemplateName = v
+	}
+	if v, ok := in.Get("default_pod_security_admission_configuration_template_name").(string); ok && len(v) > 0 {
+		obj.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName = v
 	}
 	if v, ok := in.Get("default_cluster_role_for_project_members").(string); ok && len(v) > 0 {
 		obj.Spec.DefaultClusterRoleForProjectMembers = v

--- a/rancher2/structure_cluster_v2_test.go
+++ b/rancher2/structure_cluster_v2_test.go
@@ -62,6 +62,7 @@ func init() {
 	testClusterV2Conf.Spec.AgentEnvVars = testClusterV2EnvVarConf
 	testClusterV2Conf.Spec.CloudCredentialSecretName = "cloud_credential_secret_name"
 	testClusterV2Conf.Spec.DefaultPodSecurityPolicyTemplateName = "default_pod_security_policy_template_name"
+	testClusterV2Conf.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName = "default_pod_security_admission_configuration_template_name"
 	testClusterV2Conf.Spec.DefaultClusterRoleForProjectMembers = "default_cluster_role_for_project_members"
 	testClusterV2Conf.Spec.EnableNetworkPolicy = newTrue()
 
@@ -162,8 +163,9 @@ func init() {
 		"fleet_agent_deployment_customization":      testClusterV2AgentCustomizationInterface,
 		"cloud_credential_secret_name":              "cloud_credential_secret_name",
 		"default_pod_security_policy_template_name": "default_pod_security_policy_template_name",
-		"default_cluster_role_for_project_members":  "default_cluster_role_for_project_members",
-		"enable_network_policy":                     true,
+		"default_pod_security_admission_configuration_template_name": "default_pod_security_admission_configuration_template_name",
+		"default_cluster_role_for_project_members":                   "default_cluster_role_for_project_members",
+		"enable_network_policy":                                      true,
 		"annotations": map[string]interface{}{
 			"value1": "one",
 			"value2": "two",


### PR DESCRIPTION
## Issue: rancher/terraform-provider-rancher2#1112 (partial implementation for RKE2)
 
## Feature
Implement setting the default PSACT using Terraform.
 
## Solution
Add a new property to be set using Terraform, similar to default PSP.

## Testing

```hcl
resource "rancher2_cluster_v2" "cluster" {
  name = "test-cluster"

  kubernetes_version = "v1.25.9+rke2r1"

  default_pod_security_admission_configuration_template_name = "rancher-restricted"

  rke_config {
    machine_selector_config {
      config = {
        profile = "cis-1.23"

        protect-kernel-defaults = true
      }
    }
  }
}
```

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
None expected, if unset, Rancher < 2.7.2 should be fine.