### PR TITLE
[Q3] Add retry logic to rancher2_cluster update

### DIFF
--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -192,7 +192,7 @@ func resourceRancher2ClusterCreate(d *schema.ResourceData, meta interface{}) err
 			Links:   newCluster.Links,
 			Actions: newCluster.Actions,
 		}
-		// Retry enabling monitoring until timeout if got apierr 500 https://github.com/rancher/rancher/issues/30188
+		// Retry enable monitoring until timeout if got api error 500
 		ctx, cancel := context.WithTimeout(context.Background(), meta.(*Config).Timeout)
 		defer cancel()
 		for {
@@ -385,93 +385,57 @@ func resourceRancher2ClusterUpdate(d *schema.ResourceData, meta interface{}) err
 		update["rke2Config"] = expandClusterRKE2Config(d.Get("rke2_config").([]interface{}))
 	}
 
-	newCluster := &Cluster{}
-	if replace {
-		err = client.APIBaseClient.Replace(managementClient.ClusterType, cluster, update, newCluster)
-	} else {
-		err = client.APIBaseClient.Update(managementClient.ClusterType, cluster, update, newCluster)
-	}
-	if err != nil {
-		return err
-	}
-
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"active", "provisioning", "pending", "updating", "upgrading"},
-		Target:     []string{"active", "provisioning", "pending"},
-		Refresh:    clusterStateRefreshFunc(client, newCluster.ID),
-		Timeout:    d.Timeout(schema.TimeoutUpdate),
-		Delay:      1 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-	_, waitErr := stateConf.WaitForState()
-	if waitErr != nil {
-		return fmt.Errorf("[ERROR] waiting for cluster (%s) to be updated: %s", newCluster.ID, waitErr)
-	}
-
-	// cluster_monitoring is updated here
-	if d.HasChange("enable_cluster_monitoring") || d.HasChange("cluster_monitoring_input") {
-		clusterResource := &norman.Resource{
-			ID:      newCluster.ID,
-			Type:    newCluster.Type,
-			Links:   newCluster.Links,
-			Actions: newCluster.Actions,
+	// update the cluster; retry til timeout or non retryable error is returned. If api 500 error is received,
+	// retry to see if update will go through
+	return resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		newCluster := &Cluster{}
+		if replace {
+			err = client.APIBaseClient.Replace(managementClient.ClusterType, cluster, update, newCluster)
+		} else {
+			err = client.APIBaseClient.Update(managementClient.ClusterType, cluster, update, newCluster)
 		}
-		enableMonitoring := d.Get("enable_cluster_monitoring").(bool)
-		if enableMonitoring {
-			monitoringInput := expandMonitoringInput(d.Get("cluster_monitoring_input").([]interface{}))
-			if len(newCluster.Actions[monitoringActionEnable]) > 0 {
-				err = client.APIBaseClient.Action(managementClient.ClusterType, monitoringActionEnable, clusterResource, monitoringInput, nil)
-				if err != nil {
-					return err
-				}
-			} else {
-				monitorVersionChanged := false
-				if d.HasChange("cluster_monitoring_input") {
-					old, new := d.GetChange("cluster_monitoring_input")
-					oldInput := old.([]interface{})
-					oldInputLen := len(oldInput)
-					oldVersion := ""
-					if oldInputLen > 0 {
-						oldRow, oldOK := oldInput[0].(map[string]interface{})
-						if oldOK {
-							oldVersion = oldRow["version"].(string)
-						}
-					}
-					newInput := new.([]interface{})
-					newInputLen := len(newInput)
-					newVersion := ""
-					if newInputLen > 0 {
-						newRow, newOK := newInput[0].(map[string]interface{})
-						if newOK {
-							newVersion = newRow["version"].(string)
-						}
-					}
-					if oldVersion != newVersion {
-						monitorVersionChanged = true
-					}
-				}
-				if monitorVersionChanged && monitoringInput != nil {
-					err = updateClusterMonitoringApps(meta, d.Get("system_project_id").(string), monitoringInput.Version)
-					if err != nil {
-						return err
-					}
-				}
-				err = client.APIBaseClient.Action(managementClient.ClusterType, monitoringActionEdit, clusterResource, monitoringInput, nil)
-				if err != nil {
-					return err
-				}
+		if err != nil {
+			if IsServerError(err) {
+				return nil
 			}
-		} else if len(newCluster.Actions[monitoringActionDisable]) > 0 {
-			err = client.APIBaseClient.Action(managementClient.ClusterType, monitoringActionDisable, clusterResource, nil, nil)
+			return resource.NonRetryableError(err)
+		}
+
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"active", "provisioning", "pending", "updating", "upgrading"},
+			Target:     []string{"active", "provisioning", "pending"},
+			Refresh:    clusterStateRefreshFunc(client, newCluster.ID),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
+			Delay:      1 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+		_, waitErr := stateConf.WaitForState()
+		if waitErr != nil {
+			return resource.NonRetryableError(fmt.Errorf("[ERROR] waiting for cluster (%s) to be updated: %s", newCluster.ID, waitErr))
+		}
+
+		// update cluster monitoring if it has changed
+		if d.HasChange("enable_cluster_monitoring") || d.HasChange("cluster_monitoring_input") {
+			err = updateClusterMonitoring(client, d, meta, *newCluster)
 			if err != nil {
-				return err
+				if IsServerError(err) {
+					return nil
+				}
+				return resource.NonRetryableError(err)
 			}
 		}
-	}
 
-	d.SetId(newCluster.ID)
+		d.SetId(newCluster.ID)
 
-	return resourceRancher2ClusterRead(d, meta)
+		// read cluster after update. If an error is returned then the read failed and is non retryable, else
+		// it was successful
+		err = resourceRancher2ClusterRead(d, meta)
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
 }
 
 func resourceRancher2ClusterDelete(d *schema.ResourceData, meta interface{}) error {
@@ -753,6 +717,68 @@ func getClusterKubeconfig(c *Config, id, origconfig string) (*managementClient.G
 			return nil, fmt.Errorf("Timeout getting cluster Kubeconfig: %v", err)
 		}
 	}
+}
+
+func updateClusterMonitoring(client *managementClient.Client, d *schema.ResourceData, meta interface{}, newCluster Cluster) error {
+	clusterResource := &norman.Resource{
+		ID:      newCluster.ID,
+		Type:    newCluster.Type,
+		Links:   newCluster.Links,
+		Actions: newCluster.Actions,
+	}
+	enableMonitoring := d.Get("enable_cluster_monitoring").(bool)
+
+	if enableMonitoring {
+		monitoringInput := expandMonitoringInput(d.Get("cluster_monitoring_input").([]interface{}))
+		if len(newCluster.Actions[monitoringActionEnable]) > 0 {
+			err := client.APIBaseClient.Action(managementClient.ClusterType, monitoringActionEnable, clusterResource, monitoringInput, nil)
+			if err != nil {
+				return err
+			}
+		} else {
+			monitorVersionChanged := false
+			if d.HasChange("cluster_monitoring_input") {
+				old, new := d.GetChange("cluster_monitoring_input")
+				oldInput := old.([]interface{})
+				oldInputLen := len(oldInput)
+				oldVersion := ""
+				if oldInputLen > 0 {
+					oldRow, oldOK := oldInput[0].(map[string]interface{})
+					if oldOK {
+						oldVersion = oldRow["version"].(string)
+					}
+				}
+				newInput := new.([]interface{})
+				newInputLen := len(newInput)
+				newVersion := ""
+				if newInputLen > 0 {
+					newRow, newOK := newInput[0].(map[string]interface{})
+					if newOK {
+						newVersion = newRow["version"].(string)
+					}
+				}
+				if oldVersion != newVersion {
+					monitorVersionChanged = true
+				}
+			}
+			if monitorVersionChanged && monitoringInput != nil {
+				err := updateClusterMonitoringApps(meta, d.Get("system_project_id").(string), monitoringInput.Version)
+				if err != nil {
+					return err
+				}
+			}
+			err := client.APIBaseClient.Action(managementClient.ClusterType, monitoringActionEdit, clusterResource, monitoringInput, nil)
+			if err != nil {
+				return err
+			}
+		}
+	} else if len(newCluster.Actions[monitoringActionDisable]) > 0 {
+		err := client.APIBaseClient.Action(managementClient.ClusterType, monitoringActionDisable, clusterResource, nil, nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func updateClusterMonitoringApps(meta interface{}, systemProjectID, version string) error {

--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -396,7 +396,7 @@ func resourceRancher2ClusterUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 		if err != nil {
 			if IsServerError(err) {
-				return nil
+				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
 		}
@@ -419,7 +419,7 @@ func resourceRancher2ClusterUpdate(d *schema.ResourceData, meta interface{}) err
 			err = updateClusterMonitoring(client, d, meta, *newCluster)
 			if err != nil {
 				if IsServerError(err) {
-					return nil
+					return resource.RetryableError(err)
 				}
 				return resource.NonRetryableError(err)
 			}


### PR DESCRIPTION
## Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1040 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
Error when upgrading rke cluster with Terraform 1.25

```
Error: Bad response statusCode [500]. Status [500 Internal Server Error]. Body: [code=ServerError, message=Operation cannot be fulfilled on clusters.management.cattle.io "c-mhjrs": the object has been modified; please apply your changes to the latest version and try again, baseType=error]
```

which in this case, indicates an intermittent race condition on update of the `rancher2_cluster` resource.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
 
Add retry code to `rancher2_cluster` resource Update. I have chosen to use `resource.Retry` instead of `context.WithTimeout` like in [this code](https://github.com/rancher/terraform-provider-rancher2/pull/537/commits/657341e5972b5b3f2d4fa24bdca9be92d3e80601#) because we need a cluster update to retry until a non retryable error is returned or the timeout is reached. [WithTimeout](https://golang.cafe/blog/golang-context-with-timeout-example.html) controls the timeout of an HTTP response, say a 500, but we don't want the request cancelled if it fails. We want to retry several times, especially on upgrade since customers tend to get pretty frustrated if they have to run a `terraform apply` more than once.

I've also moved `updateClusterMonitoring` into a helper function to increase readability of the Update function and updated comments.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

The race condition in the original issue is difficult to reproduce, but team discussion has concluded that adding retry code to `rancher2_cluster` Update will fix the failure on server error.

Test steps

- [x] Provision rke cluster on EC2 nodes with 1 cp/1 etcd/1 worker
- [x] Verify cluster provisions after one tf apply / no HTTP 500 error
- [x] Update rke cluster to increase worker count to 3 + add a fourth node pool
- [x] Verify cluster updates after one tf apply / no HTTP 500 error
- [x] Update rke cluster to `enable_cluster_monitoring = true` (preferably while the previous update is still running to simulate the race condition)
- [x] Verify cluster updates after one terraform apply (it took 27m for me!) / no HTTP 500 error

<details>

<summary>main.tf</summary>

```
terraform {
  required_providers {
    rancher2 = {
      source  = "terraform.local/local/rancher2"
      version = "1.0.0"
    }
  }
}
provider "rancher2" {
  api_url   = var.rancher_api_url
  token_key = var.rancher_admin_bearer_token
  insecure  = true
}
data "rancher2_cloud_credential" "rancher2_cloud_credential" {
  name = var.cloud_credential_name
}
resource "rancher2_cluster" "rancher2_cluster" {
  name = var.rke_cluster_name
  rke_config {
    kubernetes_version = "v1.26.4-rancher2-1"
    network {
      plugin = var.rke_network_plugin
    }
  }
}
resource "rancher2_node_template" "rancher2_node_template" {
  name = var.rke_node_template_name
  amazonec2_config {
    access_key           = var.aws_access_key
	  secret_key     = var.aws_secret_key
	  region         = var.aws_region
          ami            = var.aws_ami
	  security_group = [var.aws_security_group_name]
	  subnet_id      = var.aws_subnet_id
	  vpc_id         = var.aws_vpc_id
	  zone           = var.aws_zone_letter
	  root_size      = var.aws_root_size
	  instance_type  = var.aws_instance_type
  }
}
resource "rancher2_node_pool" "pool1" {
  cluster_id       = rancher2_cluster.rancher2_cluster.id
  name             = "pool1"
  hostname_prefix  = "tf-pool1-"
  node_template_id = rancher2_node_template.rancher2_node_template.id
  quantity         = 1
  control_plane    = false
  etcd             = true 
  worker           = false 
}
resource "rancher2_node_pool" "pool2" {
  cluster_id       = rancher2_cluster.rancher2_cluster.id
  name             = "pool2"
  hostname_prefix  = "tf-pool2-"
  node_template_id = rancher2_node_template.rancher2_node_template.id
  quantity         = 1
  control_plane    = true
  etcd             = false 
  worker           = false 
}
resource "rancher2_node_pool" "pool3" {
  cluster_id       = rancher2_cluster.rancher2_cluster.id
  name             = "pool3"
  hostname_prefix  = "tf-pool3-"
  node_template_id = rancher2_node_template.rancher2_node_template.id
  quantity         = 1
  control_plane    = false
  etcd             = false 
  worker           = true 
}
```

</details>

<details>

<summary>main.tf (sections with cluster updates)</summary>

```
resource "rancher2_cluster" "rancher2_cluster" {
  name = var.rke_cluster_name
  rke_config {
    kubernetes_version = "v1.26.4-rancher2-1"
    network {
      plugin = var.rke_network_plugin
    }
  }
  enable_cluster_monitoring = true
}
.
.
.
resource "rancher2_node_pool" "pool3" {
  cluster_id       = rancher2_cluster.rancher2_cluster.id
  name             = "pool3"
  hostname_prefix  = "tf-pool3-"
  node_template_id = rancher2_node_template.rancher2_node_template.id
  quantity         = 3
  control_plane    = false
  etcd             = false 
  worker           = true 
}
resource "rancher2_node_pool" "pool4" {
  cluster_id       = rancher2_cluster.rancher2_cluster.id
  name             = "pool4"
  hostname_prefix  = "tf-pool4-"
  node_template_id = rancher2_node_template.rancher2_node_template.id
  quantity         = 1
  control_plane    = false
  etcd             = true
  worker           = true
}
```

</details>

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->