### PR TITLE
[backport] correct the field name outbound_type

### DIFF
--- a/rancher2/schema_cluster_aks_config_v2.go
+++ b/rancher2/schema_cluster_aks_config_v2.go
@@ -14,7 +14,7 @@ var (
 	clusterAKSOutboundType = []string{"loadbalancer", "managednatgateway", "userassignednatgateway", "userdefinedrouting"}
 )
 
-//Schemas
+// Schemas
 
 func clusterAKSConfigV2NodePoolsFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
@@ -268,7 +268,7 @@ func clusterAKSConfigV2Fields() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "The AKS node resource group name",
 		},
-		"outboung_type": {
+		"outbound_type": {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Default:      "loadBalancer",


### PR DESCRIPTION
https://github.com/rancher/terraform-provider-rancher2/issues/1443


This PR is a backport of the PR https://github.com/rancher/terraform-provider-rancher2/pull/1448 to correct the typo on the field name outbound_type, 