### PR TITLE
fix: remove extra return in machine template, back port v5 (#1400)

### DIFF
--- a/rancher2/resource_rancher2_machine_config_v2.go
+++ b/rancher2/resource_rancher2_machine_config_v2.go
@@ -60,10 +60,6 @@ func waitForMachineConfigV2(d *schema.ResourceData, config *Config, interval tim
 			return nil
 		}
 		log.Printf("[INFO] Retrying on error Refreshing Machine Config V2 %s: %v", d.Id(), err)
-		if IsNotFound(err) || IsForbidden(err) {
-			d.SetId("")
-			return fmt.Errorf("Machine Config V2 %s not found: %s", d.Id(), err)
-		}
 		if IsNotAccessibleByID(err) {
 			// Restarting clients to update RBAC
 			config.RestartClients()
@@ -72,6 +68,7 @@ func waitForMachineConfigV2(d *schema.ResourceData, config *Config, interval tim
 		select {
 		case <-time.After(rancher2RetriesWait * time.Second):
 		case <-ctx.Done():
+			d.SetId("")
 			return fmt.Errorf("Timeout waiting for machine config V2 ID %s", d.Id())
 		}
 	}


### PR DESCRIPTION
backport #1400 to release/v5 addressing #1398 

Signed-off-by: matttrach <matt.trachier@suse.com>
(cherry picked from commit 1792a32548dd8ccac1e231c03b6be78271791113)
