### PR TITLE
Change default image to 20-04

### DIFF
--- a/rancher2/schema_machine_config_v2_digitalocean.go
+++ b/rancher2/schema_machine_config_v2_digitalocean.go
@@ -23,7 +23,7 @@ func machineConfigV2DigitaloceanFields() map[string]*schema.Schema {
 		"image": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "ubuntu-22-04-x64",
+			Default:     "ubuntu-20-04-x64",
 			Description: "Digital Ocean Image",
 		},
 		"ipv6": {

--- a/rancher2/schema_node_template_digitalocean.go
+++ b/rancher2/schema_node_template_digitalocean.go
@@ -46,7 +46,7 @@ func digitaloceanConfigFields() map[string]*schema.Schema {
 		"image": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "ubuntu-22-04-x64",
+			Default:     "ubuntu-20-04-x64",
 			Description: "Digital Ocean Image",
 		},
 		"ipv6": {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> rancher/terraform-provider-rancher2#1215 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
During tests we found a problem with  the `ubuntu-22-04-x64`, wile creating the downstream cluster it would get stuck after  `Installing Docker from: https://releases.rancher.com/install-docker/24.0.sh`     with one of  the following errors: 

* Error creating machine: Error runing "sudo apt-get update": ssh command error: command: sudo apt-get update err: exit status 100 output: Hit:1http://archive.ubuntu.com/ubuntu jammy in release 

* Error creating machine: Error Installing docker:
 
Those errors were happening 100% of the times (UI or TF) on 2.7  and also were happening on 2.8 (sometimes it worked on that one). 

 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
 
 Wile testing with  `ubuntu-20-04-x64`  we didn't get the error. 
For safety reasons we decided to change the image back to 20-04

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

Create machine using TF. 

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Create machine using TF. 

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
None 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->


main.tf
```terraform

terraform {
  required_providers {
    rancher2 = {
      source  = "terraform.local/local/rancher2"
      version = "4.0.0-rc4"
    }
  }
}

provider "rancher2" {
  api_url   = "<REDACTED>"
  token_key = "<REDACTED>"
  insecure  = true
}


resource "rancher2_node_template" "rancher2_node_template" {
  name = "qa-testing-jkeslar-plz-deletee"
  digitalocean_config {
    access_token  = "<REDACTED>"
    ipv6 = false
    monitoring = false
    private_networking = false
    region = "nyc3"
    size = "s-2vcpu-4gb-intel"
    ssh_key_fingerprint=	""
    ssh_port = "22"
    ssh_user =	"root"
    tags =""
    userdata= ""
  }
}



resource "rancher2_cluster" "rancher2_cluster" {
  depends_on = [rancher2_node_template.rancher2_node_template]
  name       = "jkeslar-qa-testing-plz-deletee"
  rke_config {
    kubernetes_version = "v1.27.6-rancher1-1"
    network {
      plugin = "canal"
    }
  }
}

resource "rancher2_node_pool" "pool1" {
  depends_on       = [rancher2_cluster.rancher2_cluster]
  cluster_id       = rancher2_cluster.rancher2_cluster.id
  name             = "pool1"
  hostname_prefix  = "jkeslar-pool1-"
  node_template_id = rancher2_node_template.rancher2_node_template.id
  quantity         = 1
  control_plane    = true
  etcd             = true
  worker           = true
}

```