### PR TITLE
Add support for group_membership_filter in azuread

### DIFF
--- a/rancher2/00_provider_test.go
+++ b/rancher2/00_provider_test.go
@@ -35,7 +35,7 @@ func init() {
 	testAccRancher2AdminPass = testAccRancher2DefaultAdminPass
 	err := testAccCheck()
 	if err != nil {
-		log.Fatalf("%v", err)
+		log.Fatalf("failed check %s", err)
 	}
 }
 
@@ -64,14 +64,8 @@ func testAccCheck() error {
 		secretKey := os.Getenv("RANCHER_SECRET_KEY")
 		caCerts := os.Getenv("RANCHER_CA_CERTS")
 		adminPass := os.Getenv("RANCHER_ADMIN_PASS")
-		insecure := false
-		if os.Getenv("RANCHER_INSECURE") == "true" {
-			insecure = true
-		}
-		bootstrap := false
-		if os.Getenv("RANCHER_BOOTSTRAP") == "true" {
-			bootstrap = true
-		}
+		insecure := os.Getenv("RANCHER_INSECURE") == "true"
+		bootstrap := os.Getenv("RANCHER_BOOTSTRAP") == "true"
 
 		if apiURL == "" {
 			return fmt.Errorf("RANCHER_URL must be set for acceptance tests")
@@ -96,12 +90,12 @@ func testAccCheck() error {
 		if len(tokenKey) > 5 {
 			err := testAccClusterDefaultName(testAccProviderConfig)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to test the default cluster name: %w", err)
 			}
 
 			testAccRancher2ClusterRKEK8SDefaultVersion, err = testAccProviderConfig.getK8SDefaultVersion()
 			if err != nil {
-				return err
+				return fmt.Errorf("failed get the default k8s version: %w", err)
 			}
 		}
 	}

--- a/rancher2/resource_rancher2_auth_config_azuread_test.go
+++ b/rancher2/resource_rancher2_auth_config_azuread_test.go
@@ -33,6 +33,19 @@ resource "` + testAccRancher2AuthConfigAzureADType + `" "azuread" {
   token_endpoint = "token"
 }
  `
+
+	testAccRancher2AuthConfigAzureADConfigWithUserGroupFilter = `
+resource "` + testAccRancher2AuthConfigAzureADType + `" "azuread" {
+  application_id = "XXXXXX"
+  application_secret = "YYYYYYYY"
+  auth_endpoint = "authorize-updated"
+  graph_endpoint = "graph"
+  rancher_url = "https://RANCHER-UPDATED"
+  tenant_id = "ZZZZZZZZ"
+  token_endpoint = "token"
+  group_membership_filter = "startswith(displayName, 'test')"
+}
+ `
 )
 
 func TestAccRancher2AuthConfigAzureAD_basic(t *testing.T) {
@@ -74,6 +87,14 @@ func TestAccRancher2AuthConfigAzureAD_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AuthConfigAzureADName, "rancher_url", "https://RANCHER"),
 					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AuthConfigAzureADName, "application_secret", "XXXXXXXX"),
 					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AuthConfigAzureADName, "tenant_id", "XXXXXXXX"),
+				),
+			},
+			{
+				Config: testAccRancher2AuthConfigAzureADConfigWithUserGroupFilter,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2AuthConfigExists(testAccRancher2AuthConfigAzureADType+"."+AuthConfigAzureADName, authConfig),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AuthConfigAzureADName, "tenant_id", "ZZZZZZZZ"),
+					resource.TestCheckResourceAttr(testAccRancher2AuthConfigAzureADType+"."+AuthConfigAzureADName, "group_membership_filter", "startswith(displayName, 'test')"),
 				),
 			},
 		},

--- a/rancher2/schema_auth_config_azuread.go
+++ b/rancher2/schema_auth_config_azuread.go
@@ -45,6 +45,10 @@ func authConfigAzureADFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Required: true,
 		},
+		"group_membership_filter": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
 	}
 
 	for k, v := range authConfigFields() {

--- a/rancher2/structure_auth_config_azuread.go
+++ b/rancher2/structure_auth_config_azuread.go
@@ -38,6 +38,7 @@ func flattenAuthConfigAzureAD(d *schema.ResourceData, in *managementClient.Azure
 	d.Set("rancher_url", in.RancherURL)
 	d.Set("tenant_id", in.TenantID)
 	d.Set("token_endpoint", in.TokenEndpoint)
+	d.Set("group_membership_filter", in.GroupMembershipFilter)
 
 	return nil
 }
@@ -107,6 +108,10 @@ func expandAuthConfigAzureAD(in *schema.ResourceData) (*managementClient.AzureAD
 
 	if v, ok := in.Get("token_endpoint").(string); ok {
 		obj.TokenEndpoint = v
+	}
+
+	if v, ok := in.Get("group_membership_filter").(string); ok {
+		obj.GroupMembershipFilter = v
 	}
 
 	return obj, nil

--- a/rancher2/structure_auth_config_azuread_test.go
+++ b/rancher2/structure_auth_config_azuread_test.go
@@ -16,37 +16,38 @@ var (
 
 func init() {
 	testAuthConfigAzureADConf = &managementClient.AzureADConfig{
-		Name:                AuthConfigAzureADName,
-		Type:                managementClient.AzureADConfigType,
-		AccessMode:          "access",
-		AllowedPrincipalIDs: []string{"allowed1", "allowed2"},
-		Enabled:             true,
-		ApplicationID:       "application_id",
-		AuthEndpoint:        "auth_endpoint",
-		Endpoint:            "endpoint",
-		GraphEndpoint:       "graph_endpoint",
-		RancherURL:          "rancher_url",
-		TenantID:            "tenant_id",
-		TokenEndpoint:       "token_endpoint",
+		Name:                  AuthConfigAzureADName,
+		Type:                  managementClient.AzureADConfigType,
+		AccessMode:            "access",
+		AllowedPrincipalIDs:   []string{"allowed1", "allowed2"},
+		Enabled:               true,
+		ApplicationID:         "application_id",
+		AuthEndpoint:          "auth_endpoint",
+		Endpoint:              "endpoint",
+		GraphEndpoint:         "graph_endpoint",
+		RancherURL:            "rancher_url",
+		TenantID:              "tenant_id",
+		TokenEndpoint:         "token_endpoint",
+		GroupMembershipFilter: "startswith(displayName,'test')",
 	}
 	testAuthConfigAzureADInterface = map[string]interface{}{
-		"name":                  AuthConfigAzureADName,
-		"type":                  managementClient.AzureADConfigType,
-		"access_mode":           "access",
-		"allowed_principal_ids": []interface{}{"allowed1", "allowed2"},
-		"enabled":               true,
-		"application_id":        "application_id",
-		"auth_endpoint":         "auth_endpoint",
-		"endpoint":              "endpoint",
-		"graph_endpoint":        "graph_endpoint",
-		"rancher_url":           "rancher_url",
-		"tenant_id":             "tenant_id",
-		"token_endpoint":        "token_endpoint",
+		"name":                    AuthConfigAzureADName,
+		"type":                    managementClient.AzureADConfigType,
+		"access_mode":             "access",
+		"allowed_principal_ids":   []interface{}{"allowed1", "allowed2"},
+		"enabled":                 true,
+		"application_id":          "application_id",
+		"auth_endpoint":           "auth_endpoint",
+		"endpoint":                "endpoint",
+		"graph_endpoint":          "graph_endpoint",
+		"rancher_url":             "rancher_url",
+		"tenant_id":               "tenant_id",
+		"token_endpoint":          "token_endpoint",
+		"group_membership_filter": "startswith(displayName,'test')",
 	}
 }
 
 func TestFlattenAuthConfigAzureAD(t *testing.T) {
-
 	cases := []struct {
 		Input          *managementClient.AzureADConfig
 		ExpectedOutput map[string]interface{}
@@ -75,7 +76,6 @@ func TestFlattenAuthConfigAzureAD(t *testing.T) {
 }
 
 func TestExpandAuthConfigAzureAD(t *testing.T) {
-
 	cases := []struct {
 		Input          map[string]interface{}
 		ExpectedOutput *managementClient.AzureADConfig


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/46209
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
It's not currently possible to configure the user-group filter from Terraform.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
This adds support for configuring the `group_memembership_filter` for Azure which configures a filter for querying groups for a user.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Configured a simple "azuread" resource...

```hcl
resource "rancher2_auth_config_azuread" "azuread" {
 // other fields omitted for simplicity
  group_membership_filter = "startswith(displayName,'admin')"
}
```

And confirmed that these are configured on the azuread `AuthConfig` resource, and that they are updated when changed.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->
Tests were added for the new behaviour.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->