### PR TITLE
Remove extra backticks from node_template.md

### DIFF
--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -487,4 +487,3 @@ $ terraform import rancher2_node_template.foo &lt;node_template_id&gt;
 **Important** This process could update `rancher2_node_template` data on tfstate file. Be sure to save a copy of tfstate file before proceed
 
 Due to [this feature](https://github.com/rancher/rancher/pull/23718) included on Rancher v2.3.3, `rancher2_node_template` are now global scoped objects with RBAC around them, instead of user scoped objects as they were. This means that existing node templates `id` field is changing on upgrade. Provider implements `fixNodeTemplateID()` that will update tfstate with proper id.
-```


### PR DESCRIPTION
Noticed these at the [end of the doc](https://registry.terraform.io/providers/rancher/rancher2/4.2.0/docs/resources/node_template#upgrading-to-rancher-v233) and figured I'd fix 'em up.

## Issue: 

Backticks appearing at the end of the `node_template` doc:

![image](https://github.com/user-attachments/assets/2ba66620-7a46-485d-b18a-3721a91ecc56)
 