### PR TITLE
feat(cluster): add use_instance_metadata_hostname flag to cloud_provider block

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -745,6 +745,7 @@ The following attributes are exported:
 * `name` - (Optional) RKE Cloud Provider name (string)
 * `openstack_cloud_provider` - (Optional/Computed) RKE Openstack Cloud Provider config for Cloud Provider [rke-openstack-cloud-provider](https://rancher.com/docs/rke/latest/en/config-options/cloud-providers/openstack/) (list maxitems:1)
 * `vsphere_cloud_provider` - (Optional/Computed) RKE Vsphere Cloud Provider config for Cloud Provider [rke-vsphere-cloud-provider](https://rancher.com/docs/rke/latest/en/config-options/cloud-providers/vsphere/) Extra argument `name` is required on `virtual_center` configuration. (list maxitems:1)
+* `use_instance_metadata_hostname` - (Optional/Computed) (bool)
 
 ##### `aws_cloud_provider`
 

--- a/rancher2/schema_cluster_rke_config_cloud_provider.go
+++ b/rancher2/schema_cluster_rke_config_cloud_provider.go
@@ -49,6 +49,11 @@ func clusterRKEConfigCloudProviderFields() map[string]*schema.Schema {
 				Schema: clusterRKEConfigCloudProviderVsphereFields(),
 			},
 		},
+		"use_instance_metadata_hostname": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
 	}
 	return s
 }

--- a/rancher2/structure_cluster_rke_config_cloud_provider.go
+++ b/rancher2/structure_cluster_rke_config_cloud_provider.go
@@ -70,6 +70,10 @@ func flattenClusterRKEConfigCloudProvider(in *managementClient.CloudProvider, p 
 		obj["vsphere_cloud_provider"] = vsphereProvider
 	}
 
+	if in.UseInstanceMetadataHostname != nil {
+		obj["use_instance_metadata_hostname"] = *in.UseInstanceMetadataHostname
+	}
+
 	return []interface{}{obj}, nil
 }
 
@@ -120,6 +124,10 @@ func expandClusterRKEConfigCloudProvider(p []interface{}) (*managementClient.Clo
 			return obj, err
 		}
 		obj.VsphereCloudProvider = vsphereProvider
+	}
+
+	if v, ok := in["use_instance_metadata_hostname"].(bool); ok {
+		obj.UseInstanceMetadataHostname = &v
 	}
 
 	return obj, nil

--- a/rancher2/structure_cluster_rke_config_cloud_provider_z_test.go
+++ b/rancher2/structure_cluster_rke_config_cloud_provider_z_test.go
@@ -50,13 +50,15 @@ func init() {
 		},
 	}
 	testClusterRKEConfigCloudProviderConf = &managementClient.CloudProvider{
-		CustomCloudProvider: "XXXXXXXXXXXX",
-		Name:                "test",
+		CustomCloudProvider:         "XXXXXXXXXXXX",
+		Name:                        "test",
+		UseInstanceMetadataHostname: newTrue(),
 	}
 	testClusterRKEConfigCloudProviderInterface = []interface{}{
 		map[string]interface{}{
-			"custom_cloud_provider": "XXXXXXXXXXXX",
-			"name":                  "test",
+			"custom_cloud_provider":          "XXXXXXXXXXXX",
+			"name":                           "test",
+			"use_instance_metadata_hostname": true,
 		},
 	}
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
Fixes: https://github.com/rancher/rancher/issues/41059

## Problem
Since Rancher v2.6.11 it is now mandatory in some cases for RKE clusters in AWS to set a newly introduced config named useInstanceMetadataHostname.
Upgrading from Rancher v2.6.10 to v2.6.11 will break the clusters if you don't specify this flag.
 
## Solution
Adding the ability to configure the `useInstanceMetadataHostname` from the `rancher2_cluster.rke_config.cloud_provider` block.
 
## Testing
Setting the flag to `true` should result in cluster nodes named using the EC2 instance metadata hostname.

## Engineering Testing
### Manual Testing
Manually checked rancher's api call with the useInstanceMetadataHostname flag present.

### Automated Testing
Added a check to the unit test that the flag is persisted and passed as expected.

## QA Testing Considerations

 
### Regressions Considerations
