### PR TITLE
Add group_search_filter, user_search_filter, and start_tls to LDAP Auth Config

### DIFF
--- a/rancher2/schema_auth_config_ldap.go
+++ b/rancher2/schema_auth_config_ldap.go
@@ -39,6 +39,10 @@ func authConfigLdapFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Required: true,
 		},
+		"user_search_filter": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		"certificate": {
 			Type:         schema.TypeString,
 			Optional:     true,
@@ -89,6 +93,10 @@ func authConfigLdapFields() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
+		"group_search_filter": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		"nested_group_membership_enabled": {
 			Type:     schema.TypeBool,
 			Optional: true,
@@ -135,6 +143,11 @@ func authConfigLdapFields() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"tls": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
+		"start_tls": {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Computed: true,

--- a/rancher2/structure_auth_config_ldap.go
+++ b/rancher2/structure_auth_config_ldap.go
@@ -33,7 +33,6 @@ func flattenAuthConfigLdap(d *schema.ResourceData, in *managementClient.LdapConf
 	}
 
 	d.Set("service_account_distinguished_name", in.ServiceAccountDistinguishedName)
-	d.Set("user_search_base", in.UserSearchBase)
 	d.Set("certificate", Base64Encode(in.Certificate))
 	d.Set("connection_timeout", int(in.ConnectionTimeout))
 	d.Set("group_dn_attribute", in.GroupDNAttribute)
@@ -43,9 +42,11 @@ func flattenAuthConfigLdap(d *schema.ResourceData, in *managementClient.LdapConf
 	d.Set("group_object_class", in.GroupObjectClass)
 	d.Set("group_search_attribute", in.GroupSearchAttribute)
 	d.Set("group_search_base", in.GroupSearchBase)
+	d.Set("group_search_filter", in.GroupSearchFilter)
 	d.Set("nested_group_membership_enabled", in.NestedGroupMembershipEnabled)
 	d.Set("port", int(in.Port))
 	d.Set("tls", in.TLS)
+	d.Set("start_tls", in.StartTLS)
 	d.Set("user_disabled_bit_mask", int(in.UserDisabledBitMask))
 	d.Set("user_enabled_attribute", in.UserEnabledAttribute)
 	d.Set("user_login_attribute", in.UserLoginAttribute)
@@ -53,6 +54,8 @@ func flattenAuthConfigLdap(d *schema.ResourceData, in *managementClient.LdapConf
 	d.Set("user_name_attribute", in.UserNameAttribute)
 	d.Set("user_object_class", in.UserObjectClass)
 	d.Set("user_search_attribute", in.UserSearchAttribute)
+	d.Set("user_search_base", in.UserSearchBase)
+	d.Set("user_search_filter", in.UserSearchFilter)
 
 	return nil
 }
@@ -105,6 +108,10 @@ func expandAuthConfigLdap(in *schema.ResourceData) (*managementClient.LdapConfig
 		obj.UserSearchBase = v
 	}
 
+	if v, ok := in.Get("user_search_filter").(string); ok && len(v) > 0 {
+		obj.UserSearchFilter = v
+	}
+
 	if v, ok := in.Get("certificate").(string); ok && len(v) > 0 {
 		cert, err := Base64Decode(v)
 		if err != nil {
@@ -145,6 +152,10 @@ func expandAuthConfigLdap(in *schema.ResourceData) (*managementClient.LdapConfig
 		obj.GroupSearchBase = v
 	}
 
+	if v, ok := in.Get("group_search_filter").(string); ok && len(v) > 0 {
+		obj.GroupSearchFilter = v
+	}
+
 	if v, ok := in.Get("nested_group_membership_enabled").(bool); ok {
 		obj.NestedGroupMembershipEnabled = v
 	}
@@ -155,6 +166,10 @@ func expandAuthConfigLdap(in *schema.ResourceData) (*managementClient.LdapConfig
 
 	if v, ok := in.Get("tls").(bool); ok {
 		obj.TLS = v
+	}
+
+	if v, ok := in.Get("start_tls").(bool); ok {
+		obj.StartTLS = v
 	}
 
 	if v, ok := in.Get("user_disabled_bit_mask").(int); ok && v > 0 {

--- a/rancher2/structure_auth_config_ldap_test.go
+++ b/rancher2/structure_auth_config_ldap_test.go
@@ -30,15 +30,18 @@ func init() {
 		GroupObjectClass:                "group_object_class",
 		GroupSearchAttribute:            "group_search_attribute",
 		GroupSearchBase:                 "group_search_base",
+		GroupSearchFilter:               "(cn=$SEARCH_STRING)",
 		NestedGroupMembershipEnabled:    true,
 		Port:                            389,
 		TLS:                             true,
+		StartTLS:                        true,
 		UserDisabledBitMask:             0,
 		UserLoginAttribute:              "user_login_attribute",
 		UserMemberAttribute:             "user_member_attribute",
 		UserNameAttribute:               "user_name_attribute",
 		UserObjectClass:                 "user_object_class",
 		UserSearchAttribute:             "user_search_attribute",
+		UserSearchFilter:                "(|(cn=$SEARCH_STRING)(sAMAccountName=$SEARCH_STRING))",
 	}
 	testAuthConfigLdapInterface = map[string]interface{}{
 		"access_mode":                        "access",
@@ -56,15 +59,18 @@ func init() {
 		"group_object_class":                 "group_object_class",
 		"group_search_attribute":             "group_search_attribute",
 		"group_search_base":                  "group_search_base",
+		"group_search_filter":                "(cn=$SEARCH_STRING)",
 		"nested_group_membership_enabled":    true,
 		"port":                               389,
 		"tls":                                true,
+		"start_tls":                          true,
 		"user_disabled_bit_mask":             0,
 		"user_login_attribute":               "user_login_attribute",
 		"user_member_attribute":              "user_member_attribute",
 		"user_name_attribute":                "user_name_attribute",
 		"user_object_class":                  "user_object_class",
 		"user_search_attribute":              "user_search_attribute",
+		"user_search_filter":                 "(|(cn=$SEARCH_STRING)(sAMAccountName=$SEARCH_STRING))",
 	}
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
https://github.com/rancher/terraform-provider-rancher2/issues/1198
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
Rancher terraform provider is missing three fields, group_search_filter, user_search_filter, and start_tls. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
Added the new fields to the base LDAP auth config schema. So any auth config which builds on top of the base LDAP one will now have these fields.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->
Check that corresponding fields are populated correctly when using the new fields.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Ran unit tests. Also verified through manual usage that the new fields are populated correctly by using a local build of the terraform provider and a QA openLDAP setup, then used the rancher UI to verify the fields are correct. 
Used a k8s v1.24.6 cluster running Rancher v2.7-head (d0eac94)

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Added fields to ldap unit tests

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
Please test that new fields configure the auth config correctly on Rancher Manager from terraform. Test that each field is working correctly on the auth config side as well (group_search_filter, user_search_filter, start_tls) as though it were configured through the UI.
This needs to be tested using Terraform RC v3.0.2-rc2

Below is a template for the auth config terraform file:
```
 resource "rancher2_auth_config_openldap" "openldap" {
   servers = ["{redacted}"]
   port = 389  
   tls = false
   service_account_distinguished_name = "{redacted}"
   service_account_password = "{redacted}"
   user_search_base = "{redacted}"
   user_search_filter = "(&(objectClass=person)(objectClass=user))"
   group_search_filter = "(objectclass=groupOfUniqueNames)"
   test_username = "{redacted}"
   test_password = "{redacted}"
 }
```
Please note this contains sensitive information which was removed and will need to be replaced. The appropriate values are available in confluence.

I am unsure if there is a need to test various filter values as well but that could be taken into account.
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->