### PR TITLE
Use dl.k8s.io for getting kubectl

### DIFF
--- a/scripts/start_testacc.sh
+++ b/scripts/start_testacc.sh
@@ -42,7 +42,7 @@ if [ "${JQ_BIN}" == "none" ] ; then
 fi
 ## kubectl
 KUBECTL_NAME=kubectl
-KUBECTL_URL="https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+KUBECTL_URL="https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 KUBECTL_BIN=$(which ${KUBECTL_NAME} || echo none)
 if [ "${KUBECTL_BIN}" == "none" ] ; then
   echo Downloading ${KUBECTL_NAME}


### PR DESCRIPTION
## Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1260
 
## Problem
Preparing for GCS bucket deprecation at some point (https://github.com/kubernetes/k8s.io/issues/2396)
 
## Solution
Change to the currently documented source
 
## Testing
Using [start_testacc.sh](https://github.com/rancher/terraform-provider-rancher2/blob/master/scripts/start_testacc.sh)

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->