### PR TITLE
Add service account for node pool in GKE cluster

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -1819,6 +1819,7 @@ The following arguments are supported:
 * `preemptible` - (Optional) Enable GKE node config preemptible. Default: `false` (bool)
 * `tags` - (Optional/Computed) The GKE node config tags (List)
 * `taints` - (Optional) The GKE node config taints (List)
+* `service_account` - (Optional) The GKE Service Account to be used by the node VMs (string)
 
 ###### `taints`
 

--- a/rancher2/schema_cluster_gke_config_v2.go
+++ b/rancher2/schema_cluster_gke_config_v2.go
@@ -243,6 +243,11 @@ func clusterGKEConfigV2NodeConfigFields() map[string]*schema.Schema {
 				Schema: clusterGKEConfigV2NodeTaintFields(),
 			},
 		},
+		"service_account": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The GKE node config service account",
+		},
 	}
 
 	return s

--- a/rancher2/structure_cluster_gke_config_v2.go
+++ b/rancher2/structure_cluster_gke_config_v2.go
@@ -164,6 +164,9 @@ func flattenClusterGKEConfigV2NodeConfig(in *managementClient.GKENodeConfig) []i
 	if len(in.Taints) > 0 {
 		obj["taints"] = flattenClusterGKEConfigV2NodeTaintsConfig(in.Taints)
 	}
+	if len(in.ServiceAccount) > 0 {
+		obj["service_account"] = in.ServiceAccount
+	}
 
 	return []interface{}{obj}
 }
@@ -491,6 +494,9 @@ func expandClusterGKEConfigV2NodeConfig(p []interface{}) *managementClient.GKENo
 	}
 	if v, ok := in["taints"].([]interface{}); ok && len(v) > 0 {
 		obj.Taints = expandClusterGKEConfigV2NodeTaintsConfig(v)
+	}
+	if v, ok := in["service_account"].(string); ok && len(v) > 0 {
+		obj.ServiceAccount = v
 	}
 	return obj
 }

--- a/rancher2/structure_cluster_gke_config_v2_test.go
+++ b/rancher2/structure_cluster_gke_config_v2_test.go
@@ -123,12 +123,13 @@ func init() {
 			"label1": "value1",
 			"label2": "value2",
 		},
-		LocalSsdCount: int64(1),
-		MachineType:   "machine_type",
-		OauthScopes:   []string{"oauth1", "oauth1"},
-		Preemptible:   true,
-		Tags:          []string{"tags1", "tags2"},
-		Taints:        testClusterGKEConfigV2NodeTaintsConfigConf,
+		LocalSsdCount:  int64(1),
+		MachineType:    "machine_type",
+		OauthScopes:    []string{"oauth1", "oauth1"},
+		Preemptible:    true,
+		Tags:           []string{"tags1", "tags2"},
+		Taints:         testClusterGKEConfigV2NodeTaintsConfigConf,
+		ServiceAccount: "test@example.com",
 	}
 	testClusterGKEConfigV2NodeConfigInterface = []interface{}{
 		map[string]interface{}{
@@ -145,6 +146,7 @@ func init() {
 			"preemptible":     true,
 			"tags":            []interface{}{"tags1", "tags2"},
 			"taints":          testClusterGKEConfigV2NodeTaintsConfigInterface,
+			"service_account": "test@example.com",
 		},
 	}
 	testClusterGKEConfigV2NodePoolsManagementConf = &managementClient.GKENodePoolManagement{


### PR DESCRIPTION
Add ability to specify a service account for a node pool in a GKE cluster

Issue: https://github.com/rancher/gke-operator/issues/262
