### PR TITLE
Add project_id syntax for rancher2_project_role_template_binding

### DIFF
--- a/docs/resources/project_role_template_binding.md
+++ b/docs/resources/project_role_template_binding.md
@@ -22,7 +22,7 @@ resource "rancher2_project_role_template_binding" "foo" {
 
 The following arguments are supported:
 
-* `project_id` - (Required/ForceNew) The project id where bind project role template (string)
+* `project_id` - (Required/ForceNew) The project id where bind project role template, in format `cluster_id:project_id`, e.g. `c-abc12:p-def34` (string)
 * `role_template_id` - (Required/ForceNew) The role template id from create project role template binding (string)
 * `name` - (Required/ForceNew) The name of the project role template binding (string)
 * `group_id` - (Optional/Computed/ForceNew) The group ID to assign project role template binding (string)


### PR DESCRIPTION
Previously undocumented but mentioned in
https://github.com/rancher/terraform-provider-rancher2/issues/225#issue-549757012

Using only the project_id produces an error:

> Error: Bad response statusCode [404]. Status [404 Not Found].
> Body: [message=failed to find resource by id, baseType=error,
> code=NotFound] from [<URL>]

## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->