### PR TITLE
Fix double base64-encoding of `ca_bundle` field

### DIFF
--- a/docs/resources/catalog_v2.md
+++ b/docs/resources/catalog_v2.md
@@ -30,7 +30,7 @@ The following arguments are supported:
 
 * `cluster_id` - (Required/ForceNew) The cluster id of the catalog V2 (string)
 * `name` - (Required) The name of the catalog v2 (string)
-* `ca_bundle` - (Optional) PEM encoded CA bundle which will be used to validate the repo's certificate (string)
+* `ca_bundle` - (Optional) CA certificate in base64-encoded DER format which will be used to validate the repo's certificate (string)
 * `enabled` - (Optional) If disabled the repo clone will not be updated or allowed to be installed from. Default: `true` (bool)
 * `git_branch` - (Optional/Computed) Git Repository branch containing Helm chart definitions. Default `master` (string)
 * `git_repo` - (Optional) The url of the catalog v2 repo. Conflicts with `url` (string)

--- a/rancher2/resource_rancher2_catalog_v2.go
+++ b/rancher2/resource_rancher2_catalog_v2.go
@@ -34,7 +34,10 @@ func resourceRancher2CatalogV2() *schema.Resource {
 func resourceRancher2CatalogV2Create(d *schema.ResourceData, meta interface{}) error {
 	clusterID := d.Get("cluster_id").(string)
 	name := d.Get("name").(string)
-	catalog := expandCatalogV2(d)
+	catalog, err := expandCatalogV2(d)
+	if err != nil {
+		return fmt.Errorf("failed to expand resource: %w", err)
+	}
 
 	log.Printf("[INFO] Creating Catalog V2 %s", name)
 
@@ -86,7 +89,10 @@ func resourceRancher2CatalogV2Read(d *schema.ResourceData, meta interface{}) err
 func resourceRancher2CatalogV2Update(d *schema.ResourceData, meta interface{}) error {
 	clusterID := d.Get("cluster_id").(string)
 	name := d.Get("name").(string)
-	catalog := expandCatalogV2(d)
+	catalog, err := expandCatalogV2(d)
+	if err != nil {
+		return fmt.Errorf("failed to expand catalog_v2 resource: %w", err)
+	}
 	log.Printf("[INFO] Updating Catalog V2 %s", name)
 
 	_, rancherID := splitID(d.Id())

--- a/rancher2/schema_catalog_v2.go
+++ b/rancher2/schema_catalog_v2.go
@@ -45,7 +45,7 @@ func catalogV2Fields() map[string]*schema.Schema {
 		"ca_bundle": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "PEM encoded CA bundle which will be used to validate the repo's certificate",
+			Description: "CA certificate in base64-encoded DER format which will be used to validate the repo's certificate",
 		},
 		"enabled": {
 			Type:        schema.TypeBool,

--- a/rancher2/structure_catalog_v2.go
+++ b/rancher2/structure_catalog_v2.go
@@ -29,7 +29,8 @@ func flattenCatalogV2(d *schema.ResourceData, in *ClusterRepo) error {
 	}
 	d.Set("resource_version", in.ObjectMeta.ResourceVersion)
 
-	d.Set("ca_bundle", string(in.Spec.CABundle))
+	encodedCABundle := base64.StdEncoding.EncodeToString(in.Spec.CABundle)
+	d.Set("ca_bundle", encodedCABundle)
 	if in.Spec.Enabled != nil {
 		d.Set("enabled", *in.Spec.Enabled)
 	}

--- a/rancher2/structure_catalog_v2_test.go
+++ b/rancher2/structure_catalog_v2_test.go
@@ -28,7 +28,7 @@ func init() {
 		"label1": "one",
 		"label2": "two",
 	}
-	testCatalogV2Conf.Spec.CABundle = []byte("ca_bundle")
+	testCatalogV2Conf.Spec.CABundle = []byte("test DER data")
 	testCatalogV2Conf.Spec.Enabled = newTrue()
 	testCatalogV2Conf.Spec.GitBranch = "git_branch"
 	testCatalogV2Conf.Spec.GitRepo = "git_repo"
@@ -43,7 +43,7 @@ func init() {
 
 	testCatalogV2Interface = map[string]interface{}{
 		"name":                      "name",
-		"ca_bundle":                 "ca_bundle",
+		"ca_bundle":                 "dGVzdCBERVIgZGF0YQ==",
 		"enabled":                   true,
 		"git_branch":                "git_branch",
 		"git_repo":                  "git_repo",
@@ -104,7 +104,10 @@ func TestExpandCatalogV2(t *testing.T) {
 
 	for _, tc := range cases {
 		inputResourceData := schema.TestResourceDataRaw(t, catalogV2Fields(), tc.Input)
-		output := expandCatalogV2(inputResourceData)
+		output, err := expandCatalogV2(inputResourceData)
+		if err != nil {
+			t.Fatal(err)
+		}
 		assert.Equal(t, tc.ExpectedOutput, output, "Unexpected output from expander.")
 	}
 }


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
For rancher/terraform-provider-rancher2#1297
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The user reports that configuring a `rancher_catalog_v2` resource with the `ca_bundle` field set fails. This is because the `caBundle` field in the configured `ClusterRepo` resource is base64-encoded twice. For more details, the JIRA issue gives a pretty good description.

Also note that there is a discrepancy between the documentation for configuring a repo/catalog via the Rancher UI, and the documentation for the `ca_bundle` field in the `rancher_catalog_v2` resource:

> Git-based chart repositories: You must add a base64 encoded copy of the CA certificate in DER format to the spec.caBundle field of the chart repo [link](https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/helm-charts-in-rancher#repositories)

> [ca_bundle](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/catalog_v2#ca_bundle) - (Optional) PEM encoded CA bundle which will be used to validate the repo's certificate (string) [link](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/catalog_v2#argument-reference)

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

The cleanest solution, as far as @nicholasSUSE and I can tell, is to slightly change the behavior of the `ca_bundle` field so that the user sets it to a base64-encoded DER value. When expanding the terraform object into a `ClusterRepo`, the `rancher2` provider base64-decodes the passed `ca_bundle` value and sets the `spec.caBundle` field of the `ClusterRepo` to the result, which is of type `[]byte`. When the `encoding/json` package marshals the `ClusterRepo` struct created by the `rancher2` provider, it automatically base64-encodes the `caBundle` field (see the [docs for `json.Marshal`](https://pkg.go.dev/encoding/json#Marshal)), which appears to be what the Rancher API expects.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

This issue can be reproduced by running the terraform provider against a v2.7.6 Rancher cluster. Note that running it against a version of Rancher run via `go run main.go` or `dlv` doesn't work - it seems that the terraform provider chokes on the fact that something (I never figured out what) has the version `dev`.

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

On a Rancher v2.7.6 deployment running in k3d, I did the following tests using the terraform provider:
- Creating a `ClusterRepo` resource with the `caBundle` field set.
- Creating a `ClusterRepo` resource without the `caBundle` field set.
- Deleting a `ClusterRepo` resource.
- Updating a `ClusterRepo` resource by changing the `name` field in the terraform resource. This failed, but I determined that this failure is present on the `master` branch and thus not related to this PR. This seems wrong to me, but also seems like it may just be due to how the Rancher API works. I'm new to the Rancher project, so can someone who has more experience with Rancher check this?

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

I updated the `ca_bundle` field in the `expandCatalogV2` and `flattenCatalogV2` unit tests to reflect the HCL value being base64-encoded DER, and the ClusterRepo value being a `[]byte` containing unencoded DER.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
I don't *think* there is any issue with changing the behavior of the `ca_bundle` field, since it is broken as is. I could easily be wrong though...

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->