### PR TITLE
fix: arrange quotes

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -37,11 +37,11 @@ jobs:
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
         run: |
           echo "Importing gpg key"
-          echo -n "${{ env.GPG_KEY }}" | gpg --import --batch > /dev/null
+          echo -n '${{ env.GPG_KEY }}' | gpg --import --batch > /dev/null
           echo "signing SHASUM file"
-          VERSION_NO_V=$(echo ${{ github.ref_name }} | sed "s/^[v|V]//")
-          SHASUM_FILE=dist/artifacts/${{ github.ref_name }}/terraform-provider-rancher2_"$VERSION_NO_V"_SHA256SUMS
-          echo ${{ env.GPG_PASSPHRASE }} | gpg --detach-sig --pinentry-mode loopback --passphrase-fd 0 --output "$SHASUM_FILE".sig --sign "$SHASUM_FILE"
+          VERSION_NO_V="$(echo ${{ github.ref_name }} | tr -d 'v')"
+          SHASUM_FILE="dist/artifacts/${{ github.ref_name }}/terraform-provider-rancher2_${VERSION_NO_V}_SHA256SUMS"
+          echo '${{ env.GPG_PASSPHRASE }}' | gpg --detach-sig --pinentry-mode loopback --passphrase-fd 0 --output "${SHASUM_FILE}.sig" --sign "${SHASUM_FILE}"
 
       - name: GH release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,11 +37,11 @@ jobs:
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
         run: |
           echo "Importing gpg key"
-          echo -n "${{ env.GPG_KEY }}" | gpg --import --batch > /dev/null
+          echo -n '${{ env.GPG_KEY }}' | gpg --import --batch > /dev/null
           echo "signing SHASUM file"
-          VERSION_NO_V=$(echo ${{ github.ref_name }} | sed "s/^[v|V]//")
-          SHASUM_FILE=dist/artifacts/${{ github.ref_name }}/terraform-provider-rancher2_"$VERSION_NO_V"_SHA256SUMS
-          echo ${{ env.GPG_PASSPHRASE }} | gpg --detach-sig --pinentry-mode loopback --passphrase-fd 0 --output "$SHASUM_FILE".sig --sign "$SHASUM_FILE"
+          VERSION_NO_V="$(echo ${{ github.ref_name }} | tr -d 'v')"
+          SHASUM_FILE="dist/artifacts/${{ github.ref_name }}/terraform-provider-rancher2_${VERSION_NO_V}_SHA256SUMS"
+          echo '${{ env.GPG_PASSPHRASE }}' | gpg --detach-sig --pinentry-mode loopback --passphrase-fd 0 --output "${SHASUM_FILE}.sig" --sign "${SHASUM_FILE}"
 
       - name: GH release
         env:


### PR DESCRIPTION
The build is failing due to misinterpreting a key.
https://github.com/rancher/terraform-provider-rancher2/actions/runs/9718161320/job/26825405853
This rearranges the quotes to prevent the shell misinterpreting the special characters.