### PR TITLE
Revert "Remove OpenStack keypair_name references"

### DIFF
--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -265,6 +265,7 @@ The following attributes are exported:
 * `image_name` - (Required+) OpenStack image name to use for the instance. Conflicts with `image_id` (string)
 * `insecure` - (Optional) Disable TLS credential checking. Default `false` (bool)
 * `ip_version` - (Optional) OpenStack version of IP address assigned for the machine Default `4` (string)
+* `keypair_name` - (Optional) OpenStack keypair to use to SSH to the instance (string)
 * `net_id` - (Required+) OpenStack network id the machine will be connected on. Conflicts with `net_name` (string)
 * `net_name` - (Required+) OpenStack network name the machine will be connected on. Conflicts with `net_id` (string)
 * `nova_network` - (Optional) Use the nova networking services instead of neutron (string)

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -292,6 +292,7 @@ The following attributes are exported:
 * `volume_device_path` - (Optional) OpenStack volume device path (attaching). Applicable only when `boot_from_volume` is `true`. Omit for auto `/dev/vdb`. (string)
 > **Note:**: `Required+` denotes that either the _name or _id is required but you cannot use both.
 > **Note:**: `Required++` denotes that either the _name or _id is required unless `application_credential_id` is defined.
+> **Note for OpenStack users:**: `keypair_name` is required to be in the schema even if there are no references in rancher itself
 
 ### `vsphere_config`
 

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -385,6 +385,7 @@ The following attributes are exported:
 * `image_name` - (Required*) OpenStack image name to use for the instance. Conflicts with `image_id` (string)
 * `insecure` - (Optional) Disable TLS credential checking. Default `false` (bool)
 * `ip_version` - (Optional) OpenStack version of IP address assigned for the machine Default `4` (string)
+* `keypair_name` - (Optional) OpenStack keypair to use to SSH to the instance (string)
 * `net_id` - (Required*) OpenStack network id the machine will be connected on. Conflicts with `net_name` (string)
 * `net_name` - (Required*) OpenStack network name the machine will be connected on. Conflicts with `net_id` (string)
 * `nova_network` - (Optional) Use the nova networking services instead of neutron (string)

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -411,6 +411,8 @@ The following attributes are exported:
 
 > **Note:**: `Required**` denotes that either the _name or _id is required unless `application_credential_id` is defined.
 
+> **Note for OpenStack users:**: `keypair_name` is required to be in the schema even if there are no references in rancher itself
+
 ### `vsphere_config`
 
 #### Arguments

--- a/rancher2/schema_machine_config_v2_openstack.go
+++ b/rancher2/schema_machine_config_v2_openstack.go
@@ -80,6 +80,10 @@ func machineConfigV2OpenstackFields() map[string]*schema.Schema {
 			Optional: true,
 			Default:  "4",
 		},
+		"keypair_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		"net_id": {
 			Type:     schema.TypeString,
 			Optional: true,

--- a/rancher2/schema_node_template_openstack.go
+++ b/rancher2/schema_node_template_openstack.go
@@ -127,6 +127,10 @@ func openstackConfigFields() map[string]*schema.Schema {
 			Optional: true,
 			Default:  "4",
 		},
+		"keypair_name": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 		"net_id": {
 			Type:     schema.TypeString,
 			Optional: true,

--- a/rancher2/structure_machine_config_v2_openstack.go
+++ b/rancher2/structure_machine_config_v2_openstack.go
@@ -90,6 +90,7 @@ func flattenMachineConfigV2Openstack(in *MachineConfigV2Openstack) []interface{}
 	obj["image_name"] = in.ImageName
 	obj["insecure"] = in.Insecure
 	obj["ip_version"] = in.IPVersion
+	obj["keypair_name"] = in.KeypairName
 	obj["net_id"] = in.NetID
 	obj["net_name"] = in.NetName
 	obj["nova_network"] = in.NovaNetwork
@@ -185,6 +186,9 @@ func expandMachineConfigV2Openstack(p []interface{}, source *MachineConfigV2) *M
 	}
 	if v, ok := in["ip_version"].(string); ok && len(v) > 0 {
 		obj.IPVersion = v
+	}
+	if v, ok := in["keypair_name"].(string); ok && len(v) > 0 {
+		obj.KeypairName = v
 	}
 	if v, ok := in["net_id"].(string); ok && len(v) > 0 {
 		obj.NetID = v

--- a/rancher2/structure_node_template_openstack.go
+++ b/rancher2/structure_node_template_openstack.go
@@ -23,6 +23,7 @@ func flattenOpenstackConfig(in *openstackConfig) []interface{} {
 	obj["image_name"] = in.ImageName
 	obj["insecure"] = in.Insecure
 	obj["ip_version"] = in.IPVersion
+	obj["keypair_name"] = in.KeypairName
 	obj["net_id"] = in.NetID
 	obj["net_name"] = in.NetName
 	obj["nova_network"] = in.NovaNetwork
@@ -105,6 +106,9 @@ func expandOpenstackConfig(p []interface{}) *openstackConfig {
 	}
 	if v, ok := in["ip_version"].(string); ok && len(v) > 0 {
 		obj.IPVersion = v
+	}
+	if v, ok := in["keypair_name"].(string); ok && len(v) > 0 {
+		obj.KeypairName = v
 	}
 	if v, ok := in["net_id"].(string); ok && len(v) > 0 {
 		obj.NetID = v


### PR DESCRIPTION
This reverts commit 4096070b7a7618e2f05cbf844757fab0ce8e02f9.

## Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1233 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
the keypair_name field for openstack was necessary even if there weren't any explicit code references to it in rancher.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
reverting commit 4096070b7a7618e2f05cbf844757fab0ce8e02f9 will fix the issue. 
