### PR TITLE
[Q2] Refactor kubeconfig token replace logic

### DIFF
--- a/rancher2/util.go
+++ b/rancher2/util.go
@@ -12,7 +12,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -34,13 +33,6 @@ const (
 	maxHTTPRedirect           = 5
 )
 
-func getMax(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func AreEqual(o, n interface{}) bool {
 	return reflect.DeepEqual(o, n)
 }
@@ -61,11 +53,6 @@ func Base64Decode(s string) (string, error) {
 	data, err := base64.StdEncoding.DecodeString(s)
 
 	return string(data), err
-}
-
-func IsBase64(s string) bool {
-	_, err := base64.StdEncoding.DecodeString(s)
-	return err == nil
 }
 
 func getKubeConfigFromObj(kubeconfig *kubeconfig.Config) (string, error) {
@@ -106,34 +93,6 @@ func getTokenFromKubeConfig(config string) (string, error) {
 		return "", nil
 	}
 	kubeconfig, err := getObjFromKubeConfig(config)
-	if err != nil {
-		return "", err
-	}
-	if kubeconfig == nil || kubeconfig.AuthInfos == nil || len(kubeconfig.AuthInfos) == 0 {
-		return "", nil
-	}
-
-	return kubeconfig.AuthInfos[0].AuthInfo.Token, nil
-}
-
-func getTokenIDFromKubeConfig(config string) (string, error) {
-	token, err := getTokenFromKubeConfig(config)
-	if err != nil {
-		return "", err
-	}
-	return splitTokenID(token), nil
-
-}
-
-func updateKubeConfigToken(config, token string) (string, error) {
-	if len(token) == 0 {
-		return config, nil
-	}
-	if len(config) == 0 {
-		return "", nil
-	}
-	kubeconfig := &kubeconfig.Config{}
-	err := jsonToInterface(config, kubeconfig)
 	if err != nil {
 		return "", err
 	}
@@ -571,19 +530,6 @@ func toMapString(in map[string]interface{}) map[string]string {
 	return out
 }
 
-func toMapByte(in map[string]interface{}) map[string][]byte {
-	out := make(map[string][]byte)
-	for i, v := range in {
-		if v == nil {
-			out[i] = []byte{}
-			continue
-		}
-		value := v.(string)
-		out[i] = []byte(value)
-	}
-	return out
-}
-
 func toMapInterface(in map[string]string) map[string]interface{} {
 	out := make(map[string]interface{})
 	for i, v := range in {
@@ -709,43 +655,6 @@ func interfaceToGhodssyaml(in interface{}) (string, error) {
 		return "", err
 	}
 	return string(out), err
-}
-
-func YAMLToJSON(in string) (string, error) {
-	if len(in) == 0 {
-		return "", nil
-	}
-	out, err := ghodssyaml.YAMLToJSON([]byte(in))
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
-
-func JSONToYAML(in string) (string, error) {
-	if len(in) == 0 {
-		return "", nil
-	}
-	out, err := ghodssyaml.JSONToYAML([]byte(in))
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
-
-func FileExist(path string) (bool, error) {
-	if path == "" {
-		return false, nil
-	}
-	_, err := os.Stat(path)
-
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 func newString(value string) *string {


### PR DESCRIPTION
## Issue: https://github.com/rancher/terraform-provider-rancher2/issues/841
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

**Summary of what has changed**

* Update kubeconfig token validation and replace logic in `rancher2_cluster` resource
* Update/add comments
* Update error message formatting
* Remove unused util functions

**More details**

Update to kubeconfig logic to include cases where 1) the kubeconfig is empty (which happens on first provisioning of a cluster if the cache or tf.state file are manually deleted) or 2) the token is expired but returned from `isKubeconfigValid` as an empty string. This case will happen if the user sets a custom value for the global setting `kubeconfig-default-token-ttl-minutes` in Rancher.

The replace token code also needed to be updated. Before, we were generating an entire kubeconfig every time we needed a token. Instead of deleting the old token and using the one from the new kubeconfig, we are now replacing the token in the cached kubeconfig OR creating a new token for the cached kubeconfig if the token is expired or removed. If a token was removed by the user, that will force a customer to reprovision their entire TF cluster -- this case is handled gracefully now.

@kinarashah I have kept the code to check token length if the kubeconfig is invalid. This case must be isolated because if the kubeconfig can't be pulled for other reasons/errors, Terraform must download a new one. Our previous discussion made the download code unreachable.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

- [x] Provision a single node, all-role rke cluster via TF.
- [x] Verify the kubeconfig was downloaded correctly
- [x] Run `terraform plan` 3 times. Verify the same cached kubeconfig is being used and additional tokens were _not_ generated
- [x] Set `kubeconfig-default-token-ttl-minutes` to 2m and run tf update to add 1 node to the cluster. Verify a token is created with 2m expiry date
- [x] Run tf apply to add 1 node to the cluster. Verify a new token is created before the old one expires
- [x] Run tf apply to add 1 node to the cluster. Verify a new token is created once the old one is removed / does not exist anymore
- [x] Edit `terraform.tfstate` file and set `kube_config` to a corrupt id, perhaps `TESTTOKEN.` Run tf apply to add 1 node to the cluster. Verify a new token is created since the old one is corrupt, no errors 

All updates _completed_ gracefully and successfully, with no errors.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->