### PR TITLE
Refine release steps to include compatibility matrix update

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,5 @@ BUG FIXES:
 
 * Create a PR to update CHANGELOG
 * Copy the updated notes back to the draft release and save (DO NOT release with just the generated notes. Those are just a template to help you)
-* Create an [EIO issue](https://github.com/rancherlabs/eio) for Hashicorp to publish the release
+* Undraft the release, which creates the tag and builds the release
+* If necessary - create a followup PR to edit [`./docs/compatibility-matrix.md`](https://github.com/rancher/terraform-provider-rancher2/blob/master/docs/compatibility-matrix.md) with the new version information


### PR DESCRIPTION
Just updating the readme with a few things:
- Remove the EIO step since that is not necessary anymore
- Adding an item to update the compatibility matrix with the new version info