### PR TITLE
Allow machine pools to be created and scaled down to 0

### DIFF
--- a/rancher2/schema_cluster_v2_rke_config_machine_pool.go
+++ b/rancher2/schema_cluster_v2_rke_config_machine_pool.go
@@ -93,11 +93,10 @@ func clusterV2RKEConfigMachinePoolFields() map[string]*schema.Schema {
 			Description: "Machine pool paused",
 		},
 		"quantity": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			Default:      1,
-			ValidateFunc: validation.IntAtLeast(1),
-			Description:  "Machine pool quantity",
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Default:     1,
+			Description: "Machine pool quantity",
 		},
 		"rolling_update": {
 			Type:        schema.TypeList,


### PR DESCRIPTION
## Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1231
 
## Problem

It's not possible to set a machine_pool quantity to 0, this blocks temporarily scaling down a pool, and instead it will be deleted. It's possible to both create and scale down clusters from the UI with a value of 0, so the provider should allow the same.
 
## Solution
Remove the [ValidateFunc: validation.IntAtLeast(1),](https://github.com/rancher/terraform-provider-rancher2/blob/master/rancher2/schema_cluster_v2_rke_config_machine_pool.go#L99)
 
## Testing
N/A

## Engineering Testing
### Manual Testing
Verified functionality by deploying to a RKE2 clusters in OpenStack with machine_pool quantity set to 0.

### Automated Testing
N/A

## QA Testing Considerations
N/A
 
### Regressions Considerations

I've manually tested this change on OpenStack and it seems to work as expected. But I'm not sure if it will work with other providers.

This was first discussed in https://github.com/rancher/terraform-provider-rancher2/issues/107, and while it's not possible to create a cluster with only empty pools, it's still possible create empty pools as long as there's at least one pool with quantity >= 1.