### PR TITLE
Update `rancher2_cluster_v2.rke_config.machine_selector_config.config` to optional/computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ FEATURES:
 
 ENHANCEMENTS:
 
-
+* Updated `rancher2_cluster_v2.rke_config.machine_selector_config.config` argument as optional/computed
 
 BUG FIXES:
 

--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -584,7 +584,7 @@ The following attributes are exported:
 ##### Arguments
 
 * `machine_label_selector` - (Optional) Machine selector label (list maxitems:1)
-* `config` - (Optional) Machine selector config (map)
+* `config` - (Optional/Computed) Machine selector config (map)
 
 ##### `machine_label_selector`
 

--- a/rancher2/schema_cluster_v2_rke_config_system_config.go
+++ b/rancher2/schema_cluster_v2_rke_config_system_config.go
@@ -65,6 +65,7 @@ func clusterV2RKEConfigSystemConfigFields() map[string]*schema.Schema {
 		"config": {
 			Type:        schema.TypeMap,
 			Optional:    true,
+			Computed:    true,
 			Description: "Machine selector config",
 		},
 	}


### PR DESCRIPTION
Related Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1074

## Problem
It is currently not possible to supply a compute value for the `rancher2_cluster_v2.rke_config.machine_selector_config.config` argument. It is common to require this, for instance when supplying a kubeconfig retrieved from a previous Terraform resource (e.g. when creating clusters using the Harvester provider).

Making this field computed will enable argument map entries (such as `cloud-provider-config`) to be computed at apply time.
 
## Solution
This change simply makes the `rancher2_cluster_v2.rke_config.machine_selector_config.config` field optional/computed.
 
## Testing
1. Take unmodified code base.
2. Create a test `rancher2_cluster_v2` resource with `rke_config.machine_selector_config.config` field set to the value of another resource.
3. Observe that the argument's value is null at plan and apply-time.
4. Apply this PR and re-run the plan and apply.
5. Observe that the value is listed as '(known after apply)' at plan-time, and is set correctly during apply.

## Engineering Testing
### Manual Testing
Conducted test steps above.

### Automated Testing
No automated test changes required.

## QA Testing Considerations
No special QA test cases required.
 
### Regressions Considerations
Unlikely to have high chance of regression.