### PR TITLE
Set protect-kernel-defaults on v2 clusters

### DIFF
--- a/rancher2/schema_cluster_v2_rke_config_system_config.go
+++ b/rancher2/schema_cluster_v2_rke_config_system_config.go
@@ -68,6 +68,7 @@ func clusterV2RKEConfigSystemConfigFieldsV0() map[string]*schema.Schema {
 		"config": {
 			Type:        schema.TypeMap,
 			Optional:    true,
+			Default:     "protect-kernel-defaults: false",
 			Description: "Machine selector config",
 		},
 	}
@@ -89,6 +90,7 @@ func clusterV2RKEConfigSystemConfigFields() map[string]*schema.Schema {
 		"config": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			Default:     "protect-kernel-defaults: false",
 			Description: "Machine selector config",
 			ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 				v, ok := val.(string)


### PR DESCRIPTION
## Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1243 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
When going to Cluster Management and clicking Edit Config on a cluster, the page crashes and displays a "Loading ..." text but ends up with the following message: Cannot read properties of undefined (reading 'length'). This happens if a MachineSelectorConfig config is set as null.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

Rancher sets [protect-kernel-defaults](https://ranchermanager.docs.rancher.com/pages-for-subheaders/rke2-hardening-guide#:~:text=Ensure%20protect%2Dkernel%2Ddefaults%20is%20set%E2%80%8B&text=This%20is%20a%20kubelet%20flag,the%20cluster%20configuration%20in%20Rancher.) false by default under the hood for rke2/k3s clusters but it is not exposed in the UI. My solution is for the TF rancher2 provider to set this field for any empty MachineSelectorConfig config so tf doesn't remove it every time to reconcile the state.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Confirmed removing `protect-kernel-defaults: false` and setting `config: null` causes the page to crash. Adding the field back in fixes it. Prov an rke2 cluster on EC2 with the fix resolves the bug. Adding the same MachineSelectorConfig via the UI that @Josh-Diamond did during our debug session and then running a `terraform refresh` to refresh the state causes the following to be set,

```
machineSelectorConfig:
      - config:
          protect-kernel-defaults: true
      - config:
          kubelet-arg:
            - cloud-provider=external
        machineLabelSelector:
          matchExpressions: []
          matchLabels:
            key: value
```

which is correct.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->