### PR TITLE
Fix the issue where the for_each in rancher2_registry keeps changing the order of the list that has not changed

### DIFF
--- a/rancher2/structure_registry_test.go
+++ b/rancher2/structure_registry_test.go
@@ -24,9 +24,29 @@ func init() {
 	}
 	testRegistryCredentialConfInterface = []interface{}{
 		map[string]interface{}{
-			"address":  "address",
-			"username": "username",
-			"password": "password",
+			"address":  "docker-registry.eu.rancher.com",
+			"username": "username1",
+			"password": "password1",
+		},
+		map[string]interface{}{
+			"address":  "external.docker.suse.com",
+			"username": "username2",
+			"password": "password2",
+		},
+		map[string]interface{}{
+			"address":  "arrow.test.com",
+			"username": "username3",
+			"password": "password3",
+		},
+		map[string]interface{}{
+			"address":  "psi-reg.rnd.dev.net",
+			"username": "username4",
+			"password": "password4",
+		},
+		map[string]interface{}{
+			"address":  "rds-dev.tea1.inf.rancher.com",
+			"username": "username5",
+			"password": "password5",
 		},
 	}
 	testDockerCredentialConf = &projectClient.DockerCredential{
@@ -34,7 +54,11 @@ func init() {
 		Name:        "name",
 		Description: "description",
 		Registries: map[string]projectClient.RegistryCredential{
-			"address": *testRegistryCredentialConf,
+			"rds-dev.tea1.inf.rancher.com":   {Username: "username5", Password: "password5"},
+			"psi-reg.rnd.dev.net":            {Username: "username4", Password: "password4"},
+			"arrow.test.com":                 {Username: "username3", Password: "password3"},
+			"external.docker.suse.com":       {Username: "username2", Password: "password2"},
+			"docker-registry.eu.rancher.com": {Username: "username1", Password: "password1"},
 		},
 		Annotations: map[string]string{
 			"node_one": "one",
@@ -65,7 +89,11 @@ func init() {
 		Description: "description",
 		NamespaceId: "namespace_id",
 		Registries: map[string]projectClient.RegistryCredential{
-			"address": *testRegistryCredentialConf,
+			"rds-dev.tea1.inf.rancher.com":   {Username: "username5", Password: "password5"},
+			"psi-reg.rnd.dev.net":            {Username: "username4", Password: "password4"},
+			"arrow.test.com":                 {Username: "username3", Password: "password3"},
+			"external.docker.suse.com":       {Username: "username2", Password: "password2"},
+			"docker-registry.eu.rancher.com": {Username: "username1", Password: "password1"},
 		},
 		Annotations: map[string]string{
 			"node_one": "one",


### PR DESCRIPTION


## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
https://github.com/rancher/terraform-provider-rancher2/issues/923

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
When we keep invoking `terraform apply` multiple times, Terraform may report changes in the `rancher2_registry` resource when we do not change anything.  
Please check the linked GH issue for detailed examples. 

It happens because when terraform-provider-rancher2 flattens the registry credential, it needs to convert a Map into a List,  Golang does not guarantee the order of returned objects when traversing a Map, and terraform-provider-rancher2 saves items in the order of receiving,  so the order of items in the final List may change even though it is the same set of items. Therefore, Terraform detects and reports changes. 

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
 
Preserve the order of existing items in the final List can prevent Terraform from reporting such changes

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

This fix is tested locally by adding extra logging lines which show that the order of existing items is preserved. 


### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

The existing test case is updated. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
the same case as the GH issue provides. 

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

none