### PR TITLE
[SURE-8832] fix: add check for external rules while updating roleTemplate

### DIFF
--- a/rancher2/resource_rancher2_role_template.go
+++ b/rancher2/resource_rancher2_role_template.go
@@ -2,9 +2,10 @@ package rancher2
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -110,7 +111,14 @@ func resourceRancher2RoleTemplateUpdate(d *schema.ResourceData, meta interface{}
 			"rules":           expandPolicyRules(d.Get("rules").([]interface{})),
 			"annotations":     toMapString(d.Get("annotations").(map[string]interface{})),
 			"labels":          toMapString(d.Get("labels").(map[string]interface{})),
-			"externalRules":   expandPolicyRules(d.Get("external_rules").([]interface{})),
+		}
+
+		if update["external"].(bool) {
+			if v, ok := d.Get("external_rules").([]interface{}); ok && len(v) > 0 {
+				update["externalRules"] = expandPolicyRules(v)
+			}
+		} else {
+			update["externalRules"] = nil
 		}
 
 		switch update["context"] {


### PR DESCRIPTION
## Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1381
 
## Problem
JIRA issue: https://jira.suse.com/browse/SURE-8832
When attempting to update a RoleTemplate using the rancher2 tf provider v4.2.0 you will get the following error:
```
Error: Bad response statusCode [400]. Status [400 Bad Request]. Body: [baseType=error,
code=BadRequest, message=admission webhook "rancher.cattle.io.roletemplates.management.cattle.io" 
denied the request: ExternalRules can't be set in RoleTemplates with external=false] from 
[https://example.com/v3/roleTemplates/rt-mb28r]
```

 
## Solution
- Modified the roleTemplate update logic to include a check for external rules.
- Added a condition to ensure external rules are only updated when the `external` flag is set.
- Set `externalRules` to `nil` if the `external` flag is not set.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
The fix was tested using the reproduction steps, and the issue was resolved.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->