### PR TITLE
add the support for graceful_shutdown_timeout for vSphere nodes

### DIFF
--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -312,6 +312,7 @@ The following attributes are exported:
 * `datastore_cluster` - (Optional) vSphere datastore cluster for virtual machine (string)
 * `disk_size` - (Optional) vSphere size of disk for docker VM (in MB). Default `20480` (string)
 * `folder` - (Optional) vSphere folder for the docker VM. This folder must already exist in the datacenter (string)
+* `graceful_shutdown_timeout` (Optional) Duration in seconds for wait for graceful shutdown of the VM. A force destroy will be performed when the value is zero (string)
 * `hostsystem` - (Optional) vSphere compute resource where the docker VM will be instantiated. This can be omitted if using a cluster with DRS (string)
 * `memory_size` - (Optional) vSphere size of memory for docker VM (in MB). Default `2048` (string)
 * `network` - (Optional) vSphere network where the docker VM will be attached (list)

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -312,7 +312,7 @@ The following attributes are exported:
 * `datastore_cluster` - (Optional) vSphere datastore cluster for virtual machine (string)
 * `disk_size` - (Optional) vSphere size of disk for docker VM (in MB). Default `20480` (string)
 * `folder` - (Optional) vSphere folder for the docker VM. This folder must already exist in the datacenter (string)
-* `graceful_shutdown_timeout` (Optional) Duration in seconds for wait for graceful shutdown of the VM. A force destroy will be performed when the value is zero (string)
+* `graceful_shutdown_timeout` (Optional) Duration in seconds before the graceful shutdown of the VM times out and the VM is destroyed. A force destroy will be performed when the value is zero (string)
 * `hostsystem` - (Optional) vSphere compute resource where the docker VM will be instantiated. This can be omitted if using a cluster with DRS (string)
 * `memory_size` - (Optional) vSphere size of memory for docker VM (in MB). Default `2048` (string)
 * `network` - (Optional) vSphere network where the docker VM will be attached (list)

--- a/rancher2/resource_rancher2_node_template_test.go
+++ b/rancher2/resource_rancher2_node_template_test.go
@@ -267,6 +267,7 @@ resource "` + testAccRancher2NodeTemplateType + `" "foo-vsphere" {
 	cpu_count = "8"
 	disk_size = "20480"
 	pool =  "pool-YYYYYYYY"
+	graceful_shutdown_timeout = "30"
   }
 }
 `
@@ -742,6 +743,7 @@ func TestAccRancher2NodeTemplate_basic_Vsphere(t *testing.T) {
 					resource.TestCheckResourceAttr(name, "vsphere_config.0.cpu_count", "8"),
 					resource.TestCheckResourceAttr(name, "vsphere_config.0.disk_size", "20480"),
 					resource.TestCheckResourceAttr(name, "vsphere_config.0.pool", "pool-YYYYYYYY"),
+					resource.TestCheckResourceAttr(name, "vsphere_config.0.graceful_shutdown_timeout", "30"),
 				),
 			},
 			{

--- a/rancher2/schema_cloud_credential_vsphere.go
+++ b/rancher2/schema_cloud_credential_vsphere.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-//Types
+// Types
 
 type vmwarevsphereCredentialConfig struct {
 	Password    string `json:"password,omitempty" yaml:"password,omitempty"`
@@ -13,7 +13,7 @@ type vmwarevsphereCredentialConfig struct {
 	VcenterPort string `json:"vcenterPort,omitempty" yaml:"vcenterPort,omitempty"`
 }
 
-//Schemas
+// Schemas
 
 func cloudCredentialVsphereFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{

--- a/rancher2/schema_cluster_rke_config_cloud_provider_vsphere.go
+++ b/rancher2/schema_cluster_rke_config_cloud_provider_vsphere.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-//Schemas
+// Schemas
 
 func clusterRKEConfigCloudProviderVsphereDiskFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
@@ -48,6 +48,11 @@ func clusterRKEConfigCloudProviderVsphereGlobalFields() map[string]*schema.Schem
 		},
 		"soap_roundtrip_count": {
 			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
+		"graceful_shutdown_timeout": {
+			Type:     schema.TypeString,
 			Optional: true,
 			Computed: true,
 		},

--- a/rancher2/schema_cluster_rke_config_cloud_provider_vsphere.go
+++ b/rancher2/schema_cluster_rke_config_cloud_provider_vsphere.go
@@ -54,7 +54,6 @@ func clusterRKEConfigCloudProviderVsphereGlobalFields() map[string]*schema.Schem
 		"graceful_shutdown_timeout": {
 			Type:     schema.TypeString,
 			Optional: true,
-			Computed: true,
 		},
 	}
 	return s

--- a/rancher2/schema_machine_config_v2_vsphere.go
+++ b/rancher2/schema_machine_config_v2_vsphere.go
@@ -16,7 +16,7 @@ var (
 	machineConfigV2VmwarevsphereVappTransports           = []string{"iso", "com.vmware.guestInfo"}
 )
 
-//Schemas
+// Schemas
 
 func machineConfigV2VmwarevsphereFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
@@ -205,6 +205,11 @@ func machineConfigV2VmwarevsphereFields() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     "443",
 			Description: "vSphere Port for vCenter",
+		},
+		"graceful_shutdown_timeout": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Duration in seconds for wait for graceful shutdown of the VM. A force destroy will be performed when the value is zero",
 		},
 	}
 

--- a/rancher2/schema_machine_config_v2_vsphere.go
+++ b/rancher2/schema_machine_config_v2_vsphere.go
@@ -209,7 +209,7 @@ func machineConfigV2VmwarevsphereFields() map[string]*schema.Schema {
 		"graceful_shutdown_timeout": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "Duration in seconds for wait for graceful shutdown of the VM. A force destroy will be performed when the value is zero",
+			Description: "Duration in seconds before the graceful shutdown of the VM times out and the VM is destroyed. A force destroy will be performed when the value is zero",
 		},
 	}
 

--- a/rancher2/schema_node_template_vsphere.go
+++ b/rancher2/schema_node_template_vsphere.go
@@ -17,43 +17,44 @@ var (
 	vmwarevsphereConfigVappTransports           = []string{"iso", "com.vmware.guestInfo"}
 )
 
-//Types
+// Types
 
 type vmwarevsphereConfig struct {
-	Boot2dockerURL         string   `json:"boot2dockerUrl,omitempty" yaml:"boot2dockerUrl,omitempty"`
-	Cfgparam               []string `json:"cfgparam,omitempty" yaml:"cfgparam,omitempty"`
-	CloneFrom              string   `json:"cloneFrom,omitempty" yaml:"cloneFrom,omitempty"`
-	CloudConfig            string   `json:"cloudConfig,omitempty" yaml:"cloudConfig,omitempty"`
-	Cloudinit              string   `json:"cloudinit,omitempty" yaml:"cloudinit,omitempty"`
-	ContentLibrary         string   `json:"contentLibrary,omitempty" yaml:"contentLibrary,omitempty"`
-	CPUCount               string   `json:"cpuCount,omitempty" yaml:"cpuCount,omitempty"`
-	CreationType           string   `json:"creationType,omitempty" yaml:"creationType,omitempty"`
-	CustomAttributes       []string `json:"customAttribute,omitempty" yaml:"customAttribute,omitempty"`
-	Datacenter             string   `json:"datacenter,omitempty" yaml:"datacenter,omitempty"`
-	Datastore              string   `json:"datastore,omitempty" yaml:"datastore,omitempty"`
-	DatastoreCluster       string   `json:"datastoreCluster,omitempty" yaml:"datastoreCluster,omitempty"`
-	DiskSize               string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
-	Folder                 string   `json:"folder,omitempty" yaml:"folder,omitempty"`
-	Hostsystem             string   `json:"hostsystem,omitempty" yaml:"hostsystem,omitempty"`
-	MemorySize             string   `json:"memorySize,omitempty" yaml:"memorySize,omitempty"`
-	Network                []string `json:"network,omitempty" yaml:"network,omitempty"`
-	Password               string   `json:"password,omitempty" yaml:"password,omitempty"`
-	Pool                   string   `json:"pool,omitempty" yaml:"pool,omitempty"`
-	SSHPassword            string   `json:"sshPassword,omitempty" yaml:"sshPassword,omitempty"`
-	SSHPort                string   `json:"sshPort,omitempty" yaml:"sshPort,omitempty"`
-	SSHUser                string   `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
-	SSHUserGroup           string   `json:"sshUserGroup,omitempty" yaml:"sshUserGroup,omitempty"`
-	Tags                   []string `json:"tag,omitempty" yaml:"tag,omitempty"`
-	Username               string   `json:"username,omitempty" yaml:"username,omitempty"`
-	VappIpallocationpolicy string   `json:"vappIpallocationpolicy,omitempty" yaml:"vappIpallocationpolicy,omitempty"`
-	VappIpprotocol         string   `json:"vappIpprotocol,omitempty" yaml:"vappIpprotocol,omitempty"`
-	VappProperty           []string `json:"vappProperty,omitempty" yaml:"vappProperty,omitempty"`
-	VappTransport          string   `json:"vappTransport,omitempty" yaml:"vappTransport,omitempty"`
-	Vcenter                string   `json:"vcenter,omitempty" yaml:"vcenter,omitempty"`
-	VcenterPort            string   `json:"vcenterPort,omitempty" yaml:"vcenterPort,omitempty"`
+	Boot2dockerURL          string   `json:"boot2dockerUrl,omitempty" yaml:"boot2dockerUrl,omitempty"`
+	Cfgparam                []string `json:"cfgparam,omitempty" yaml:"cfgparam,omitempty"`
+	CloneFrom               string   `json:"cloneFrom,omitempty" yaml:"cloneFrom,omitempty"`
+	CloudConfig             string   `json:"cloudConfig,omitempty" yaml:"cloudConfig,omitempty"`
+	Cloudinit               string   `json:"cloudinit,omitempty" yaml:"cloudinit,omitempty"`
+	ContentLibrary          string   `json:"contentLibrary,omitempty" yaml:"contentLibrary,omitempty"`
+	CPUCount                string   `json:"cpuCount,omitempty" yaml:"cpuCount,omitempty"`
+	CreationType            string   `json:"creationType,omitempty" yaml:"creationType,omitempty"`
+	CustomAttributes        []string `json:"customAttribute,omitempty" yaml:"customAttribute,omitempty"`
+	Datacenter              string   `json:"datacenter,omitempty" yaml:"datacenter,omitempty"`
+	Datastore               string   `json:"datastore,omitempty" yaml:"datastore,omitempty"`
+	DatastoreCluster        string   `json:"datastoreCluster,omitempty" yaml:"datastoreCluster,omitempty"`
+	DiskSize                string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
+	Folder                  string   `json:"folder,omitempty" yaml:"folder,omitempty"`
+	Hostsystem              string   `json:"hostsystem,omitempty" yaml:"hostsystem,omitempty"`
+	MemorySize              string   `json:"memorySize,omitempty" yaml:"memorySize,omitempty"`
+	Network                 []string `json:"network,omitempty" yaml:"network,omitempty"`
+	Password                string   `json:"password,omitempty" yaml:"password,omitempty"`
+	Pool                    string   `json:"pool,omitempty" yaml:"pool,omitempty"`
+	SSHPassword             string   `json:"sshPassword,omitempty" yaml:"sshPassword,omitempty"`
+	SSHPort                 string   `json:"sshPort,omitempty" yaml:"sshPort,omitempty"`
+	SSHUser                 string   `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	SSHUserGroup            string   `json:"sshUserGroup,omitempty" yaml:"sshUserGroup,omitempty"`
+	Tags                    []string `json:"tag,omitempty" yaml:"tag,omitempty"`
+	Username                string   `json:"username,omitempty" yaml:"username,omitempty"`
+	VappIpallocationpolicy  string   `json:"vappIpallocationpolicy,omitempty" yaml:"vappIpallocationpolicy,omitempty"`
+	VappIpprotocol          string   `json:"vappIpprotocol,omitempty" yaml:"vappIpprotocol,omitempty"`
+	VappProperty            []string `json:"vappProperty,omitempty" yaml:"vappProperty,omitempty"`
+	VappTransport           string   `json:"vappTransport,omitempty" yaml:"vappTransport,omitempty"`
+	Vcenter                 string   `json:"vcenter,omitempty" yaml:"vcenter,omitempty"`
+	VcenterPort             string   `json:"vcenterPort,omitempty" yaml:"vcenterPort,omitempty"`
+	GracefulShutdownTimeout string   `json:"gracefulShutdownTimeout,omitempty" yaml:"gracefulShutdownTimeout, omitempty"`
 }
 
-//Schemas
+// Schemas
 
 func vsphereConfigFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
@@ -242,6 +243,11 @@ func vsphereConfigFields() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     "443",
 			Description: "vSphere Port for vCenter",
+		},
+		"graceful_shutdown_timeout": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Duration in seconds for wait for graceful shutdown of the VM. A force destroy will be performed when the value is zero",
 		},
 	}
 	return s

--- a/rancher2/schema_node_template_vsphere.go
+++ b/rancher2/schema_node_template_vsphere.go
@@ -247,7 +247,7 @@ func vsphereConfigFields() map[string]*schema.Schema {
 		"graceful_shutdown_timeout": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "Duration in seconds for wait for graceful shutdown of the VM. A force destroy will be performed when the value is zero",
+			Description: "Duration in seconds before the graceful shutdown of the VM times out and the VM is destroyed. A force destroy will be performed when the value is zero",
 		},
 	}
 	return s

--- a/rancher2/structure_machine_config_v2_vsphere.go
+++ b/rancher2/structure_machine_config_v2_vsphere.go
@@ -12,42 +12,43 @@ const (
 	machineConfigV2VmwarevsphereClusterIDsep = "."
 )
 
-//Types
+// Types
 
 type machineConfigV2Vmwarevsphere struct {
-	metav1.TypeMeta        `json:",inline"`
-	metav1.ObjectMeta      `json:"metadata,omitempty"`
-	Boot2dockerURL         string   `json:"boot2dockerUrl,omitempty" yaml:"boot2dockerUrl,omitempty"`
-	Cfgparam               []string `json:"cfgparam,omitempty" yaml:"cfgparam,omitempty"`
-	CloneFrom              string   `json:"cloneFrom,omitempty" yaml:"cloneFrom,omitempty"`
-	CloudConfig            string   `json:"cloudConfig,omitempty" yaml:"cloudConfig,omitempty"`
-	Cloudinit              string   `json:"cloudinit,omitempty" yaml:"cloudinit,omitempty"`
-	ContentLibrary         string   `json:"contentLibrary,omitempty" yaml:"contentLibrary,omitempty"`
-	CPUCount               string   `json:"cpuCount,omitempty" yaml:"cpuCount,omitempty"`
-	CreationType           string   `json:"creationType,omitempty" yaml:"creationType,omitempty"`
-	CustomAttributes       []string `json:"customAttribute,omitempty" yaml:"customAttribute,omitempty"`
-	Datacenter             string   `json:"datacenter,omitempty" yaml:"datacenter,omitempty"`
-	Datastore              string   `json:"datastore,omitempty" yaml:"datastore,omitempty"`
-	DatastoreCluster       string   `json:"datastoreCluster,omitempty" yaml:"datastoreCluster,omitempty"`
-	DiskSize               string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
-	Folder                 string   `json:"folder,omitempty" yaml:"folder,omitempty"`
-	Hostsystem             string   `json:"hostsystem,omitempty" yaml:"hostsystem,omitempty"`
-	MemorySize             string   `json:"memorySize,omitempty" yaml:"memorySize,omitempty"`
-	Network                []string `json:"network,omitempty" yaml:"network,omitempty"`
-	Password               string   `json:"password,omitempty" yaml:"password,omitempty"`
-	Pool                   string   `json:"pool,omitempty" yaml:"pool,omitempty"`
-	SSHPassword            string   `json:"sshPassword,omitempty" yaml:"sshPassword,omitempty"`
-	SSHPort                string   `json:"sshPort,omitempty" yaml:"sshPort,omitempty"`
-	SSHUser                string   `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
-	SSHUserGroup           string   `json:"sshUserGroup,omitempty" yaml:"sshUserGroup,omitempty"`
-	Tags                   []string `json:"tag,omitempty" yaml:"tag,omitempty"`
-	Username               string   `json:"username,omitempty" yaml:"username,omitempty"`
-	VappIpallocationpolicy string   `json:"vappIpallocationpolicy,omitempty" yaml:"vappIpallocationpolicy,omitempty"`
-	VappIpprotocol         string   `json:"vappIpprotocol,omitempty" yaml:"vappIpprotocol,omitempty"`
-	VappProperty           []string `json:"vappProperty,omitempty" yaml:"vappProperty,omitempty"`
-	VappTransport          string   `json:"vappTransport,omitempty" yaml:"vappTransport,omitempty"`
-	Vcenter                string   `json:"vcenter,omitempty" yaml:"vcenter,omitempty"`
-	VcenterPort            string   `json:"vcenterPort,omitempty" yaml:"vcenterPort,omitempty"`
+	metav1.TypeMeta         `json:",inline"`
+	metav1.ObjectMeta       `json:"metadata,omitempty"`
+	Boot2dockerURL          string   `json:"boot2dockerUrl,omitempty" yaml:"boot2dockerUrl,omitempty"`
+	Cfgparam                []string `json:"cfgparam,omitempty" yaml:"cfgparam,omitempty"`
+	CloneFrom               string   `json:"cloneFrom,omitempty" yaml:"cloneFrom,omitempty"`
+	CloudConfig             string   `json:"cloudConfig,omitempty" yaml:"cloudConfig,omitempty"`
+	Cloudinit               string   `json:"cloudinit,omitempty" yaml:"cloudinit,omitempty"`
+	ContentLibrary          string   `json:"contentLibrary,omitempty" yaml:"contentLibrary,omitempty"`
+	CPUCount                string   `json:"cpuCount,omitempty" yaml:"cpuCount,omitempty"`
+	CreationType            string   `json:"creationType,omitempty" yaml:"creationType,omitempty"`
+	CustomAttributes        []string `json:"customAttribute,omitempty" yaml:"customAttribute,omitempty"`
+	Datacenter              string   `json:"datacenter,omitempty" yaml:"datacenter,omitempty"`
+	Datastore               string   `json:"datastore,omitempty" yaml:"datastore,omitempty"`
+	DatastoreCluster        string   `json:"datastoreCluster,omitempty" yaml:"datastoreCluster,omitempty"`
+	DiskSize                string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
+	Folder                  string   `json:"folder,omitempty" yaml:"folder,omitempty"`
+	Hostsystem              string   `json:"hostsystem,omitempty" yaml:"hostsystem,omitempty"`
+	MemorySize              string   `json:"memorySize,omitempty" yaml:"memorySize,omitempty"`
+	Network                 []string `json:"network,omitempty" yaml:"network,omitempty"`
+	Password                string   `json:"password,omitempty" yaml:"password,omitempty"`
+	Pool                    string   `json:"pool,omitempty" yaml:"pool,omitempty"`
+	SSHPassword             string   `json:"sshPassword,omitempty" yaml:"sshPassword,omitempty"`
+	SSHPort                 string   `json:"sshPort,omitempty" yaml:"sshPort,omitempty"`
+	SSHUser                 string   `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	SSHUserGroup            string   `json:"sshUserGroup,omitempty" yaml:"sshUserGroup,omitempty"`
+	Tags                    []string `json:"tag,omitempty" yaml:"tag,omitempty"`
+	Username                string   `json:"username,omitempty" yaml:"username,omitempty"`
+	VappIpallocationpolicy  string   `json:"vappIpallocationpolicy,omitempty" yaml:"vappIpallocationpolicy,omitempty"`
+	VappIpprotocol          string   `json:"vappIpprotocol,omitempty" yaml:"vappIpprotocol,omitempty"`
+	VappProperty            []string `json:"vappProperty,omitempty" yaml:"vappProperty,omitempty"`
+	VappTransport           string   `json:"vappTransport,omitempty" yaml:"vappTransport,omitempty"`
+	Vcenter                 string   `json:"vcenter,omitempty" yaml:"vcenter,omitempty"`
+	VcenterPort             string   `json:"vcenterPort,omitempty" yaml:"vcenterPort,omitempty"`
+	GracefulShutdownTimeout string   `json:"gracefulShutdownTimeout,omitempty" yaml:"gracefulShutdownTimeout, omitempty"`
 }
 
 type MachineConfigV2Vmwarevsphere struct {
@@ -156,6 +157,9 @@ func flattenMachineConfigV2Vmwarevsphere(in *MachineConfigV2Vmwarevsphere) []int
 	}
 	if len(in.VcenterPort) > 0 {
 		obj["vcenter_port"] = in.VcenterPort
+	}
+	if len(in.GracefulShutdownTimeout) > 0 {
+		obj["graceful_shutdown_timeout"] = in.GracefulShutdownTimeout
 	}
 
 	return []interface{}{obj}
@@ -271,6 +275,9 @@ func expandMachineConfigV2Vmwarevsphere(p []interface{}, source *MachineConfigV2
 	}
 	if v, ok := in["vcenter_port"].(string); ok && len(v) > 0 {
 		obj.VcenterPort = v
+	}
+	if v, ok := in["graceful_shutdown_timeout"].(string); ok && len(v) > 0 {
+		obj.GracefulShutdownTimeout = v
 	}
 
 	return obj

--- a/rancher2/structure_node_template_vsphere.go
+++ b/rancher2/structure_node_template_vsphere.go
@@ -101,6 +101,9 @@ func flattenVsphereConfig(in *vmwarevsphereConfig) []interface{} {
 	if len(in.VcenterPort) > 0 {
 		obj["vcenter_port"] = in.VcenterPort
 	}
+	if len(in.GracefulShutdownTimeout) > 0 {
+		obj["graceful_shutdown_timeout"] = in.GracefulShutdownTimeout
+	}
 
 	return []interface{}{obj}
 }
@@ -206,6 +209,9 @@ func expandVsphereConfig(p []interface{}) *vmwarevsphereConfig {
 	}
 	if v, ok := in["vcenter_port"].(string); ok && len(v) > 0 {
 		obj.VcenterPort = v
+	}
+	if v, ok := in["graceful_shutdown_timeout"].(string); ok && len(v) > 0 {
+		obj.GracefulShutdownTimeout = v
 	}
 
 	return obj


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
https://github.com/rancher/terraform-provider-rancher2/issues/1222

 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

We would like to have support for graceful_shutdown_timeout for vSphere nodes in the TF provider. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
 
Add the support for graceful_shutdown_timeout for vSphere nodes


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

This PR has been validated working in the internal vSphere envenomation, including RKE1/RKE2/K3s node-driver vsphere cluster 

If the field `graceful_shutdown_timeout` is set in the vsphere_config, when we delete the cluster (`terraform destory`), the task "initial guest os shutdown" is triggered in vSphere Center Client, which does not happen if we do not set the flag.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

Exiting tests are expanded to cover the new field, and that is all we can do for now. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

Provisioning and upgrading of the RKE1/RKE2/K3s node-driver vsphere cluster  


### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

 Provisioning and upgrading of the RKE1/RKE2/K3s node-driver vsphere cluster  
