### PR TITLE
Enable provisioning of Windows nodes using vSphere templates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
           CROSS: 1
           VERSION: ${{ github.ref_name }}
         run: |
-          make build-rancher
+          make build
 
       - name: package
         run: |

--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -978,6 +978,7 @@ see more information on [Resource Management for Pods and Containers](https://ku
 * `max_unhealthy` - (Optional, string) Max unhealthy nodes for automated replacement to be allowed.
 * `unhealthy_range` - (Optional, string) Range of unhealthy nodes for automated replacement to be allowed.
 * `machine_labels` - (Optional, map) Labels for Machine pool nodes.
+* `machine_os` - (Optional) OS Type in machine pool. Default `linux`(string)
 * `labels` - (Optional, map) Labels for Machine Deployment Resource.
 * `annotations` - (Optional, map) Annotations for Machine Deployment Resource. 
 

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -315,6 +315,7 @@ The following attributes are exported:
 * `memory_size` - (Optional) vSphere size of memory for docker VM (in MB). Default `2048` (string)
 * `network` - (Optional) vSphere network where the docker VM will be attached (list)
 * `pool` - (Optional) vSphere resource pool for docker VM (string)
+* `os` - (Optional) Type of virtual machine OS in vSphere. Default `linux`(string)
 * `ssh_password` - (Optional) If using a non-B2D image you can specify the ssh password. Default `tcuser` (string)
 * `ssh_port` - (Optional) If using a non-B2D image you can specify the ssh port. Default `22` (string)
 * `ssh_user` - (Optional) If using a non-B2D image you can specify the ssh user. Default `docker`. (string)

--- a/docs/resources/node_template.md
+++ b/docs/resources/node_template.md
@@ -436,6 +436,7 @@ The following attributes are exported:
 * `network` - (Optional) vSphere network where the docker VM will be attached (list)
 * `password` - (Optional/Sensitive) vSphere password. Mandatory on Rancher v2.0.x and v2.1.x. Use `rancher2_cloud_credential` from Rancher v2.2.x (string)
 * `pool` - (Optional) vSphere resource pool for docker VM (string)
+* `os` - (Optional) Type of virtual machine OS in vSphere. Default `linux`(string)
 * `ssh_password` - (Optional) If using a non-B2D image you can specify the ssh password. Default `tcuser`. From Rancher v2.3.3 (string)
 * `ssh_port` - (Optional) If using a non-B2D image you can specify the ssh port. Default `22`. From Rancher v2.3.3 (string)
 * `ssh_user` - (Optional) If using a non-B2D image you can specify the ssh user. Default `docker`. From Rancher v2.3.3 (string)

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/rancher/terraform-provider-rancher2/rancher2"
+	"github.com/ihor.kolomiiets/terraform-provider-rancher2/rancher2"
 )
 
 func main() {

--- a/rancher2/schema_cluster_v2_rke_config_machine_pool.go
+++ b/rancher2/schema_cluster_v2_rke_config_machine_pool.go
@@ -145,6 +145,12 @@ func clusterV2RKEConfigMachinePoolFields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "range of unhealthy nodes for automated replacement to be allowed",
 		},
+		"machine_os": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "linux",
+			Description: "OS Type in machine pool",
+		},
 		"machine_labels": {
 			Type:        schema.TypeMap,
 			Optional:    true,

--- a/rancher2/schema_machine_config_v2_vsphere.go
+++ b/rancher2/schema_machine_config_v2_vsphere.go
@@ -39,6 +39,12 @@ func machineConfigV2VmwarevsphereFields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "If you choose creation type clone a name of what you want to clone is required",
 		},
+		"os": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "linux",
+			Description: "Type of virtual machine OS in vSphere",
+		},
 		"cloud_config": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/rancher2/schema_node_template_vsphere.go
+++ b/rancher2/schema_node_template_vsphere.go
@@ -32,6 +32,7 @@ type vmwarevsphereConfig struct {
 	Datacenter              string   `json:"datacenter,omitempty" yaml:"datacenter,omitempty"`
 	Datastore               string   `json:"datastore,omitempty" yaml:"datastore,omitempty"`
 	DatastoreCluster        string   `json:"datastoreCluster,omitempty" yaml:"datastoreCluster,omitempty"`
+	OS                      string   `json:"os,omitempty" yaml:"os,omitempty"`
 	DiskSize                string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
 	Folder                  string   `json:"folder,omitempty" yaml:"folder,omitempty"`
 	Hostsystem              string   `json:"hostsystem,omitempty" yaml:"hostsystem,omitempty"`
@@ -122,6 +123,12 @@ func vsphereConfigFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "vSphere datastore for virtual machine",
+		},
+		"os": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "linux",
+			Description: "Type of virtual machine OS in vSphere",
 		},
 		"datastore_cluster": {
 			Type:        schema.TypeString,

--- a/rancher2/structure_cluster_v2_rke_config_machine_pool.go
+++ b/rancher2/structure_cluster_v2_rke_config_machine_pool.go
@@ -97,6 +97,9 @@ func flattenClusterV2RKEConfigMachinePools(p []provisionv1.RKEMachinePool) []int
 		if in.MaxUnhealthy != nil {
 			obj["max_unhealthy"] = *in.MaxUnhealthy
 		}
+		if len(in.MachineOS) > 0 {
+			obj["machine_os"] = in.MachineOS
+		}
 		if in.UnhealthyRange != nil {
 			obj["unhealthy_range"] = *in.UnhealthyRange
 		}
@@ -221,6 +224,9 @@ func expandClusterV2RKEConfigMachinePools(p []interface{}) []provisionv1.RKEMach
 		}
 		if v, ok := in["max_unhealthy"].(string); ok && len(v) > 0 {
 			obj.MaxUnhealthy = &v
+		}
+		if v, ok := in["machine_os"].(string); ok && len(v) > 0 {
+			obj.MachineOS = v
 		}
 		if v, ok := in["unhealthy_range"].(string); ok && len(v) > 0 {
 			obj.UnhealthyRange = &v

--- a/rancher2/structure_cluster_v2_rke_config_machine_pool_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_machine_pool_test.go
@@ -128,6 +128,7 @@ func init() {
 			"max_unhealthy":                  "2",
 			"unhealthy_range":                "[2,5]",
 			"hostname_length_limit":          16,
+			"machineOS":                      "linux",
 		},
 	}
 }

--- a/rancher2/structure_machine_config_v2_vsphere.go
+++ b/rancher2/structure_machine_config_v2_vsphere.go
@@ -29,6 +29,7 @@ type machineConfigV2Vmwarevsphere struct {
 	Datacenter              string   `json:"datacenter,omitempty" yaml:"datacenter,omitempty"`
 	Datastore               string   `json:"datastore,omitempty" yaml:"datastore,omitempty"`
 	DatastoreCluster        string   `json:"datastoreCluster,omitempty" yaml:"datastoreCluster,omitempty"`
+	OS                      string   `json:"os,omitempty" yaml:"os,omitempty"`
 	DiskSize                string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
 	Folder                  string   `json:"folder,omitempty" yaml:"folder,omitempty"`
 	Hostsystem              string   `json:"hostsystem,omitempty" yaml:"hostsystem,omitempty"`
@@ -100,6 +101,9 @@ func flattenMachineConfigV2Vmwarevsphere(in *MachineConfigV2Vmwarevsphere) []int
 	}
 	if len(in.DatastoreCluster) > 0 {
 		obj["datastore_cluster"] = in.DatastoreCluster
+	}
+	if len(in.OS) > 0 {
+		obj["os"] = in.OS
 	}
 	if len(in.DiskSize) > 0 {
 		obj["disk_size"] = in.DiskSize
@@ -218,6 +222,9 @@ func expandMachineConfigV2Vmwarevsphere(p []interface{}, source *MachineConfigV2
 	}
 	if v, ok := in["datastore_cluster"].(string); ok && len(v) > 0 {
 		obj.DatastoreCluster = v
+	}
+	if v, ok := in["os"].(string); ok && len(v) > 0 {
+		obj.OS = v
 	}
 	if v, ok := in["disk_size"].(string); ok && len(v) > 0 {
 		obj.DiskSize = v

--- a/rancher2/structure_node_template_vsphere.go
+++ b/rancher2/structure_node_template_vsphere.go
@@ -44,6 +44,9 @@ func flattenVsphereConfig(in *vmwarevsphereConfig) []interface{} {
 	if len(in.DatastoreCluster) > 0 {
 		obj["datastore_cluster"] = in.DatastoreCluster
 	}
+	if len(in.OS) > 0 {
+		obj["os"] = in.OS
+	}
 	if len(in.DiskSize) > 0 {
 		obj["disk_size"] = in.DiskSize
 	}
@@ -152,6 +155,9 @@ func expandVsphereConfig(p []interface{}) *vmwarevsphereConfig {
 	}
 	if v, ok := in["datastore_cluster"].(string); ok && len(v) > 0 {
 		obj.DatastoreCluster = v
+	}
+	if v, ok := in["os"].(string); ok && len(v) > 0 {
+		obj.OS = v
 	}
 	if v, ok := in["disk_size"].(string); ok && len(v) > 0 {
 		obj.DiskSize = v


### PR DESCRIPTION
This PR adds support for provisioning Windows nodes using vSphere templates in the Rancher2 provider. It enables users to create and manage Windows-based nodes using the same vSphere template logic as for Linux nodes.

## Changes
- Modified the Rancher2 provider to support Windows machine pool in cluster_v2
- Updated the provider logic to handle vSphere Windows template.
- Added new string into tests to ensure proper functionality for Windows nodes.

## Related Issues
- Closes [https://github.com/rancher/terraform-provider-rancher2/issues/1193]
- Closes [https://github.com/rancher/terraform-provider-rancher2/issues/1090]
