### PR TITLE
fix: validate signature before release (#1483)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,14 @@ jobs:
           SHASUM_FILE="dist/artifacts/${{ github.ref_name }}/terraform-provider-rancher2_${VERSION_NO_V}_SHA256SUMS"
           echo '${{ env.GPG_PASSPHRASE }}' | gpg --detach-sig --pinentry-mode loopback --passphrase-fd 0 --output "${SHASUM_FILE}.sig" --sign "${SHASUM_FILE}"
 
+          echo "Validating signature..."
+          gpg --verify "${SHASUM_FILE}.sig" "${SHASUM_FILE}"
+          if [ $? -eq 0 ]; then
+            echo "Signature is valid..."
+          else
+            echo "Signature verification failed!"
+            exit 1
+          fi
       - name: GH release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Backport of #1483 to release/v6
Signed-off-by: matttrach <matt.trachier@suse.com>
(cherry picked from commit f356f5a64655bc91bebaaf72bd81c19d57cffeb2)
