### PR TITLE
Add support for machine_selector_files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pkg/sftp v1.13.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect

--- a/rancher2/schema_cluster_v2_rke_config.go
+++ b/rancher2/schema_cluster_v2_rke_config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-//Types
+// Types
 
 func clusterV2RKEConfigFieldsV0() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
@@ -110,6 +110,15 @@ func clusterV2RKEConfigFieldsV0() map[string]*schema.Schema {
 			Description: "Cluster V2 machine selector config",
 			Elem: &schema.Resource{
 				Schema: clusterV2RKEConfigSystemConfigFieldsV0(),
+			},
+		},
+		"machine_selector_files": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Computed:    true,
+			Description: "Cluster V2 machine selector files",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigMachineSelectorFilesFields(),
 			},
 		},
 		"registries": {
@@ -264,6 +273,15 @@ func clusterV2RKEConfigFields() map[string]*schema.Schema {
 			Description: "Cluster V2 machine selector config",
 			Elem: &schema.Resource{
 				Schema: clusterV2RKEConfigSystemConfigFields(),
+			},
+		},
+		"machine_selector_files": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Computed:    true,
+			Description: "Cluster V2 machine selector files",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigMachineSelectorFilesFields(),
 			},
 		},
 		"registries": {

--- a/rancher2/schema_cluster_v2_rke_config_files.go
+++ b/rancher2/schema_cluster_v2_rke_config_files.go
@@ -1,0 +1,113 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// Types
+
+func clusterV2RKEConfigKeyToPathFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"key": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The key of the item(file) to retrieve",
+		},
+		"path": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The path to put the file in the target node",
+		},
+		"dynamic": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "If ture, the file is ignored when determining whether the node should be drained before updating the node plan (default: true).",
+		},
+		"permissions": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The numeric representation of the file permissions",
+		},
+		"hash": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The base64 encoded value of the SHA256 checksum of the file's content",
+		},
+	}
+
+	return s
+}
+
+func clusterV2RKEConfigK8sObjectFileSourceFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The name of the K8s object",
+		},
+		"items": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Items(files) to retrieve from the K8s object",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigKeyToPathFields(),
+			},
+		},
+		"default_permissions": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The default permissions to be applied when they are not set at the item level",
+		},
+	}
+
+	return s
+}
+func clusterV2RKEConfigFileSourceFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"secret": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "The secret which is the source of files",
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigK8sObjectFileSourceFields(),
+			},
+		},
+		"configmap": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "The configmap which is the source of files",
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigK8sObjectFileSourceFields(),
+			},
+		},
+	}
+
+	return s
+}
+
+func clusterV2RKEConfigMachineSelectorFilesFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"machine_label_selector": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Description: "Machine label selector",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigSystemConfigLabelSelectorFields(),
+			},
+		},
+		"file_sources": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "File sources",
+			Elem: &schema.Resource{
+				Schema: clusterV2RKEConfigFileSourceFields(),
+			},
+		},
+	}
+
+	return s
+}

--- a/rancher2/structure_cluster_v2_rke_config.go
+++ b/rancher2/structure_cluster_v2_rke_config.go
@@ -36,6 +36,9 @@ func flattenClusterV2RKEConfig(in *provisionv1.RKEConfig) []interface{} {
 	if in.MachineSelectorConfig != nil && len(in.MachineSelectorConfig) > 0 {
 		obj["machine_selector_config"] = flattenClusterV2RKEConfigSystemConfig(in.MachineSelectorConfig)
 	}
+	if in.MachineSelectorFiles != nil && len(in.MachineSelectorFiles) > 0 {
+		obj["machine_selector_files"] = flattenClusterV2RKEConfigMachineSelectorFiles(in.MachineSelectorFiles)
+	}
 	if in.Registries != nil {
 		obj["registries"] = flattenClusterV2RKEConfigRegistry(in.Registries)
 	}
@@ -90,6 +93,9 @@ func expandClusterV2RKEConfig(p []interface{}) *provisionv1.RKEConfig {
 	}
 	if v, ok := in["machine_selector_config"].([]interface{}); ok && len(v) > 0 {
 		obj.MachineSelectorConfig = expandClusterV2RKEConfigSystemConfig(v)
+	}
+	if v, ok := in["machine_selector_files"].([]interface{}); ok && len(v) > 0 {
+		obj.MachineSelectorFiles = expandClusterV2RKEConfigProvisioningFiles(v)
 	}
 	if v, ok := in["registries"].([]interface{}); ok && len(v) > 0 {
 		obj.Registries = expandClusterV2RKEConfigRegistry(v)

--- a/rancher2/structure_cluster_v2_rke_config_system_config.go
+++ b/rancher2/structure_cluster_v2_rke_config_system_config.go
@@ -68,6 +68,86 @@ func flattenClusterV2RKEConfigSystemConfig(p []rkev1.RKESystemConfig) []interfac
 	return out
 }
 
+func flattenClusterV2RKEConfigMachineSelectorFiles(p []rkev1.RKEProvisioningFiles) []interface{} {
+	if p == nil {
+		return nil
+	}
+	out := make([]interface{}, len(p))
+	for i, in := range p {
+		obj := map[string]interface{}{}
+
+		if in.MachineLabelSelector != nil {
+			obj["machine_label_selector"] = flattenClusterV2RKEConfigSystemConfigLabelSelector(in.MachineLabelSelector)
+		}
+		if len(in.FileSources) > 0 {
+			obj["file_sources"] = flattenClusterV2RKEConfigFileSources(in.FileSources)
+		}
+		out[i] = obj
+	}
+
+	return out
+}
+
+func flattenClusterV2RKEConfigFileSources(p []rkev1.ProvisioningFileSource) []interface{} {
+	if p == nil {
+		return nil
+	}
+	out := make([]interface{}, len(p))
+	for i, in := range p {
+		obj := map[string]interface{}{}
+		if results := flattenClusterV2RKEConfigK8sObjectFileSource(in.Secret); len(results) > 0 {
+			obj["secret"] = results
+		}
+		if results := flattenClusterV2RKEConfigK8sObjectFileSource(in.ConfigMap); len(results) > 0 {
+			obj["configmap"] = results
+		}
+		out[i] = obj
+	}
+
+	return out
+}
+
+func flattenClusterV2RKEConfigK8sObjectFileSource(p rkev1.K8sObjectFileSource) []interface{} {
+	if p.Name == "" {
+		return []interface{}{}
+	}
+
+	obj := make(map[string]interface{})
+	obj["name"] = p.Name
+	obj["default_permissions"] = p.DefaultPermissions
+	if len(p.Items) > 0 {
+		obj["items"] = flattenClusterV2RKEConfigKeyToPath(p.Items)
+	}
+
+	return []interface{}{obj}
+}
+
+func flattenClusterV2RKEConfigKeyToPath(p []rkev1.KeyToPath) []interface{} {
+	if p == nil {
+		return nil
+	}
+	out := make([]interface{}, len(p))
+	for i, in := range p {
+		obj := map[string]interface{}{}
+		if len(in.Key) > 0 {
+			obj["key"] = in.Key
+		}
+		if len(in.Path) > 0 {
+			obj["path"] = in.Path
+		}
+		obj["dynamic"] = in.Dynamic
+		if len(in.Permissions) > 0 {
+			obj["permissions"] = in.Permissions
+		}
+		if len(in.Hash) > 0 {
+			obj["hash"] = in.Hash
+		}
+		out[i] = obj
+	}
+
+	return out
+}
+
 // Expanders
 
 func expandClusterV2RKEConfigSystemConfigLabelSelectorExpression(p []interface{}) []metav1.LabelSelectorRequirement {
@@ -99,7 +179,6 @@ func expandClusterV2RKEConfigSystemConfigLabelSelector(p []interface{}) *metav1.
 	if p == nil || len(p) == 0 || p[0] == nil {
 		return nil
 	}
-
 	obj := &metav1.LabelSelector{}
 
 	in := p[0].(map[string]interface{})
@@ -130,6 +209,101 @@ func expandClusterV2RKEConfigSystemConfig(p []interface{}) []rkev1.RKESystemConf
 		if v, ok := in["config"].(string); ok && len(v) > 0 {
 			values, _ := ghodssyamlToMapInterface(v)
 			obj.Config.Data = values
+		}
+		out[i] = obj
+	}
+
+	return out
+}
+
+func expandClusterV2RKEConfigProvisioningFiles(p []interface{}) []rkev1.RKEProvisioningFiles {
+	if p == nil || len(p) == 0 || p[0] == nil {
+		return nil
+	}
+
+	out := make([]rkev1.RKEProvisioningFiles, len(p))
+	for i := range p {
+		in := p[i].(map[string]interface{})
+		obj := rkev1.RKEProvisioningFiles{}
+
+		if v, ok := in["machine_label_selector"].([]interface{}); ok && len(v) > 0 {
+			obj.MachineLabelSelector = expandClusterV2RKEConfigSystemConfigLabelSelector(v)
+		}
+		if v, ok := in["file_sources"].([]interface{}); ok && len(v) > 0 {
+			obj.FileSources = expandClusterV2RKEConfigFileSources(v)
+		}
+		out[i] = obj
+	}
+
+	return out
+}
+
+func expandClusterV2RKEConfigFileSources(p []interface{}) []rkev1.ProvisioningFileSource {
+	if p == nil || len(p) == 0 || p[0] == nil {
+		return nil
+	}
+
+	out := make([]rkev1.ProvisioningFileSource, len(p))
+	for i := range p {
+		in := p[i].(map[string]interface{})
+		obj := rkev1.ProvisioningFileSource{}
+
+		if v, ok := in["secret"].([]interface{}); ok && len(v) > 0 {
+			obj.Secret = expandClusterV2RKEConfigK8sObjectFileSource(v)
+		}
+		if v, ok := in["configmap"].([]interface{}); ok && len(v) > 0 {
+			obj.ConfigMap = expandClusterV2RKEConfigK8sObjectFileSource(v)
+		}
+		out[i] = obj
+	}
+
+	return out
+}
+
+func expandClusterV2RKEConfigK8sObjectFileSource(p []interface{}) rkev1.K8sObjectFileSource {
+	obj := rkev1.K8sObjectFileSource{}
+	if p == nil || len(p) == 0 || p[0] == nil {
+		return obj
+	}
+
+	in := p[0].(map[string]interface{})
+	if v, ok := in["name"].(string); ok && len(v) > 0 {
+		obj.Name = v
+	}
+	if v, ok := in["default_permissions"].(string); ok && len(v) > 0 {
+		obj.DefaultPermissions = v
+	}
+	if v, ok := in["items"].([]interface{}); ok && len(v) > 0 {
+		obj.Items = expandClusterV2RKEConfigKeyToPath(v)
+	}
+
+	return obj
+}
+
+func expandClusterV2RKEConfigKeyToPath(p []interface{}) []rkev1.KeyToPath {
+	if p == nil || len(p) == 0 || p[0] == nil {
+		return nil
+	}
+
+	out := make([]rkev1.KeyToPath, len(p))
+	for i := range p {
+		in := p[i].(map[string]interface{})
+		obj := rkev1.KeyToPath{}
+
+		if v, ok := in["key"].(string); ok && len(v) > 0 {
+			obj.Key = v
+		}
+		if v, ok := in["path"].(string); ok && len(v) > 0 {
+			obj.Path = v
+		}
+		if v, ok := in["dynamic"].(bool); ok {
+			obj.Dynamic = v
+		}
+		if v, ok := in["permissions"].(string); ok && len(v) > 0 {
+			obj.Permissions = v
+		}
+		if v, ok := in["hash"].(string); ok && len(v) > 0 {
+			obj.Hash = v
 		}
 		out[i] = obj
 	}

--- a/rancher2/structure_cluster_v2_rke_config_system_config_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_system_config_test.go
@@ -15,6 +15,8 @@ var (
 	testClusterV2RKEConfigSystemConfigLabelSelectorInterface           []interface{}
 	testClusterV2RKEConfigSystemConfigConf                             []rkev1.RKESystemConfig
 	testClusterV2RKEConfigSystemConfigInterface                        []interface{}
+	testClusterV2RKEConfigMachineSelectorFilesConf                     []rkev1.RKEProvisioningFiles
+	testClusterV2RKEConfigMachineSelectorFilesInterface                []interface{}
 )
 
 func init() {
@@ -66,6 +68,83 @@ func init() {
 			"config":                 "config_one: one\nconfig_two: two\n",
 		},
 	}
+
+	testClusterV2RKEConfigMachineSelectorFilesConf = []rkev1.RKEProvisioningFiles{
+		{
+			MachineLabelSelector: testClusterV2RKEConfigSystemConfigLabelSelectorConf,
+			FileSources: []rkev1.ProvisioningFileSource{
+				{
+					Secret: rkev1.K8sObjectFileSource{
+						Name:               "test-config-secret",
+						DefaultPermissions: "0644",
+						Items: []rkev1.KeyToPath{
+							{
+								Key:         "a",
+								Path:        "/etc/rancher/rke2/test.yaml",
+								Permissions: "600",
+								Hash:        "abcdefg",
+								Dynamic:     true,
+							},
+						},
+					},
+					ConfigMap: rkev1.K8sObjectFileSource{
+						Name:               "test-config-configmap",
+						DefaultPermissions: "0644",
+						Items: []rkev1.KeyToPath{
+							{
+								Key:         "a",
+								Path:        "/etc/rancher/rke2/test.yaml",
+								Permissions: "600",
+								Hash:        "abcdefg",
+								Dynamic:     true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testClusterV2RKEConfigMachineSelectorFilesInterface = []interface{}{
+		map[string]interface{}{
+			"machine_label_selector": testClusterV2RKEConfigSystemConfigLabelSelectorInterface,
+			"file_sources": []interface{}{
+				map[string]interface{}{
+					"secret": []interface{}{
+						map[string]interface{}{
+							"name":                "test-config-secret",
+							"default_permissions": "0644",
+							"items": []interface{}{
+								map[string]interface{}{
+									"key":         "a",
+									"path":        "/etc/rancher/rke2/test.yaml",
+									"permissions": "600",
+									"hash":        "abcdefg",
+									"dynamic":     true,
+								},
+							},
+						},
+					},
+					"configmap": []interface{}{
+						map[string]interface{}{
+							"name":                "test-config-configmap",
+							"default_permissions": "0644",
+							"items": []interface{}{
+								map[string]interface{}{
+									"key":         "a",
+									"path":        "/etc/rancher/rke2/test.yaml",
+									"permissions": "600",
+									"hash":        "abcdefg",
+									"dynamic":     true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
 }
 
 func TestFlattenClusterV2RKEConfigSystemConfigLabelSelectorExpression(t *testing.T) {

--- a/rancher2/structure_cluster_v2_rke_config_z_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_z_test.go
@@ -33,6 +33,7 @@ func init() {
 		},
 	}
 	testClusterV2RKEConfigConf.MachineSelectorConfig = testClusterV2RKEConfigSystemConfigConf
+	testClusterV2RKEConfigConf.MachineSelectorFiles = testClusterV2RKEConfigMachineSelectorFilesConf
 	testClusterV2RKEConfigConf.Registries = testClusterV2RKEConfigRegistryConf
 	testClusterV2RKEConfigConf.ETCD = testClusterV2RKEConfigETCDConf
 	testClusterV2RKEConfigConf.RotateCertificates = testClusterV2RKEConfigRotateCertificatesConf
@@ -48,6 +49,7 @@ func init() {
 			"machine_pools":           testClusterV2RKEConfigMachinePoolsInterface,
 			"machine_pool_defaults":   testClusterV2RKEConfigMachinePoolDefaultsInterface,
 			"machine_selector_config": testClusterV2RKEConfigSystemConfigInterface,
+			"machine_selector_files":  testClusterV2RKEConfigMachineSelectorFilesInterface,
 			"registries":              testClusterV2RKEConfigRegistryInterface,
 			"etcd":                    testClusterV2RKEConfigETCDInterface,
 			"rotate_certificates":     testClusterV2RKEConfigRotateCertificatesInterface,

--- a/rancher2/structure_cluster_v2_test.go
+++ b/rancher2/structure_cluster_v2_test.go
@@ -1,7 +1,6 @@
 package rancher2
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -196,19 +195,16 @@ func TestFlattenClusterV2(t *testing.T) {
 		if err != nil {
 			assert.FailNow(t, "[ERROR] on flattener: %#v", err)
 		}
-		expectedOutput := map[string]interface{}{}
+		actualOutput := map[string]interface{}{}
 		for k := range tc.ExpectedOutput {
-			expectedOutput[k] = output.Get(k)
+			actualOutput[k] = output.Get(k)
 			if k == "rke_config" {
 				// This is a hack to remove the deprecated field because it is not being set.
-				rkeConfig := expectedOutput[k].([]interface{})[0].(map[string]interface{})
+				rkeConfig := actualOutput[k].([]interface{})[0].(map[string]interface{})
 				delete(rkeConfig, "local_auth_endpoint")
 			}
 		}
-		if !reflect.DeepEqual(expectedOutput, tc.ExpectedOutput) {
-			assert.FailNow(t, "Unexpected output from flattener.\nExpected: %#v\nGiven:    %#v",
-				tc.ExpectedOutput, expectedOutput)
-		}
+		assert.Equal(t, tc.ExpectedOutput, actualOutput)
 	}
 }
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
https://github.com/rancher/terraform-provider-rancher2/issues/1194

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
`machine_selector_files` can be used, combined with the `machine_selector_config`, to achieve the goal of configuring the API audit logging on REK2/K3s clusters. 

The support for setting `machine_selector_files` is missing on the TF side. 


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
 
This PR adds support for the `machine_selector_files` filed on the Cluster_v2 resource. 

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->



Below are the TF files I used for testing the new fields 

<details>
<summary>Details</summary>

```

provider "rancher2" {
  api_url   = var.rancher_api_url
  token_key = var.rancher_admin_bearer_token
  insecure  = true
}

# Create amazonec2 cloud credential
resource "rancher2_cloud_credential" "foo" {
  name = "foo"
  amazonec2_credential_config {
    access_key = var.aws_access_key
    secret_key = var.aws_secret_key
  }
}

# Create amazonec2 machine config v2
resource "rancher2_machine_config_v2" "foo" {
  generate_name = "jiaqi-machine"
  amazonec2_config {
    ami            = var.aws_ami
    region         = var.aws_region
    security_group = [var.aws_security_group_name]
    subnet_id      = var.aws_subnet_id
    vpc_id         = var.aws_vpc_id
    zone           = var.aws_zone_letter
    root_size      = var.aws_root_size
  }
}

resource "rancher2_secret_v2" "foo" {
  cluster_id = "local"
  name = "config-file-1"
  namespace = "fleet-default"
  data = {
    audit-policy = "testing file for machine selector files \n"
  }
  annotations = {
    "rke.cattle.io/object-authorized-for-clusters" = "rke2-1"
  }
}


# Create a new rancher v2 amazonec2 RKE2 Cluster v2
resource "rancher2_cluster_v2" "jiaqi-rke2" {
  name = var.rke2_cluster_name
  kubernetes_version = "v1.25.13+rke2r1"
  enable_network_policy = false
  default_cluster_role_for_project_members = "user"
  rke_config {
    machine_pools {
      name = "pool1"
      cloud_credential_secret_name = rancher2_cloud_credential.foo.id
      control_plane_role = true
      etcd_role = true
      worker_role = true
      quantity = 1
      machine_config {
        kind = rancher2_machine_config_v2.foo.kind
        name = rancher2_machine_config_v2.foo.name
      }
    }
    machine_selector_files {
      machine_label_selector {
        match_labels = {
          "rke.cattle.io/control-plane-role" = "true"
        }
      }
      file_sources {
        secret {
          name = "config-file-1"
          default_permissions = "644"
          items {
            key = "audit-policy"
            path ="/etc/rancher/rke2/custom/test-policy.yaml"
            permissions = "666"
          }
        }
      }
    }
  }
}
```

</details>

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

The existing tests are updated. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
- Provision a new cluster with utilizing `machine_selector_files` 
- Upgrade an ending cluster from not utilizing to utilizing `machine_selector_files`  



### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

Cluster provisioning or upgrading fails