### PR TITLE
Updating default_system_registry behavior at rancher2_app_v2 resource

### DIFF
--- a/docs/resources/app_v2.md
+++ b/docs/resources/app_v2.md
@@ -21,6 +21,23 @@ resource "rancher2_app_v2" "foo" {
 }
 ```
 
+### Create an App from a Helm Chart using a different registry
+
+The `system_default_registry` argument can override the global value at App installation. If argument is not provided, the global value for System Default Registry will be used instead.
+
+```hcl
+resource "rancher2_app_v2" "cis_benchmark" {
+  cluster_id = "<CLUSTER_ID>"
+  name = "rancher-cis-benchmark"
+  namespace = "cis-operator-system"
+  repo_name = "rancher-charts"
+  chart_name = "rancher-cis-benchmark"
+
+  # Valid DNS for Private Registry
+  system_default_registry = "<some.dns.here>:<PORT>"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -40,6 +57,7 @@ The following arguments are supported:
 * `wait` - (Optional) Wait until app is deployed. Default: `true` (bool)
 * `annotations` - (Optional/Computed) Annotations for the app v2 (map)
 * `labels` - (Optional/Computed) Labels for the app v2 (map)
+* `system_default_registry` - (Optional/Computed) System default registry providing images for app deployment (string)
 
 ## Attributes Reference
 

--- a/rancher2/config.go
+++ b/rancher2/config.go
@@ -800,9 +800,9 @@ func (c *Config) getObjectV2ByID(clusterID, id, APIType string, resp interface{}
 	}
 }
 
-func (c *Config) GetSettingV2ByID(id string) (*SettingV2, error) {
+func (c *Config) GetSettingV2ByID(clusterID, id string) (*SettingV2, error) {
 	resp := &SettingV2{}
-	err := c.getObjectV2ByID("local", id, settingV2APIType, resp)
+	err := c.getObjectV2ByID(clusterID, id, settingV2APIType, resp)
 	if err != nil {
 		if !IsServerError(err) && !IsNotFound(err) && !IsForbidden(err) {
 			return nil, fmt.Errorf("Getting Setting V2: %s", err)

--- a/rancher2/config.go
+++ b/rancher2/config.go
@@ -800,9 +800,9 @@ func (c *Config) getObjectV2ByID(clusterID, id, APIType string, resp interface{}
 	}
 }
 
-func (c *Config) GetSettingV2ByID(clusterID, id string) (*SettingV2, error) {
+func (c *Config) GetSettingV2ByID(id string) (*SettingV2, error) {
 	resp := &SettingV2{}
-	err := c.getObjectV2ByID(clusterID, id, settingV2APIType, resp)
+	err := c.getObjectV2ByID("local", id, settingV2APIType, resp)
 	if err != nil {
 		if !IsServerError(err) && !IsNotFound(err) && !IsForbidden(err) {
 			return nil, fmt.Errorf("Getting Setting V2: %s", err)

--- a/rancher2/resource_rancher2_app_v2.go
+++ b/rancher2/resource_rancher2_app_v2.go
@@ -98,7 +98,7 @@ func resourceRancher2AppV2Read(d *schema.ResourceData, meta interface{}) error {
 			d.Set("cluster_name", cluster.Name)
 		}
 		if systemDefaultRegistry, ok := d.Get("system_default_registry").(string); !ok || len(systemDefaultRegistry) == 0 {
-			systemDefaultRegistry, err := meta.(*Config).GetSettingV2ByID(appV2DefaultRegistryID)
+			systemDefaultRegistry, err := meta.(*Config).GetSettingV2ByID(clusterID, appV2DefaultRegistryID)
 			if err != nil {
 				return resource.NonRetryableError(err)
 			}

--- a/rancher2/resource_rancher2_app_v2.go
+++ b/rancher2/resource_rancher2_app_v2.go
@@ -37,6 +37,7 @@ func resourceRancher2AppV2Create(d *schema.ResourceData, meta interface{}) error
 	repoName := d.Get("repo_name").(string)
 	chartName := d.Get("chart_name").(string)
 	chartVersion := d.Get("chart_version").(string)
+	systemDefaultRegistry := d.Get("system_default_registry").(string)
 
 	log.Printf("[INFO] Creating App V2 %s at cluster ID %s", name, clusterID)
 
@@ -49,11 +50,16 @@ func resourceRancher2AppV2Create(d *schema.ResourceData, meta interface{}) error
 	}
 	d.Set("cluster_name", cluster.Name)
 
-	systemDefaultRegistry, err := meta.(*Config).GetSettingV2ByID(appV2DefaultRegistryID)
+	globalSystemDefaultRegistry, err := meta.(*Config).GetSettingV2ByID("local", appV2DefaultRegistryID)
 	if err != nil {
 		return err
 	}
-	d.Set("system_default_registry", systemDefaultRegistry.Value)
+
+	if systemDefaultRegistry != globalSystemDefaultRegistry.Value {
+		d.Set("system_default_registry", systemDefaultRegistry)
+	} else {
+		d.Set("system_default_registry", globalSystemDefaultRegistry.Value)
+	}
 
 	repo, chartInfo, err := infoAppV2(meta.(*Config), clusterID, repoName, chartName, chartVersion)
 	if err != nil {

--- a/rancher2/resource_rancher2_app_v2.go
+++ b/rancher2/resource_rancher2_app_v2.go
@@ -50,14 +50,12 @@ func resourceRancher2AppV2Create(d *schema.ResourceData, meta interface{}) error
 	}
 	d.Set("cluster_name", cluster.Name)
 
-	globalSystemDefaultRegistry, err := meta.(*Config).GetSettingV2ByID("local", appV2DefaultRegistryID)
+	globalSystemDefaultRegistry, err := meta.(*Config).GetSettingV2ByID(appV2DefaultRegistryID)
 	if err != nil {
 		return err
 	}
 
-	if systemDefaultRegistry != globalSystemDefaultRegistry.Value {
-		d.Set("system_default_registry", systemDefaultRegistry)
-	} else {
+	if systemDefaultRegistry == "" {
 		d.Set("system_default_registry", globalSystemDefaultRegistry.Value)
 	}
 
@@ -98,7 +96,7 @@ func resourceRancher2AppV2Read(d *schema.ResourceData, meta interface{}) error {
 			d.Set("cluster_name", cluster.Name)
 		}
 		if systemDefaultRegistry, ok := d.Get("system_default_registry").(string); !ok || len(systemDefaultRegistry) == 0 {
-			systemDefaultRegistry, err := meta.(*Config).GetSettingV2ByID(clusterID, appV2DefaultRegistryID)
+			systemDefaultRegistry, err := meta.(*Config).GetSettingV2ByID(appV2DefaultRegistryID)
 			if err != nil {
 				return resource.NonRetryableError(err)
 			}

--- a/rancher2/schema_app_v2.go
+++ b/rancher2/schema_app_v2.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	norman "github.com/rancher/norman/types"
-	"github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	v1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 )
 
 const (
@@ -79,8 +79,10 @@ func appV2Fields() map[string]*schema.Schema {
 			Description: "Deploy app within project ID",
 		},
 		"system_default_registry": {
-			Type:     schema.TypeString,
-			Computed: true,
+			Type:        schema.TypeString,
+			Computed:    true,
+			Optional:    true,
+			Description: "System default registry providing images for app deployment.",
 		},
 		"values": {
 			Type:             schema.TypeString,


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
https://github.com/rancher/terraform-provider-rancher2/issues/1187
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
The terraform resource `rancher2_app_v2` had no **Argument** for setting up a **Custom** System Registry, limiting clients to install an app only from a previously configured **SystemDefaultRegistry**.

There was in place a **computed attribute** named `default_system_registry`.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
 
Transform the **computed attribute** `default_system_registry` into an **optional argument** for the resource too. 

- **If the argument is used**: override the installation with its value. 
- **If it is not used**: use the **Global Default System Registry** value which might be an empty string or not.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

The reproducing steps in the Github Issue are very hard and take a long time to execute. 

In order to test without needing to set all the infrastructure (specially the private registry with all the images):

Testing With Terraform:
1. Apply 1 AWS Instance + Rancher 
2. Apply 1 AWS Instance + Import RKE downstream cluster
3. Use resource `rancher2_app_v2` to create a new app installation passing the recently created `system_default_registry` **argument** pointing to a random string pretending to be the private registry DNS.
4. Check if the Charts begins the installation under Apps.
5. Check if the related system image for running the chart fails because it points out to the random string we passed. 

Results when trying to install CIS Benchmark passing a random string as the value:
![image](https://github.com/rancher/terraform-provider-rancher2/assets/127259813/75396c37-2892-4cf9-9e4f-276aa0349092)

---



## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Part of the terraform code to execute the tests:
```(hcl)

resource "rancher2_cluster" "bug_cluster" {
    provider = rancher2.BUG

    depends_on = [
        aws_instance.bug_node
    ]

    name = "${var.prefix}-bug-cluster"
    enable_cluster_alerting = false
    enable_cluster_monitoring = false

    rke_config {
      network {
        plugin = "canal"
      }
      enable_cri_dockerd    = true
      kubernetes_version = "v1.25.9-rancher2-1"
      ignore_docker_version = true
    }
}

# Create Rancher-CIS-Benchark App from Helm chart
resource "rancher2_app_v2" "cis_benchmark_bug_cluster" {
  provider = rancher2.BUG

  depends_on = [
    rancher2_cluster_sync.bug_sync
  ]

  cluster_id = rancher2_cluster_sync.bug_sync.cluster_id
  name = "rancher-cis-benchmark"
  namespace = "cis-operator-system"
  repo_name = "rancher-charts"
  chart_name = "rancher-cis-benchmark"
  cleanup_on_fail = true
  wait = false

  # comment/uncomment to reproduce/disable the bug
  # system_default_registry = "YYYYZ"
  timeouts {
    create = "5m"
    update = "5m"
    delete = "5m"
  }
}


```

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->