### PR TITLE
fix: validate signature before release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,6 @@ jobs:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/key/app-credentials passphrase | GPG_PASSPHRASE ;
             secret/data/github/repo/${{ github.repository }}/key/app-credentials privateKey | GPG_KEY
-
       - name: sign shasum
         env:
           GPG_KEY: ${{ env.GPG_KEY }}
@@ -43,6 +42,14 @@ jobs:
           SHASUM_FILE="dist/artifacts/${{ github.ref_name }}/terraform-provider-rancher2_${VERSION_NO_V}_SHA256SUMS"
           echo '${{ env.GPG_PASSPHRASE }}' | gpg --detach-sig --pinentry-mode loopback --passphrase-fd 0 --output "${SHASUM_FILE}.sig" --sign "${SHASUM_FILE}"
 
+          echo "Validating signature..."
+          gpg --verify "${SHASUM_FILE}.sig" "${SHASUM_FILE}"
+          if [ $? -eq 0 ]; then
+            echo "Signature is valid..."
+          else
+            echo "Signature verification failed!"
+            exit 1
+          fi
       - name: GH release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/key/app-credentials passphrase | GPG_PASSPHRASE ;
             secret/data/github/repo/${{ github.repository }}/key/app-credentials privateKey | GPG_KEY
+
       - name: sign shasum
         env:
           GPG_KEY: ${{ env.GPG_KEY }}


### PR DESCRIPTION
This is meant to catch gpg signing issues on our side before attempting to publish to the Terraform registry.