### PR TITLE
Fix Harvester disk_size default value

### DIFF
--- a/rancher2/schema_machine_config_v2_harvester.go
+++ b/rancher2/schema_machine_config_v2_harvester.go
@@ -33,6 +33,7 @@ func machineConfigV2HarvesterFields() map[string]*schema.Schema {
 		"disk_size": {
 			Type:     schema.TypeString,
 			Optional: true,
+			Default:  "0",
 			ConflictsWith: []string{
 				"harvester_config.0.disk_info",
 			},

--- a/rancher2/schema_node_template_harvester.go
+++ b/rancher2/schema_node_template_harvester.go
@@ -68,6 +68,7 @@ func harvesterConfigFields() map[string]*schema.Schema {
 		"disk_size": {
 			Type:     schema.TypeString,
 			Optional: true,
+			Default:  "0",
 			ConflictsWith: []string{
 				"harvester_config.0.disk_info",
 			},


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
https://github.com/rancher/terraform-provider-rancher2/issues/1150
 https://github.com/harvester/harvester/issues/4097

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
The disk_size field is an int in the Harvester node driver and will be converted to 0 by Harvester node driver if it is set to empty by the user.

Refer to https://github.com/harvester/docker-machine-driver-harvester/blob/a43dbc6d7d0091a955813ae18fc907de12b8e316/harvester/flags.go#L56

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
 
Set Harvester disk_size default value to "0" in terraform-provider-rancher2

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
1. Setup a Harvester v1.1.2 cluster, refer to https://docs.harvesterhci.io/v1.1/install/iso-install
2. Add a cloud image `harvester-public/focal-server` and a vlan network `harvester-public/mgmt-vlan1` to the Harvester by using terraform-provider-harvester
```hcl
terraform {
  required_version = ">= 0.13"
  required_providers {
    harvester = {
      source  = "harvester/harvester"
      version = "0.6.2"
    }
  }
}

provider "harvester" {
 kubeconfig = "<the kubeconfig file path of the harvester cluster>"
}

resource "harvester_image" "focal-server" {
  name      = "focal-server"
  namespace = "harvester-public"

  display_name = "focal-server-cloudimg-amd64.img"
  source_type  = "download"
  url          = "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
}

data "harvester_clusternetwork" "mgmt" {
  name = "mgmt"
}

resource "harvester_network" "mgmt-vlan1" {
  name      = "mgmt-vlan1"
  namespace = "harvester-public"

  vlan_id = 1

  route_mode           = "auto"
  route_dhcp_server_ip = ""

  cluster_network_name = data.harvester_clusternetwork.mgmt.name
}
```
4. Setup a Rancher 2.7.4 server
5. Import Harvester cluster to the Rancher cluster in `Virtualization Management`, use  `foo-harvester` as the cluster name
6. Build terraform-provider-rancher2 from the PR branch
```bash
make
```
7. install the custom provider as version `0.0.0-dev`:
```bash
PROVIDER="rancher2"
VERSION="0.0.0-dev"
OS_PLATFORM=$(uname -sp | tr '[:upper:] ' '[:lower:]_' | sed 's/x86_64/amd64/' | sed 's/i386/amd64/' | sed 's/arm/arm64/')
PROVIDERS_DIR=$HOME/.terraform.d/plugins/terraform.local/local/${PROVIDER}
PROVIDER_DIR=${PROVIDERS_DIR}/${VERSION}/${OS_PLATFORM}
mkdir -p ${PROVIDER_DIR}
cp bin/terraform-provider-${PROVIDER} ${PROVIDER_DIR}/terraform-provider-${PROVIDER}_v${VERSION}
```
7. Create a guest RKE2 cluster using the following test config:
```hcl
terraform {
  required_providers {
    rancher2 = {
      source = "terraform.local/local/rancher2"
      version = "0.0.0-dev"
    }
  }
}


provider "rancher2" {
  api_url    = "<change me>"
  access_key = "<change me>"
  secret_key = "<change me>"
  insecure = true
}


data "rancher2_cluster_v2" "foo-harvester" {
  name = "foo-harvester"
}

# Create a new Cloud Credential for an imported Harvester cluster
resource "rancher2_cloud_credential" "foo-harvester" {
  name = "foo-harvester"
  harvester_credential_config {
    cluster_id = data.rancher2_cluster_v2.foo-harvester.cluster_v1_id
    cluster_type = "imported"
    kubeconfig_content = data.rancher2_cluster_v2.foo-harvester.kube_config
  }
}

# Create a new rancher2 machine config v2 using harvester node_driver
resource "rancher2_machine_config_v2" "foo-harvester-v2" {
  generate_name = "foo-harvester-v2"
  harvester_config {
    vm_namespace = "default"
    cpu_count = "2"
    memory_size = "4"
    disk_info = <<EOF
    {
        "disks": [{
            "imageName": "harvester-public/focal-server",
            "size": 40,
            "bootOrder": 1
        }]
    }
    EOF
    network_info = <<EOF
    {
        "interfaces": [{
            "networkName": "harvester-public/mgmt-vlan1"
        }]
    }
    EOF
    ssh_user = "ubuntu"
    user_data = "I2Nsb3VkLWNvbmZpZwpwYWNrYWdlX3VwZGF0ZTogdHJ1ZQpwYWNrYWdlczoKICAtIHFlbXUtZ3Vlc3QtYWdlbnQKICAtIGlwdGFibGVzCnJ1bmNtZDoKICAtIC0gc3lzdGVtY3RsCiAgICAtIGVuYWJsZQogICAgLSAnLS1ub3cnCiAgICAtIHFlbXUtZ3Vlc3QtYWdlbnQuc2VydmljZQo="
  }
}

resource "rancher2_cluster_v2" "foo-harvester-v2" {
  name = "foo-harvester-v2"
  kubernetes_version = "v1.25.9+rke2r1"
  rke_config {
    machine_pools {
      name = "pool1"
      cloud_credential_secret_name = rancher2_cloud_credential.foo-harvester.id
      control_plane_role = true
      etcd_role = true
      worker_role = true
      quantity = 1
      machine_config {
        kind = rancher2_machine_config_v2.foo-harvester-v2.kind
        name = rancher2_machine_config_v2.foo-harvester-v2.name
      }
    }
    machine_selector_config {
      config = {
        cloud-provider-name = ""
      }
    }
    machine_global_config = <<EOF
cni: "calico"
disable-kube-proxy: false
etcd-expose-metrics: false
EOF
    upgrade_strategy {
      control_plane_concurrency = "10%"
      worker_concurrency = "10%"
    }
    etcd {
      snapshot_schedule_cron = "0 */5 * * *"
      snapshot_retention = 5
    }
    chart_values = ""
  }
}
```
```bash
terraform init
terraform apply
```
8. Check plan again
```bash
terraform apply
```
13. Run `terraform plan`

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->