### PR TITLE
Fix machine selector config to allow kubelet arg list

### DIFF
--- a/rancher2/schema_cluster_v2.go
+++ b/rancher2/schema_cluster_v2.go
@@ -4,6 +4,126 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+func clusterV2FieldsV0() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "Cluster V2 name",
+		},
+		"fleet_namespace": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  "fleet-default",
+		},
+		"kubernetes_version": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Cluster V2 kubernetes version",
+		},
+		"local_auth_endpoint": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Cluster V2 local auth endpoint",
+			Elem: &schema.Resource{
+				Schema: clusterV2LocalAuthEndpointFields(),
+			},
+		},
+		"rke_config": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Computed:    true,
+			Description: "Cluster V2 rke config",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigFieldsV0(),
+			},
+		},
+		"agent_env_vars": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Cluster V2 default agent env vars",
+			Elem: &schema.Resource{
+				Schema: envVarFields(),
+			},
+		},
+		"cloud_credential_secret_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Cluster V2 cloud credential secret name",
+		},
+		"cluster_agent_deployment_customization": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Optional customization for cluster agent",
+			Elem: &schema.Resource{
+				Schema: agentDeploymentCustomizationFields(),
+			},
+		},
+		"fleet_agent_deployment_customization": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Optional customization for fleet agent",
+			Elem: &schema.Resource{
+				Schema: agentDeploymentCustomizationFields(),
+			},
+		},
+		"default_pod_security_policy_template_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Cluster V2 default pod security policy template name",
+		},
+		"default_pod_security_admission_configuration_template_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Cluster V2 default pod security admission configuration template name",
+		},
+		"default_cluster_role_for_project_members": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Cluster V2 default cluster role for project members",
+		},
+		"enable_network_policy": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			Description: "Enable k8s network policy",
+		},
+		// Computed attributes
+		"cluster_registration_token": {
+			Type:      schema.TypeList,
+			MaxItems:  1,
+			Computed:  true,
+			Sensitive: true,
+			Elem: &schema.Resource{
+				Schema: clusterRegistrationTokenFields(),
+			},
+		},
+		"kube_config": {
+			Type:      schema.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+		"cluster_v1_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"resource_version": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
+	}
+
+	return s
+}
+
 func clusterV2Fields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"name": {

--- a/rancher2/schema_cluster_v2_rke_config.go
+++ b/rancher2/schema_cluster_v2_rke_config.go
@@ -9,6 +9,160 @@ import (
 
 //Types
 
+func clusterV2RKEConfigFieldsV0() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"additional_manifest": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Cluster V2 additional manifest",
+		},
+		"local_auth_endpoint": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Deprecated:  "Use rancher2_cluster_v2.local_auth_endpoint instead",
+			Description: "Cluster V2 local auth endpoint",
+			Elem: &schema.Resource{
+				Schema: clusterV2LocalAuthEndpointFields(),
+			},
+		},
+		"upgrade_strategy": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Cluster V2 upgrade strategy",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigUpgradeStrategyFields(),
+			},
+		},
+		"chart_values": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Cluster V2 chart values. It should be in YAML format",
+			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+				v, ok := val.(string)
+				if !ok || len(v) == 0 {
+					return
+				}
+				_, err := ghodssyamlToMapInterface(v)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("%q must be in yaml format, error: %v", key, err))
+					return
+				}
+				return
+			},
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				if old == "" || new == "" {
+					return false
+				}
+				oldMap, _ := ghodssyamlToMapInterface(old)
+				newMap, _ := ghodssyamlToMapInterface(new)
+				return reflect.DeepEqual(oldMap, newMap)
+			},
+		},
+		"machine_global_config": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Cluster V2 machine global config",
+			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+				v, ok := val.(string)
+				if !ok || len(v) == 0 {
+					return
+				}
+				_, err := ghodssyamlToMapInterface(v)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("%q must be in yaml format, error: %v", key, err))
+					return
+				}
+				return
+			},
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				if old == "" || new == "" {
+					return false
+				}
+				oldMap, _ := ghodssyamlToMapInterface(old)
+				newMap, _ := ghodssyamlToMapInterface(new)
+				return reflect.DeepEqual(oldMap, newMap)
+			},
+		},
+		"machine_pools": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Computed:    true,
+			Description: "Cluster V2 machine pools",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigMachinePoolFields(),
+			},
+		},
+		"machine_pool_defaults": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Computed:    true,
+			Description: "Default values for machine pool configurations if unset",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigMachinePoolDefaultFields(),
+			},
+		},
+		"machine_selector_config": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Computed:    true,
+			Description: "Cluster V2 machine selector config",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigSystemConfigFieldsV0(),
+			},
+		},
+		"registries": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Cluster V2 registries",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigRegistryFields(),
+			},
+		},
+		"etcd": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Computed:    true,
+			Description: "Cluster V2 etcd",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigETCDFields(),
+			},
+		},
+		"rotate_certificates": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Cluster V2 certificate rotation",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigRotateCertificatesFields(),
+			},
+		},
+		"etcd_snapshot_create": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Cluster V2 etcd snapshot create",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigETCDSnapshotCreateFields(),
+			},
+		},
+		"etcd_snapshot_restore": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Cluster V2 etcd snapshot restore",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigETCDSnapshotRestoreFields(),
+			},
+		},
+	}
+
+	return s
+}
+
 func clusterV2RKEConfigFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"additional_manifest": {

--- a/rancher2/schema_cluster_v2_rke_config_system_config.go
+++ b/rancher2/schema_cluster_v2_rke_config_system_config.go
@@ -1,6 +1,9 @@
 package rancher2
 
 import (
+	"fmt"
+	"reflect"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -51,6 +54,47 @@ func clusterV2RKEConfigSystemConfigLabelSelectorFields() map[string]*schema.Sche
 	return s
 }
 
+func clusterV2RKEConfigSystemConfigFieldsV0() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"machine_label_selector": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Machine label selector",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigSystemConfigLabelSelectorFields(),
+			},
+		},
+		"config": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Machine selector config",
+			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+				v, ok := val.(string)
+				if !ok || len(v) == 0 {
+					return
+				}
+				_, err := ghodssyamlToMapInterface(v)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("%q must be in yaml format, error: %v", key, err))
+					return
+				}
+				return
+			},
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				if old == "" || new == "" {
+					return false
+				}
+				oldMap, _ := ghodssyamlToMapInterface(old)
+				newMap, _ := ghodssyamlToMapInterface(new)
+				return reflect.DeepEqual(oldMap, newMap)
+			},
+		},
+	}
+
+	return s
+}
+
 func clusterV2RKEConfigSystemConfigFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"machine_label_selector": {
@@ -63,9 +107,29 @@ func clusterV2RKEConfigSystemConfigFields() map[string]*schema.Schema {
 			},
 		},
 		"config": {
-			Type:        schema.TypeMap,
+			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "Machine selector config",
+			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+				v, ok := val.(string)
+				if !ok || len(v) == 0 {
+					return
+				}
+				_, err := ghodssyamlToMapInterface(v)
+				if err != nil {
+					errs = append(errs, fmt.Errorf("%q must be in yaml format, error: %v", key, err))
+					return
+				}
+				return
+			},
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				if old == "" || new == "" {
+					return false
+				}
+				oldMap, _ := ghodssyamlToMapInterface(old)
+				newMap, _ := ghodssyamlToMapInterface(new)
+				return reflect.DeepEqual(oldMap, newMap)
+			},
 		},
 	}
 

--- a/rancher2/structure_cluster_v2_rke_config_system_config.go
+++ b/rancher2/structure_cluster_v2_rke_config_system_config.go
@@ -59,7 +59,8 @@ func flattenClusterV2RKEConfigSystemConfig(p []rkev1.RKESystemConfig) []interfac
 			obj["machine_label_selector"] = flattenClusterV2RKEConfigSystemConfigLabelSelector(in.MachineLabelSelector)
 		}
 		if len(in.Config.Data) > 0 {
-			obj["config"] = in.Config.Data
+			values, _ := interfaceToGhodssyaml(in.Config.Data)
+			obj["config"] = values
 		}
 		out[i] = obj
 	}
@@ -126,8 +127,9 @@ func expandClusterV2RKEConfigSystemConfig(p []interface{}) []rkev1.RKESystemConf
 		if v, ok := in["machine_label_selector"].([]interface{}); ok && len(v) > 0 {
 			obj.MachineLabelSelector = expandClusterV2RKEConfigSystemConfigLabelSelector(v)
 		}
-		if v, ok := in["config"].(map[string]interface{}); ok && len(v) > 0 {
-			obj.Config.Data = v
+		if v, ok := in["config"].(string); ok && len(v) > 0 {
+			values, _ := ghodssyamlToMapInterface(v)
+			obj.Config.Data = values
 		}
 		out[i] = obj
 	}

--- a/rancher2/structure_cluster_v2_rke_config_system_config_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_system_config_test.go
@@ -21,7 +21,7 @@ func init() {
 	testClusterV2RKEConfigSystemConfigLabelSelectorExpressionConf = []metav1.LabelSelectorRequirement{
 		{
 			Key:      "key",
-			Operator: metav1.LabelSelectorOperator("operator"),
+			Operator: "operator",
 			Values:   []string{"value1", "value2"},
 		},
 	}
@@ -63,10 +63,7 @@ func init() {
 	testClusterV2RKEConfigSystemConfigInterface = []interface{}{
 		map[string]interface{}{
 			"machine_label_selector": testClusterV2RKEConfigSystemConfigLabelSelectorInterface,
-			"config": map[string]interface{}{
-				"config_one": "one",
-				"config_two": "two",
-			},
+			"config":                 "config_one: one\nconfig_two: two\n",
 		},
 	}
 }

--- a/rancher2/util.go
+++ b/rancher2/util.go
@@ -590,15 +590,6 @@ func ghodssyamlToInterface(in string, out interface{}) error {
 	return err
 }
 
-func yamlToMapInterface(in string) (map[string]interface{}, error) {
-	out := make(map[string]interface{})
-	err := yaml.Unmarshal([]byte(in), &out)
-	if err != nil {
-		return nil, err
-	}
-	return out, err
-}
-
 func yamlToInterface(in string, out interface{}) error {
 	if out == nil {
 		return nil


### PR DESCRIPTION
## Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1074 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Machine Selector Config `kubelet-arg` values could not be passed via Terraform to downstream machines and would not show up in the rancher UI. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
 
My solution is to convert `machine_selector_config.config` from Type.Map (string map) to Type.String that supports yaml like Machine Global Config + state migration logic to handle the schema update. This allows for users to input both strings and lists, which allows subfield `kubelet-arg` to be passed as a list which is what Rancher is expecting. It also prevents a potential regression caused by 1) only allowing string args or lists which will reduce the flexibility of Machine Selector Config or 2) defining kubelet-arg as a subfield which will break other config fields that are already expected in the Rancher backend such as `private-default-registry.`

Before, passing `kubelet-arg` under Machine Selector Config would not work. This feature now works with the following configuration

```
machine_selector_config {
  config = <<EOF
    protect-kernel-default: true
    kubelet-arg:
      - key1=value1
      - key2=value2
  EOF
}
```

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Test plan
- [x] Prov rke2 cluster with Machine Selector Config and 2 kubelet args set. Verify cluster provisions successfully and args are displayed correctly in the rancher ui
- [x]  Add/remove a kubelet-arg via tf and verify list is updated in the ui
- [x] Prov rke2 cluster with tf 3.1.0. Add machine selector config with 2 kubelet args via the rancher ui
- [x] Upgrade tf to rc version with fix
- [x] Verify no errors appear on `terraform plan/apply` or updates to Machine Selector Config.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

Tests updated. Ran `go test -v ./rancher2` to make sure all automated tests pass.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->