### PR TITLE
Add extra_args_array Field

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1271,6 +1271,7 @@ The following attributes are exported:
 * `creation` - (Optional/Computed) Creation option for etcd service (string)
 * `external_urls` - (Optional) External urls for etcd service (list)
 * `extra_args` - (Optional/Computed) Extra arguments for etcd service (map)
+* `extra_args_array` - (Optional/Computed) Extra arguments array for etcd service (list)
 * `extra_binds` - (Optional) Extra binds for etcd service (list)
 * `extra_env` - (Optional) Extra environment for etcd service (list)
 * `gid` - (Optional) Etcd service GID. Default: `0`. For Rancher v2.3.x and above (int)
@@ -1313,6 +1314,7 @@ The following attributes are exported:
 * `audit_log` - (Optional) K8s audit log configuration. (list maxitems: 1)
 * `event_rate_limit` - (Optional) K8s event rate limit configuration. (list maxitems: 1)
 * `extra_args` - (Optional/Computed) Extra arguments for kube API service (map)
+* `extra_args_array` - (Optional/Computed) Extra arguments array for kube API service (list)
 * `extra_binds` - (Optional) Extra binds for kube API service (list)
 * `extra_env` - (Optional) Extra environment for kube API service (list)
 * `image` - (Optional/Computed) Docker image for kube API service (string)
@@ -1435,6 +1437,7 @@ EOF
 
 * `cluster_cidr` - (Optional/Computed) Cluster CIDR option for kube controller service (string)
 * `extra_args` - (Optional/Computed) Extra arguments for kube controller service (map)
+* `extra_args_array` - (Optional/Computed) Extra arguments array for kube controller service (list)
 * `extra_binds` - (Optional) Extra binds for kube controller service (list)
 * `extra_env` - (Optional) Extra environment for kube controller service (list)
 * `image` - (Optional/Computed) Docker image for kube controller service (string)
@@ -1447,6 +1450,7 @@ EOF
 * `cluster_dns_server` - (Optional/Computed) Cluster DNS Server option for kubelet service (string)
 * `cluster_domain` - (Optional/Computed) Cluster Domain option for kubelet service (string)
 * `extra_args` - (Optional/Computed) Extra arguments for kubelet service (map)
+* `extra_args_array` - (Optional/Computed) Extra arguments array for kubelet service (list)
 * `extra_binds` - (Optional) Extra binds for kubelet service (list)
 * `extra_env` - (Optional) Extra environment for kubelet service (list)
 * `fail_swap_on` - (Optional/Computed) Enable or disable failing when swap on is not supported (bool)
@@ -1459,6 +1463,7 @@ EOF
 ###### Arguments
 
 * `extra_args` - (Optional/Computed) Extra arguments for kubeproxy service (map)
+* `extra_args_array` - (Optional/Computed) Extra arguments array for kubeproxy service (list)
 * `extra_binds` - (Optional) Extra binds for kubeproxy service (list)
 * `extra_env` - (Optional) Extra environment for kubeproxy service (list)
 * `image` - (Optional/Computed) Docker image for kubeproxy service (string)
@@ -1468,6 +1473,7 @@ EOF
 ###### Arguments
 
 * `extra_args` - (Optional/Computed) Extra arguments for scheduler service (map)
+* `extra_args_array` - (Optional/Computed) Extra arguments array for scheduler service (list)
 * `extra_binds` - (Optional) Extra binds for scheduler service (list)
 * `extra_env` - (Optional) Extra environment for scheduler service (list)
 * `image` - (Optional/Computed) Docker image for scheduler service (string)

--- a/rancher2/schema_cluster_rke_config_services.go
+++ b/rancher2/schema_cluster_rke_config_services.go
@@ -186,3 +186,26 @@ func clusterRKEConfigServicesFieldsData() map[string]*schema.Schema {
 	}
 	return s
 }
+
+func clusterRKEConfigServicesExtraArgsArrayFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Required: true,
+			Type:     schema.TypeString,
+		},
+		"value": {
+			Type:     schema.TypeList,
+			Required: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+}
+
+func clusterRKEConfigServicesExtraArgsArraySchemaSetFunc(v interface{}) int {
+	resource := &schema.Resource{
+		Schema: clusterRKEConfigServicesExtraArgsArrayFields(),
+	}
+	return schema.HashResource(resource)(v)
+}

--- a/rancher2/schema_cluster_rke_config_services_etcd.go
+++ b/rancher2/schema_cluster_rke_config_services_etcd.go
@@ -120,6 +120,14 @@ func clusterRKEConfigServicesEtcdFields() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
+		"extra_args_array": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesExtraArgsArrayFields(),
+			},
+			Set: clusterRKEConfigServicesExtraArgsArraySchemaSetFunc,
+		},
 		"extra_binds": {
 			Type:     schema.TypeList,
 			Optional: true,

--- a/rancher2/schema_cluster_rke_config_services_kube_api.go
+++ b/rancher2/schema_cluster_rke_config_services_kube_api.go
@@ -517,6 +517,14 @@ func clusterRKEConfigServicesKubeAPIFieldsV0() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
+		"extra_args_array": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesExtraArgsArrayFields(),
+			},
+			Set: clusterRKEConfigServicesExtraArgsArraySchemaSetFunc,
+		},
 		"extra_binds": {
 			Type:     schema.TypeList,
 			Optional: true,
@@ -599,6 +607,14 @@ func clusterRKEConfigServicesKubeAPIFields() map[string]*schema.Schema {
 			Type:     schema.TypeMap,
 			Optional: true,
 			Computed: true,
+		},
+		"extra_args_array": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesExtraArgsArrayFields(),
+			},
+			Set: clusterRKEConfigServicesExtraArgsArraySchemaSetFunc,
 		},
 		"extra_binds": {
 			Type:     schema.TypeList,
@@ -683,6 +699,14 @@ func clusterRKEConfigServicesKubeAPIFieldsData() map[string]*schema.Schema {
 			Type:     schema.TypeMap,
 			Optional: true,
 			Computed: true,
+		},
+		"extra_args_array": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesExtraArgsArrayFields(),
+			},
+			Set: clusterRKEConfigServicesExtraArgsArraySchemaSetFunc,
 		},
 		"extra_binds": {
 			Type:     schema.TypeList,

--- a/rancher2/schema_cluster_rke_config_services_kube_controller.go
+++ b/rancher2/schema_cluster_rke_config_services_kube_controller.go
@@ -18,6 +18,14 @@ func clusterRKEConfigServicesKubeControllerFields() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
+		"extra_args_array": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesExtraArgsArrayFields(),
+			},
+			Set: clusterRKEConfigServicesExtraArgsArraySchemaSetFunc,
+		},
 		"extra_binds": {
 			Type:     schema.TypeList,
 			Optional: true,

--- a/rancher2/schema_cluster_rke_config_services_kubelet.go
+++ b/rancher2/schema_cluster_rke_config_services_kubelet.go
@@ -23,6 +23,14 @@ func clusterRKEConfigServicesKubeletFields() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
+		"extra_args_array": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesExtraArgsArrayFields(),
+			},
+			Set: clusterRKEConfigServicesExtraArgsArraySchemaSetFunc,
+		},
 		"extra_binds": {
 			Type:     schema.TypeList,
 			Optional: true,

--- a/rancher2/schema_cluster_rke_config_services_kubeproxy.go
+++ b/rancher2/schema_cluster_rke_config_services_kubeproxy.go
@@ -13,6 +13,14 @@ func clusterRKEConfigServicesKubeproxyFields() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
+		"extra_args_array": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesExtraArgsArrayFields(),
+			},
+			Set: clusterRKEConfigServicesExtraArgsArraySchemaSetFunc,
+		},
 		"extra_binds": {
 			Type:     schema.TypeList,
 			Optional: true,

--- a/rancher2/schema_cluster_rke_config_services_scheduler.go
+++ b/rancher2/schema_cluster_rke_config_services_scheduler.go
@@ -13,6 +13,14 @@ func clusterRKEConfigServicesSchedulerFields() map[string]*schema.Schema {
 			Optional: true,
 			Computed: true,
 		},
+		"extra_args_array": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: clusterRKEConfigServicesExtraArgsArrayFields(),
+			},
+			Set: clusterRKEConfigServicesExtraArgsArraySchemaSetFunc,
+		},
 		"extra_binds": {
 			Type:     schema.TypeList,
 			Optional: true,

--- a/rancher2/structure_cluster_rke_config_services_etcd.go
+++ b/rancher2/structure_cluster_rke_config_services_etcd.go
@@ -3,6 +3,7 @@ package rancher2
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 )
 
@@ -121,6 +122,10 @@ func flattenClusterRKEConfigServicesEtcd(in *managementClient.ETCDService, p []i
 
 	if len(in.ExtraArgs) > 0 {
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
+	}
+
+	if len(in.ExtraArgsArray) > 0 {
+		obj["extra_args_array"] = flattenExtraArgsArray(in.ExtraArgsArray)
 	}
 
 	if len(in.ExtraBinds) > 0 {
@@ -275,6 +280,10 @@ func expandClusterRKEConfigServicesEtcd(p []interface{}) (*managementClient.ETCD
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_args_array"].(*schema.Set); ok && len(v.List()) > 0 {
+		obj.ExtraArgsArray = expandExtraArgsArray(v)
 	}
 
 	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {

--- a/rancher2/structure_cluster_rke_config_services_etcd_test.go
+++ b/rancher2/structure_cluster_rke_config_services_etcd_test.go
@@ -3,17 +3,20 @@ package rancher2
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	testClusterRKEConfigServicesETCDBackupS3Conf      *managementClient.S3BackupConfig
-	testClusterRKEConfigServicesETCDBackupS3Interface []interface{}
-	testClusterRKEConfigServicesETCDBackupConf        *managementClient.BackupConfig
-	testClusterRKEConfigServicesETCDBackupInterface   []interface{}
-	testClusterRKEConfigServicesETCDConf              *managementClient.ETCDService
-	testClusterRKEConfigServicesETCDInterface         []interface{}
+	testClusterRKEConfigServicesETCDBackupS3Conf            *managementClient.S3BackupConfig
+	testClusterRKEConfigServicesETCDBackupS3Interface       []interface{}
+	testClusterRKEConfigServicesETCDBackupConf              *managementClient.BackupConfig
+	testClusterRKEConfigServicesETCDBackupInterface         []interface{}
+	testClusterRKEConfigServicesETCDExtraArgsArrayConf      map[string][]string
+	testClusterRKEConfigServicesETCDExtraArgsArrayInterface *schema.Set
+	testClusterRKEConfigServicesETCDConf                    *managementClient.ETCDService
+	testClusterRKEConfigServicesETCDInterface               []interface{}
 )
 
 func init() {
@@ -53,6 +56,23 @@ func init() {
 			"timeout":          500,
 		},
 	}
+	testClusterRKEConfigServicesETCDExtraArgsArrayConf = map[string][]string{
+		"arg1": {"v1"},
+		"arg2": {"v2"},
+	}
+	testClusterRKEConfigServicesETCDExtraArgsArrayInterface = schema.NewSet(
+		clusterRKEConfigServicesExtraArgsArraySchemaSetFunc,
+		[]interface{}{
+			map[string]interface{}{
+				"name":  "arg1",
+				"value": []interface{}{"v1"},
+			},
+			map[string]interface{}{
+				"name":  "arg2",
+				"value": []interface{}{"v2"},
+			},
+		},
+	)
 	testClusterRKEConfigServicesETCDConf = &managementClient.ETCDService{
 		BackupConfig: testClusterRKEConfigServicesETCDBackupConf,
 		CACert:       "XXXXXXXX",
@@ -132,6 +152,23 @@ func TestFlattenClusterRKEConfigServicesEtcdBackupConfig(t *testing.T) {
 	}
 }
 
+func TestFlattenClusterRKEConfigServicesEtcdExtraArgsArray(t *testing.T) {
+
+	cases := []struct {
+		Input          map[string][]string
+		ExpectedOutput *schema.Set
+	}{
+		{
+			testClusterRKEConfigServicesETCDExtraArgsArrayConf,
+			testClusterRKEConfigServicesETCDExtraArgsArrayInterface,
+		},
+	}
+	for _, tc := range cases {
+		output := flattenExtraArgsArray(tc.Input)
+		assert.ElementsMatch(t, tc.ExpectedOutput.List(), output.List(), "Unexpected output from flattener.")
+	}
+}
+
 func TestFlattenClusterRKEConfigServicesEtcd(t *testing.T) {
 
 	cases := []struct {
@@ -188,6 +225,23 @@ func TestExpandClusterRKEConfigServicesEtcdBackupConfig(t *testing.T) {
 		if err != nil {
 			assert.FailNow(t, "[ERROR] on expander: %#v", err)
 		}
+		assert.Equal(t, tc.ExpectedOutput, output, "Unexpected output from expander.")
+	}
+}
+
+func TestExpandClusterRKEConfigServicesEtcdExtraArgsArrayConfig(t *testing.T) {
+
+	cases := []struct {
+		Input          *schema.Set
+		ExpectedOutput map[string][]string
+	}{
+		{
+			testClusterRKEConfigServicesETCDExtraArgsArrayInterface,
+			testClusterRKEConfigServicesETCDExtraArgsArrayConf,
+		},
+	}
+	for _, tc := range cases {
+		output := expandExtraArgsArray(tc.Input)
 		assert.Equal(t, tc.ExpectedOutput, output, "Unexpected output from expander.")
 	}
 }

--- a/rancher2/structure_cluster_rke_config_services_kube_api.go
+++ b/rancher2/structure_cluster_rke_config_services_kube_api.go
@@ -3,6 +3,7 @@ package rancher2
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 )
 
@@ -165,6 +166,10 @@ func flattenClusterRKEConfigServicesKubeAPI(in *managementClient.KubeAPIService)
 
 	if len(in.ExtraArgs) > 0 {
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
+	}
+
+	if len(in.ExtraArgsArray) > 0 {
+		obj["extra_args_array"] = flattenExtraArgsArray(in.ExtraArgsArray)
 	}
 
 	if len(in.ExtraBinds) > 0 {
@@ -390,6 +395,10 @@ func expandClusterRKEConfigServicesKubeAPI(p []interface{}) (*managementClient.K
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_args_array"].(*schema.Set); ok && len(v.List()) > 0 {
+		obj.ExtraArgsArray = expandExtraArgsArray(v)
 	}
 
 	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {

--- a/rancher2/structure_cluster_rke_config_services_kube_controller.go
+++ b/rancher2/structure_cluster_rke_config_services_kube_controller.go
@@ -1,6 +1,7 @@
 package rancher2
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 )
 
@@ -18,6 +19,10 @@ func flattenClusterRKEConfigServicesKubeController(in *managementClient.KubeCont
 
 	if len(in.ExtraArgs) > 0 {
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
+	}
+
+	if len(in.ExtraArgsArray) > 0 {
+		obj["extra_args_array"] = flattenExtraArgsArray(in.ExtraArgsArray)
 	}
 
 	if len(in.ExtraBinds) > 0 {
@@ -54,6 +59,10 @@ func expandClusterRKEConfigServicesKubeController(p []interface{}) (*managementC
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_args_array"].(*schema.Set); ok && len(v.List()) > 0 {
+		obj.ExtraArgsArray = expandExtraArgsArray(v)
 	}
 
 	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {

--- a/rancher2/structure_cluster_rke_config_services_kubelet.go
+++ b/rancher2/structure_cluster_rke_config_services_kubelet.go
@@ -1,6 +1,7 @@
 package rancher2
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 )
 
@@ -22,6 +23,10 @@ func flattenClusterRKEConfigServicesKubelet(in *managementClient.KubeletService)
 
 	if len(in.ExtraArgs) > 0 {
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
+	}
+
+	if len(in.ExtraArgsArray) > 0 {
+		obj["extra_args_array"] = flattenExtraArgsArray(in.ExtraArgsArray)
 	}
 
 	if len(in.ExtraBinds) > 0 {
@@ -65,6 +70,10 @@ func expandClusterRKEConfigServicesKubelet(p []interface{}) (*managementClient.K
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_args_array"].(*schema.Set); ok && len(v.List()) > 0 {
+		obj.ExtraArgsArray = expandExtraArgsArray(v)
 	}
 
 	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {

--- a/rancher2/structure_cluster_rke_config_services_kubeproxy.go
+++ b/rancher2/structure_cluster_rke_config_services_kubeproxy.go
@@ -1,6 +1,7 @@
 package rancher2
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 )
 
@@ -14,6 +15,10 @@ func flattenClusterRKEConfigServicesKubeproxy(in *managementClient.KubeproxyServ
 
 	if len(in.ExtraArgs) > 0 {
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
+	}
+
+	if len(in.ExtraArgsArray) > 0 {
+		obj["extra_args_array"] = flattenExtraArgsArray(in.ExtraArgsArray)
 	}
 
 	if len(in.ExtraBinds) > 0 {
@@ -42,6 +47,10 @@ func expandClusterRKEConfigServicesKubeproxy(p []interface{}) (*managementClient
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_args_array"].(*schema.Set); ok && len(v.List()) > 0 {
+		obj.ExtraArgsArray = expandExtraArgsArray(v)
 	}
 
 	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {

--- a/rancher2/structure_cluster_rke_config_services_scheduler.go
+++ b/rancher2/structure_cluster_rke_config_services_scheduler.go
@@ -1,6 +1,7 @@
 package rancher2
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 )
 
@@ -14,6 +15,10 @@ func flattenClusterRKEConfigServicesScheduler(in *managementClient.SchedulerServ
 
 	if len(in.ExtraArgs) > 0 {
 		obj["extra_args"] = toMapInterface(in.ExtraArgs)
+	}
+
+	if len(in.ExtraArgsArray) > 0 {
+		obj["extra_args_array"] = flattenExtraArgsArray(in.ExtraArgsArray)
 	}
 
 	if len(in.ExtraBinds) > 0 {
@@ -42,6 +47,10 @@ func expandClusterRKEConfigServicesScheduler(p []interface{}) (*managementClient
 
 	if v, ok := in["extra_args"].(map[string]interface{}); ok && len(v) > 0 {
 		obj.ExtraArgs = toMapString(v)
+	}
+
+	if v, ok := in["extra_args_array"].(*schema.Set); ok && len(v.List()) > 0 {
+		obj.ExtraArgsArray = expandExtraArgsArray(v)
 	}
 
 	if v, ok := in["extra_binds"].([]interface{}); ok && len(v) > 0 {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/terraform-provider-rancher2/issues/1209

## Problem
> Two new fields were added to RKE, ExtraArgsArray and WindowsExtraArgsArray. These fields allow users to specify an extraArg multiple times with different values. The provider now needs to be updated to support these two new fields.
 
## Solution
An `extra_args_array` set field was added adjacent to the existing `extra_args` field.
 
## Testing

## Engineering Testing
### Manual Testing

Here's a snippet demonstrating which fields were added, with everything else in ellipsis.

```hcl
resource "rancher2_cluster" "cluster" {

  rke_config {
    services {
      kube_api {
        extra_args_array {
          name  = "api-audiences"
          value = [
            "sts.amazonaws.com",
          ]
        }
        extra_args_array {
          name  = "service-account-key-file"
          value = [
            "/etc/kubernetes/ssl/sa-signer-pkcs8.pub",
          ]
        }
        extra_args_array {
          name  = "service-account-issuer"
          value = [
            "rke",
          ]
        }
      }
   }
}
```

And these were the results, trimmed for clarity

```console
      ~ rke_config {
          ~ services {
              ~ kube_api {
                  + extra_args_array {
                      + name  = "api-audiences"
                      + value = [
                          + "sts.amazonaws.com",
                        ]
                    }
                  + extra_args_array {
                      + name  = "service-account-issuer"
                      + value = [
                          + "rke",
                        ]
                    }
                  + extra_args_array {
                      + name  = "service-account-key-file"
                      + value = [
                          + "/etc/kubernetes/ssl/sa-signer-pkcs8.pub",
                        ]
                    }
                }
            }
        }
    }
```

### Automated Testing
Tests have been added only to `rancher2/structure_cluster_rke_config_services_etcd_test.go`, since the tests for the other services would otherwise use identical schemas, flatteners, and expanders.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->