### PR TITLE
Remove telemetry field from rancher2_bootstrap resource

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,6 @@ resource "rancher2_bootstrap" "admin" {
   provider = "rancher2.bootstrap"
 
   password = "blahblah"
-  telemetry = true
 }
 
 # Provider config for admin

--- a/docs/resources/bootstrap.md
+++ b/docs/resources/bootstrap.md
@@ -9,7 +9,6 @@ Provides a Rancher v2 bootstrap resource. This can be used to bootstrap Rancher 
 This resource bootstraps a Rancher system by performing the following tasks:
 - Updates the default admin password, provided by setting `password` or generating a random one.
 - Sets `server-url` setting, based on `api_url`.
-- Sets `telemetry-opt` setting.
 - Creates a token for admin user with concrete TTL.
 
 **Note:** Starting from Rancher v2.6.0, the Rancher2 installation is setting a random initial admin password by default. To specify the initial password during rancher2 installation, helm chart [`bootstrapPassword`](https://github.com/rancher/rancher/blob/release/v2.6/chart/values.yaml#L157) value for HA installation or docker env variable [`CATTLE_BOOTSTRAP_PASSWORD`](https://github.com/rancher/rancher/blob/release/v2.6/chart/templates/deployment.yaml#L135) for single node installation can be used. To properly use this resource for Rancher v2.6.0 and above, set the `initial_password` argument to the password generated or set during installation.
@@ -32,7 +31,6 @@ provider "rancher2" {
 # Create a new rancher2_bootstrap
 resource "rancher2_bootstrap" "admin" {
   password = "blahblah"
-  telemetry = true
 }
 ```
 
@@ -47,7 +45,6 @@ provider "rancher2" {
 resource "rancher2_bootstrap" "admin" {
   initial_password = "<INSTALL_PASSWORD>"
   password = "blahblah"
-  telemetry = true
 }
 ```
 
@@ -65,7 +62,6 @@ resource "rancher2_bootstrap" "admin" {
   provider = "rancher2.bootstrap"
 
   password = "blahblah"
-  telemetry = true
 }
 ```
 
@@ -75,7 +71,6 @@ The following arguments are supported:
 
 * `initial_password` - (Optional/Computed/Sensitive) Initial password for Admin user. Default: `admin` (string)
 * `password` - (Optional/Computed/Sensitive) Password for Admin user or random generated if empty (string)
-* `telemetry` - (Optional) Send telemetry anonymous data. Default: `false` (bool)
 * `token_ttl` - (Optional) TTL in seconds for generated admin token. Default: `0`  (int)
 * `token_update` - (Optional) Regenerate admin token. Default: `false` (bool)
 * `ui_default_landing` - (Optional) Default UI landing for k8s clusters. Available options: `ember` (cluster manager ui)  and `vue` (cluster explorer ui). Default: `ember` (string)

--- a/rancher2/0_provider_upgrade_test.go
+++ b/rancher2/0_provider_upgrade_test.go
@@ -64,7 +64,6 @@ resource "rancher2_bootstrap" "foo" {
   provider = rancher2.bootstrap
 
   password = "` + testAccRancher2DefaultAdminPass + `"
-  telemetry = true
 }
 provider "rancher2" {
   api_url = rancher2_bootstrap.foo.url
@@ -87,7 +86,6 @@ resource "rancher2_bootstrap" "foo" {
   provider = rancher2.bootstrap
 
   password = "` + testAccRancher2DefaultAdminPass + `"
-  telemetry = true
 }
 provider "rancher2" {
   api_url = rancher2_bootstrap.foo.url
@@ -272,7 +270,6 @@ func TestAccRancher2Upgrade(t *testing.T) {
 					testAccRancher2UpgradeVars(),
 					testAccCheckRancher2BootstrapExists(testAccRancher2BootstrapType+".foo"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "password", testAccRancher2DefaultAdminPass),
-					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "telemetry", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "current_password", testAccRancher2DefaultAdminPass),
 				),
 			},
@@ -281,7 +278,6 @@ func TestAccRancher2Upgrade(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2BootstrapExists(testAccRancher2BootstrapType+".foo"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "password", testAccRancher2DefaultAdminPass),
-					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "telemetry", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "current_password", testAccRancher2DefaultAdminPass),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "name", "foo-global"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "description", "Terraform catalog acceptance test"),
@@ -296,7 +292,6 @@ func TestAccRancher2Upgrade(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2BootstrapExists(testAccRancher2BootstrapType+".foo"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "password", testAccRancher2DefaultAdminPass),
-					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "telemetry", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "current_password", testAccRancher2DefaultAdminPass),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "name", "foo-global"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "description", "Terraform catalog acceptance test"),
@@ -312,7 +307,6 @@ func TestAccRancher2Upgrade(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2BootstrapExists(testAccRancher2BootstrapType+".foo"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "password", testAccRancher2DefaultAdminPass),
-					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "telemetry", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "current_password", testAccRancher2DefaultAdminPass),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "name", "foo-global"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "description", "Terraform catalog acceptance test"),
@@ -328,7 +322,6 @@ func TestAccRancher2Upgrade(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2BootstrapExists(testAccRancher2BootstrapType+".foo"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "password", testAccRancher2DefaultAdminPass),
-					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "telemetry", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "current_password", testAccRancher2DefaultAdminPass),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "name", "foo-global"),
 					resource.TestCheckResourceAttr(testAccRancher2CatalogType+".foo-global", "description", "Terraform catalog acceptance test"),

--- a/rancher2/resource_rancher2_bootstrap.go
+++ b/rancher2/resource_rancher2_bootstrap.go
@@ -38,17 +38,6 @@ func resourceRancher2BootstrapCreate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	// Set telemetry option
-	telemetry := "out"
-	if d.Get("telemetry").(bool) {
-		telemetry = "in"
-	}
-
-	err = meta.(*Config).SetSetting(bootstrapSettingTelemetry, telemetry)
-	if err != nil {
-		return err
-	}
-
 	// Set ui default landing option for rancher up to 2.5.0
 	if ok, _ := meta.(*Config).IsRancherVersionGreaterThanOrEqual(rancher2UILandingVersion); ok {
 		uiLanding := d.Get("ui_default_landing").(string)
@@ -142,18 +131,6 @@ func resourceRancher2BootstrapRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("url", url)
 
-	// Get telemetry
-	telemetry, err := meta.(*Config).GetSettingValue(bootstrapSettingTelemetry)
-	if err != nil {
-		return err
-	}
-
-	if telemetry == "in" {
-		d.Set("telemetry", true)
-	} else {
-		d.Set("telemetry", false)
-	}
-
 	return bootstrapCleanUpTempToken(d, meta)
 }
 
@@ -168,17 +145,6 @@ func resourceRancher2BootstrapUpdate(d *schema.ResourceData, meta interface{}) e
 
 	// Set rancher url
 	err = meta.(*Config).SetSetting(bootstrapSettingURL, meta.(*Config).URL)
-	if err != nil {
-		return err
-	}
-
-	// Set telemetry option
-	telemetry := "out"
-	if d.Get("telemetry").(bool) {
-		telemetry = "in"
-	}
-
-	err = meta.(*Config).SetSetting(bootstrapSettingTelemetry, telemetry)
 	if err != nil {
 		return err
 	}

--- a/rancher2/resource_rancher2_bootstrap_test.go
+++ b/rancher2/resource_rancher2_bootstrap_test.go
@@ -31,7 +31,6 @@ provider "rancher2" {
 	testAccRancher2BootstrapConfig = testAccRancher2ProviderConfig + `
 resource "` + testAccRancher2BootstrapType + `" "foo" {
   password = "` + testAccRancher2BootstrapPass + `"
-  telemetry = true
 }
 `
 
@@ -53,7 +52,6 @@ func TestAccRancher2Bootstrap_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2BootstrapExists(testAccRancher2BootstrapType+".foo"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "password", testAccRancher2BootstrapPass),
-					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "telemetry", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "current_password", testAccRancher2BootstrapPass),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "ui_default_landing", bootstrapUILandingManager),
 				),
@@ -63,7 +61,6 @@ func TestAccRancher2Bootstrap_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2BootstrapExists(testAccRancher2BootstrapType+".foo"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "password", testAccRancher2BootstrapPass),
-					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "telemetry", "false"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "current_password", testAccRancher2BootstrapPass),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "ui_default_landing", bootstrapUILandingExplorer),
 				),
@@ -73,7 +70,6 @@ func TestAccRancher2Bootstrap_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRancher2BootstrapExists(testAccRancher2BootstrapType+".foo"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "password", testAccRancher2BootstrapPass),
-					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "telemetry", "true"),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "current_password", testAccRancher2BootstrapPass),
 					resource.TestCheckResourceAttr(testAccRancher2BootstrapType+".foo", "ui_default_landing", bootstrapUILandingManager),
 				),

--- a/rancher2/schema_bootstrap.go
+++ b/rancher2/schema_bootstrap.go
@@ -13,7 +13,6 @@ const (
 	bootstrapDefaultTTL         = "60000"
 	bootstrapSettingUILanding   = "ui-default-landing"
 	bootstrapSettingURL         = "server-url"
-	bootstrapSettingTelemetry   = "telemetry-opt"
 	bootstrapUILandingExplorer  = "vue"
 	bootstrapUILandingManager   = "ember"
 )
@@ -58,11 +57,6 @@ func bootstrapFields() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"token_update": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-		},
-		"telemetry": {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,


### PR DESCRIPTION
This PR removes the `telemetry` field from the `rancher2_bootstrap` resource. It also removes related code and documentation. This is part of the work associated with SURE-9295, which is about removing legacy telemetry from Rancher Manager. Please see that issue for related PRs in other repositories.

Looking at https://github.com/rancher/terraform-provider-rancher2?tab=readme-ov-file#branching-the-provider, this PR should only be merged into `release/v7` because legacy telemetry will be removed in Rancher Manager 2.11. I don't think `release/v7` exists yet, so I have added the `version/rancher-v2.11` label to this PR.