### PR TITLE
fix: try removing the decode

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -37,7 +37,7 @@ jobs:
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
         run: |
           echo "Importing gpg key"
-          echo -n "${{ env.GPG_KEY }}" | base64 --decode | gpg --import --batch > /dev/null          
+          echo -n "${{ env.GPG_KEY }}" | gpg --import --batch > /dev/null
           echo "signing SHASUM file"
           VERSION_NO_V=$(echo ${{ github.ref_name }} | sed "s/^[v|V]//")
           SHASUM_FILE=dist/artifacts/${{ github.ref_name }}/terraform-provider-rancher2_"$VERSION_NO_V"_SHA256SUMS

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
         run: |
           echo "Importing gpg key"
-          echo -n "${{ env.GPG_KEY }}" | base64 --decode | gpg --import --batch > /dev/null          
+          echo -n "${{ env.GPG_KEY }}" | gpg --import --batch > /dev/null
           echo "signing SHASUM file"
           VERSION_NO_V=$(echo ${{ github.ref_name }} | sed "s/^[v|V]//")
           SHASUM_FILE=dist/artifacts/${{ github.ref_name }}/terraform-provider-rancher2_"$VERSION_NO_V"_SHA256SUMS


### PR DESCRIPTION
Pre-release is failing at decoding the gpg private key. My hunch is that the secret isn't base64 encoded. This will remove the decode call in the workflow so that we can try again.