### PR TITLE
fix: Allow for int values

### DIFF
--- a/rancher2/structure_cluster_v2_rke_config_machine_pool.go
+++ b/rancher2/structure_cluster_v2_rke_config_machine_pool.go
@@ -142,11 +142,11 @@ func expandClusterV2RKEConfigMachinePoolRollingUpdate(p []interface{}) *provisio
 	in := p[0].(map[string]interface{})
 
 	if v, ok := in["max_surge"].(string); ok && len(v) > 0 {
-		maxSurge := intstr.FromString(v)
+		maxSurge := intstr.Parse(v)
 		obj.MaxSurge = &maxSurge
 	}
 	if v, ok := in["max_unavailable"].(string); ok && len(v) > 0 {
-		maxUnavailable := intstr.FromString(v)
+		maxUnavailable := intstr.Parse(v)
 		obj.MaxUnavailable = &maxUnavailable
 	}
 


### PR DESCRIPTION
Replace intstr.FromString with intstr.Parse to allow for int values (#1496)

(cherry picked from commit f9b095c165f88689faeb853fde2d3dea4f2fe85b)
