### PR TITLE
Make DO userdata default empty for v2prov

### DIFF
--- a/rancher2/schema_machine_config_v2_digitalocean.go
+++ b/rancher2/schema_machine_config_v2_digitalocean.go
@@ -88,7 +88,6 @@ func machineConfigV2DigitaloceanFields() map[string]*schema.Schema {
 		"userdata": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "docker-user",
 			Description: "Path to file with cloud-init user-data",
 		},
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> https://github.com/rancher/terraform-provider-rancher2/issues/1120
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

For some reason, the default userdata is populated as docker-user, when it should be empty. This prevent users from provisioning DO downstream clusters without specifying an empty userdata.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

Make default empty.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

I'll update this when I test it.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->