### PR TITLE
Add note linking to AWS docs

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -424,7 +424,7 @@ resource "rancher2_cluster" "foo" {
 
 ### Creating EKS cluster from Rancher v2, using `eks_config_v2` and launch template. For Rancher v2.5.6 and above.
 
-Note: To use `launch_template` you must provide the ID (seen as `<EC2_LAUNCH_TEMPLATE_ID>`) to the template either as a static value. Or fetched via AWS data-source using one of: [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami.html), [aws_ami_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami_ids), or similar data-sources.
+Note: To use `launch_template` you must provide the ID (seen as `<EC2_LAUNCH_TEMPLATE_ID>`) to the template either as a static value. Or fetched via AWS data-source using one of: [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami.html), [aws_ami_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami_ids), or similar data-sources. You can also create a custom [`launch_template`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) first and provide the ID to that.
 
 ```hcl
 resource "rancher2_cloud_credential" "foo" {

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -424,6 +424,8 @@ resource "rancher2_cluster" "foo" {
 
 ### Creating EKS cluster from Rancher v2, using `eks_config_v2` and launch template. For Rancher v2.5.6 and above.
 
+Note: To effectively use `launch_template` you must provide the ID (seen as `<EC2_LAUNCH_TEMPLATE_ID>`) to the template either as a static value. Or fetched via AWS data-source using one of: [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami.html), [aws_ami_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami_ids), or similar data-sources.
+
 ```hcl
 resource "rancher2_cloud_credential" "foo" {
   name = "foo"

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -484,7 +484,7 @@ resource "rancher2_cluster" "foo" {
 
 ### Creating GKE cluster from Rancher v2, using `gke_config_v2`. For Rancher v2.5.8 and above.
 
-**Note:** At the moment, routed-based GKE clusters are not supported due to [rancher/issues/32585]](https://github.com/rancher/rancher/issues/32585)
+**Note:** At the moment, routed-based GKE clusters are not supported due to [rancher/issues/32585](https://github.com/rancher/rancher/issues/32585)
 
 ```hcl
 resource "rancher2_cloud_credential" "foo-google" {

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -424,7 +424,7 @@ resource "rancher2_cluster" "foo" {
 
 ### Creating EKS cluster from Rancher v2, using `eks_config_v2` and launch template. For Rancher v2.5.6 and above.
 
-Note: To effectively use `launch_template` you must provide the ID (seen as `<EC2_LAUNCH_TEMPLATE_ID>`) to the template either as a static value. Or fetched via AWS data-source using one of: [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami.html), [aws_ami_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami_ids), or similar data-sources.
+Note: To use `launch_template` you must provide the ID (seen as `<EC2_LAUNCH_TEMPLATE_ID>`) to the template either as a static value. Or fetched via AWS data-source using one of: [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami.html), [aws_ami_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami_ids), or similar data-sources.
 
 ```hcl
 resource "rancher2_cloud_credential" "foo" {


### PR DESCRIPTION
## Problem
Some customers come into Infrastructure as Code because they are Rancher users, rather than because they are embracing IaC out right. As such, some users don't realize they should user other Terraform providers than just Rancher. This gives the impression that if the Rancher TFP doesn't do a thing then it's a missing feature or bug.
 
## Solution
We can provide users with context clues of when to user other terraform providers as necessary. In this case we are linking to the relevant AWS terraform data-sources. By telling users to fetch image IDs this way we are implicitly telling them to use other Terraform providers.
 
## Testing
N/A; docs change.

## Engineering Testing
### Manual Testing
N/A; docs change.

### Automated Testing
N/A; docs change.

## QA Testing Considerations
N/A; docs change.
 
### Regressions Considerations
N/A; docs change.