### PR TITLE
Add OS field for vmwarevsphereConfig and machineConfigV2Vmwarevsphere

### DIFF
--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -314,6 +314,7 @@ The following attributes are exported:
 * `hostsystem` - (Optional) vSphere compute resource where the docker VM will be instantiated. This can be omitted if using a cluster with DRS (string)
 * `memory_size` - (Optional) vSphere size of memory for docker VM (in MB). Default `2048` (string)
 * `network` - (Optional) vSphere network where the docker VM will be attached (list)
+* `os` - (Optional) Operating System of the vSphere virtual machines . Default `linux`(string)
 * `pool` - (Optional) vSphere resource pool for docker VM (string)
 * `ssh_password` - (Optional) If using a non-B2D image you can specify the ssh password. Default `tcuser` (string)
 * `ssh_port` - (Optional) If using a non-B2D image you can specify the ssh port. Default `22` (string)

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -434,6 +434,7 @@ The following attributes are exported:
 * `hostsystem` - (Optional) vSphere compute resource where the docker VM will be instantiated. This can be omitted if using a cluster with DRS (string)
 * `memory_size` - (Optional) vSphere size of memory for docker VM (in MB). Default `2048` (string)
 * `network` - (Optional) vSphere network where the docker VM will be attached (list)
+* `os` - (Optional) Operating System of the vSphere virtual machines. Default `linux` (string)
 * `password` - (Optional/Sensitive) vSphere password. Mandatory on Rancher v2.0.x and v2.1.x. Use `rancher2_cloud_credential` from Rancher v2.2.x (string)
 * `pool` - (Optional) vSphere resource pool for docker VM (string)
 * `ssh_password` - (Optional) If using a non-B2D image you can specify the ssh password. Default `tcuser`. From Rancher v2.3.3 (string)

--- a/rancher2/schema_machine_config_v2_vsphere.go
+++ b/rancher2/schema_machine_config_v2_vsphere.go
@@ -120,6 +120,12 @@ func machineConfigV2VmwarevsphereFields() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
+		"os": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "linux",
+			Description: "Operating System of the vSphere virtual machines",
+		},
 		"password": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/rancher2/schema_node_template_vsphere.go
+++ b/rancher2/schema_node_template_vsphere.go
@@ -37,6 +37,7 @@ type vmwarevsphereConfig struct {
 	Hostsystem              string   `json:"hostsystem,omitempty" yaml:"hostsystem,omitempty"`
 	MemorySize              string   `json:"memorySize,omitempty" yaml:"memorySize,omitempty"`
 	Network                 []string `json:"network,omitempty" yaml:"network,omitempty"`
+	OS                      string   `json:"os,omitempty" yaml:"os,omitempty"`
 	Password                string   `json:"password,omitempty" yaml:"password,omitempty"`
 	Pool                    string   `json:"pool,omitempty" yaml:"pool,omitempty"`
 	SSHPassword             string   `json:"sshPassword,omitempty" yaml:"sshPassword,omitempty"`
@@ -157,6 +158,12 @@ func vsphereConfigFields() map[string]*schema.Schema {
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
+		},
+		"os": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "linux",
+			Description: "Operating System of the vSphere virtual machines",
 		},
 		"password": {
 			Type:        schema.TypeString,

--- a/rancher2/structure_machine_config_v2_vsphere.go
+++ b/rancher2/structure_machine_config_v2_vsphere.go
@@ -34,6 +34,7 @@ type machineConfigV2Vmwarevsphere struct {
 	Hostsystem              string   `json:"hostsystem,omitempty" yaml:"hostsystem,omitempty"`
 	MemorySize              string   `json:"memorySize,omitempty" yaml:"memorySize,omitempty"`
 	Network                 []string `json:"network,omitempty" yaml:"network,omitempty"`
+	OS                      string   `json:"os,omitempty" yaml:"os,omitempty"`
 	Password                string   `json:"password,omitempty" yaml:"password,omitempty"`
 	Pool                    string   `json:"pool,omitempty" yaml:"pool,omitempty"`
 	SSHPassword             string   `json:"sshPassword,omitempty" yaml:"sshPassword,omitempty"`
@@ -115,6 +116,9 @@ func flattenMachineConfigV2Vmwarevsphere(in *MachineConfigV2Vmwarevsphere) []int
 	}
 	if len(in.Network) > 0 {
 		obj["network"] = toArrayInterface(in.Network)
+	}
+	if len(in.OS) > 0 {
+		obj["os"] = in.OS
 	}
 	if len(in.Password) > 0 {
 		obj["password"] = in.Password
@@ -233,6 +237,9 @@ func expandMachineConfigV2Vmwarevsphere(p []interface{}, source *MachineConfigV2
 	}
 	if v, ok := in["network"].([]interface{}); ok && len(v) > 0 {
 		obj.Network = toArrayString(v)
+	}
+	if v, ok := in["os"].(string); ok && len(v) > 0 {
+		obj.OS = v
 	}
 	if v, ok := in["password"].(string); ok && len(v) > 0 {
 		obj.Password = v

--- a/rancher2/structure_node_template_vsphere.go
+++ b/rancher2/structure_node_template_vsphere.go
@@ -59,6 +59,9 @@ func flattenVsphereConfig(in *vmwarevsphereConfig) []interface{} {
 	if len(in.Network) > 0 {
 		obj["network"] = toArrayInterface(in.Network)
 	}
+	if len(in.OS) > 0 {
+		obj["os"] = in.OS
+	}
 	if len(in.Password) > 0 {
 		obj["password"] = in.Password
 	}
@@ -167,6 +170,9 @@ func expandVsphereConfig(p []interface{}) *vmwarevsphereConfig {
 	}
 	if v, ok := in["network"].([]interface{}); ok && len(v) > 0 {
 		obj.Network = toArrayString(v)
+	}
+	if v, ok := in["os"].(string); ok && len(v) > 0 {
+		obj.OS = v
 	}
 	if v, ok := in["password"].(string); ok && len(v) > 0 {
 		obj.Password = v


### PR DESCRIPTION
## Issue: #1193 
 
## Problem
Currently it is impossible to provision Windows nodes with the vSphere driver through the terraform provider.
 
## Solution
Expose the `os` field of the `rke-machine-config.cattle.io.vmwarevsphereconfigs` API in the provider.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->