### PR TITLE
feat: add manage-namespaces and updatepsa to verb list

### DIFF
--- a/docs/resources/global_role.md
+++ b/docs/resources/global_role.md
@@ -52,7 +52,7 @@ The following attributes are exported:
 * `non_resource_urls` - (Optional) Policy rule non resource urls (list)
 * `resource_names` - (Optional) Policy rule resource names (list)
 * `resources` - (Optional) Policy rule resources (list)
-* `verbs` - (Optional) Policy rule verbs. `bind`, `create`, `delete`, `deletecollection`, `escalate`, `get`, `impersonate`, `list`, `patch`, `update`, `use`, `view`, `watch`, `own` and `*` values are supported (list)
+* `verbs` - (Optional) Policy rule verbs. `bind`, `create`, `delete`, `deletecollection`, `escalate`, `get`, `impersonate`, `list`, `manage-namespaces`, `patch`, `update`, `updatepsa`, `use`, `view`, `watch`, `own` and `*` values are supported (list)
 
 ## Timeouts
 

--- a/docs/resources/role_template.md
+++ b/docs/resources/role_template.md
@@ -75,7 +75,7 @@ The following attributes are exported:
 * `non_resource_urls` - (Optional) Policy rule non resource urls (list)
 * `resource_names` - (Optional) Policy rule resource names (list)
 * `resources` - (Optional) Policy rule resources (list)
-* `verbs` - (Optional) Policy rule verbs. `bind`, `create`, `delete`, `deletecollection`, `escalate`, `get`, `impersonate`, `list`, `patch`, `update`, `use`, `view`, `watch`, `own` and `*` values are supported (list)
+* `verbs` - (Optional) Policy rule verbs. `bind`, `create`, `delete`, `deletecollection`, `escalate`, `get`, `impersonate`, `list`, `manage-namespaces`, `patch`, `update`, `updatepsa`, `use`, `view`, `watch`, `own` and `*` values are supported (list)
 
 ## Timeouts
 

--- a/rancher2/schema_policy_rule.go
+++ b/rancher2/schema_policy_rule.go
@@ -21,6 +21,8 @@ const (
 	policyRuleVerbBind             = "bind"
 	policyRuleVerbEscalate         = "escalate"
 	policyRuleVerbImpersonate      = "impersonate"
+	policyRuleVerbManageNamespaces = "manage-namespaces"
+	policyRuleVerbUpdatePSA        = "updatepsa"
 )
 
 var (
@@ -40,6 +42,8 @@ var (
 		policyRuleVerbBind,
 		policyRuleVerbEscalate,
 		policyRuleVerbImpersonate,
+		policyRuleVerbManageNamespaces,
+		policyRuleVerbUpdatePSA,
 	}
 )
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/terraform-provider-rancher2/issues/1219
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
## Problem
`manage-namespaces` and `updatepsa` verbs were not available to be used in RoleTemplate rules.
 
## Solution
Add `manage-namespaces` and `updatepsa` to the list of available verbs.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing

Run a rancher instance using docker:

```shell
sudo docker run --privileged -it --rm -p 80:80 -p 443:443 --dns 1.1.1.1 -e CATTLE_BOOTSTRAP_PASSWORD=password rancher/rancher
```

Build the terraform plugin:

```shell
make build 
```

Move the binary under the right directory for plugins:

```shell
mkdir -p ~/.terraform.d/plugins/terraform.local/local/rancher2/4.3.0/linux_amd64/
mv terraform-provider-rancher2 ~/.terraform.d/plugins/terraform.local/local/rancher2/4.3.0/linux_amd64/
```

Create a terraform file with the following content (`main.tf`):

```hcl
provider "rancher2" {
  api_url    = "https://localhost:443/"
  access_key = "token-xxxx"
  secret_key = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
  insecure = true
}

resource "rancher2_user" "testuser" {
  name     = "Test User"
  username = "testuser"
  password = "password12345"
  enabled     = true
}

# Assign global role bindings to the user (optional)
resource "rancher2_global_role_binding" "new_user_role" {
  user_id       = rancher2_user.testuser.id
  global_role_id = "user-base"
}

resource "rancher2_role_template" "foo-test" {
  name = "foo-test"
  context = "project"
  default_role = true
  description = "Terraform role template acceptance test"
  rules {
    api_groups = ["management.cattle.io"]
    resources = ["projects"]
    verbs = ["manage-namespaces", "updatepsa"]
  }
}
```
Replace `access_key` and `secret_key` with your rancher instance keys.

Create another file `provider.tf`:

```hcl
terraform {
  required_providers {
    rancher2 = {
      source = "terraform.local/local/rancher2"
      version = "4.3.0"
    }
  }
}
```

Run terraform and check the resource has been created properly:

```shell
terraform init
terraform plan
terraform apply
```