### PR TITLE
fix: add support for imported cluster config

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -20,7 +20,19 @@ resource "rancher2_cluster" "foo-imported" {
 }
 ```
 
-Creating Rancher v2 RKE cluster
+### Creating Rancher v2 imported cluster with custom configuration. For Rancher v2.11.x and above.
+
+```hcl
+# Create a new rancher2 imported Cluster with custom configuration 
+resource "rancher2_cluster" "foo-imported" {
+  name        = "foo-imported"
+  imported_config {
+    private_registry_url = "test.io"
+  }
+}
+```
+
+### Creating Rancher v2 RKE cluster
 
 ```hcl
 # Create auditlog policy yaml file
@@ -626,6 +638,7 @@ The following arguments are supported:
 * `eks_config_v2` - (Optional/Computed) The Amazon EKS V2 configuration to create or import `eks` Clusters. Conflicts with `gke_config_v2`, `k3s_config`, `oke_config` and `rke_config`. For Rancher v2.5.x and above (list maxitems:1)
 * `gke_config_v2` - (Optional) The Google GKE V2 configuration for `gke` Clusters. Conflicts with `aks_config_v2`, `eks_config_v2`, `k3s_config`, `oke_config` and `rke_config`. For Rancher v2.5.8 and above (list maxitems:1)
 * `oke_config` - (Optional) The Oracle OKE configuration for `oke` Clusters. Conflicts with `aks_config_v2`, `eks_config_v2`, `gke_config_v2`, `k3s_config` and `rke_config` (list maxitems:1)
+* `imported_config` - (Optional) The imported configuration for generic imported Clusters. Conflicts with `aks_config_v2`, `eks_config_v2`, `gke_config_v2`, `rke_config`, `rke2_config` and `k3s_config` (list maxitems:1)
 * `description` - (Optional) The description for Cluster (string)
 * `cluster_auth_endpoint` - (Optional/Computed) Enabling the [local cluster authorized endpoint](https://rancher.com/docs/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#local-cluster-auth-endpoint) allows direct communication with the cluster, bypassing the Rancher API proxy. (list maxitems:1)
 * `cluster_template_answers` - (Optional/Computed) Cluster template answers. For Rancher v2.3.x and above (list maxitems:1)
@@ -1824,6 +1837,12 @@ The following arguments are supported:
 * `type` - (Optional) Variable type. `boolean`, `int`, `password`, and `string` are allowed. Default `string` (string)
 * `variable` - (Optional) Variable name (string)
 
+### `imported_config`
+
+#### Arguments
+
+* `private_registry_url` - (Optional) The URL for a cluster-level private registry (string)
+
 ### `cluster_registration_token`
 
 #### Attributes
@@ -1840,7 +1859,6 @@ The following arguments are supported:
 * `windows_node_command` - (Computed) Node command to execute in windows nodes for custom k8s cluster (string)
 * `annotations` - (Computed) Annotations for cluster registration token object (map)
 * `labels` - (Computed) Labels for cluster registration token object (map)
-
 
 ## Timeouts
 

--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -148,12 +148,20 @@ func resourceRancher2ClusterCreate(d *schema.ResourceData, meta interface{}) err
 
 	expectedState := []string{"active"}
 
-	if cluster.Driver == clusterDriverImported || (cluster.Driver == clusterDriverEKSV2 && cluster.EKSConfig.Imported) {
+	if cluster.Driver == clusterDriverEKSV2 && cluster.EKSConfig.Imported {
 		expectedState = append(expectedState, "pending")
 	}
 
 	if cluster.Driver == clusterDriverRKE || cluster.Driver == clusterDriverK3S || cluster.Driver == clusterDriverRKE2 {
 		expectedState = append(expectedState, "provisioning")
+	}
+
+	if cluster.Driver == clusterDriverImported {
+		if cluster.ImportedConfig != nil {
+			expectedState = append(expectedState, "provisioning")
+		} else {
+			expectedState = append(expectedState, "pending")
+		}
 	}
 
 	// Creating cluster with monitoring disabled
@@ -331,6 +339,8 @@ func resourceRancher2ClusterUpdate(d *schema.ResourceData, meta interface{}) err
 	case clusterDriverRKE2:
 		update["rke2Config"] = expandClusterRKE2Config(d.Get("rke2_config").([]interface{}))
 		replace = d.HasChange("cluster_agent_deployment_customization")
+	case clusterDriverImported:
+		update["importedConfig"] = expandClusterImportedConfig(d.Get("imported_config").([]interface{}))
 	}
 
 	// update the cluster; retry til timeout or non retryable error is returned. If api 500 error is received,

--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -305,7 +305,7 @@ func clusterFields() map[string]*schema.Schema {
 			MaxItems:      1,
 			Optional:      true,
 			Computed:      true,
-			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "gke_config_v2", "k3s_config", "oke_config", "rke2_config"},
+			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "gke_config_v2", "k3s_config", "oke_config", "rke2_config", "imported_config"},
 			Elem: &schema.Resource{
 				Schema: clusterRKEConfigFields(),
 			},
@@ -315,7 +315,7 @@ func clusterFields() map[string]*schema.Schema {
 			MaxItems:      1,
 			Optional:      true,
 			Computed:      true,
-			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "gke_config_v2", "k3s_config", "oke_config", "rke_config"},
+			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "gke_config_v2", "k3s_config", "oke_config", "rke_config", "imported_config"},
 			Elem: &schema.Resource{
 				Schema: clusterRKE2ConfigFields(),
 			},
@@ -325,7 +325,7 @@ func clusterFields() map[string]*schema.Schema {
 			MaxItems:      1,
 			Optional:      true,
 			Computed:      true,
-			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "gke_config_v2", "rke_config", "oke_config", "rke2_config"},
+			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "gke_config_v2", "rke_config", "oke_config", "rke2_config", "imported_config"},
 			Elem: &schema.Resource{
 				Schema: clusterK3SConfigFields(),
 			},
@@ -335,7 +335,7 @@ func clusterFields() map[string]*schema.Schema {
 			MaxItems:      1,
 			Optional:      true,
 			Computed:      true,
-			ConflictsWith: []string{"aks_config_v2", "gke_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config"},
+			ConflictsWith: []string{"aks_config_v2", "gke_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config", "imported_config"},
 			Elem: &schema.Resource{
 				Schema: clusterEKSConfigV2Fields(),
 			},
@@ -344,7 +344,7 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"eks_config_v2", "gke_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config"},
+			ConflictsWith: []string{"eks_config_v2", "gke_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config", "imported_config"},
 			Elem: &schema.Resource{
 				Schema: clusterAKSConfigV2Fields(),
 			},
@@ -353,7 +353,7 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config"},
+			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config", "imported_config"},
 			Elem: &schema.Resource{
 				Schema: clusterGKEConfigV2Fields(),
 			},
@@ -362,9 +362,18 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "gke_config_v2", "k3s_config", "rke_config", "rke2_config"},
+			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "gke_config_v2", "k3s_config", "rke_config", "rke2_config", "imported_config"},
 			Elem: &schema.Resource{
 				Schema: clusterOKEConfigFields(),
+			},
+		},
+		"imported_config": {
+			Type:          schema.TypeList,
+			MaxItems:      1,
+			Optional:      true,
+			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "gke_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config"},
+			Elem: &schema.Resource{
+				Schema: clusterImportedConfigFields(),
 			},
 		},
 		"default_project_id": {

--- a/rancher2/schema_cluster_imported_config.go
+++ b/rancher2/schema_cluster_imported_config.go
@@ -1,0 +1,18 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+//Schemas
+
+func clusterImportedConfigFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"private_registry_url": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "Private registry URL",
+		},
+	}
+}

--- a/rancher2/structure_cluster.go
+++ b/rancher2/structure_cluster.go
@@ -2,7 +2,6 @@ package rancher2
 
 import (
 	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 )
@@ -192,6 +191,19 @@ func flattenCluster(d *schema.ResourceData, in *Cluster, clusterRegToken *manage
 			return err
 		}
 		err = d.Set("oke_config", okeConfig)
+		if err != nil {
+			return err
+		}
+	case clusterDriverImported:
+		v, ok := d.Get("imported_config").([]interface{})
+		if !ok {
+			v = []interface{}{}
+		}
+		importedConfig, err := flattenClusterImportedConfig(in.ImportedConfig, v)
+		if err != nil {
+			return err
+		}
+		err = d.Set("imported_config", importedConfig)
 		if err != nil {
 			return err
 		}
@@ -492,6 +504,10 @@ func expandCluster(in *schema.ResourceData) (*Cluster, error) {
 	if v, ok := in.Get("rke2_config").([]interface{}); ok && len(v) > 0 {
 		obj.Rke2Config = expandClusterRKE2Config(v)
 		obj.Driver = clusterDriverRKE2
+	}
+
+	if v, ok := in.Get("imported_config").([]interface{}); ok && len(v) > 0 {
+		obj.ImportedConfig = expandClusterImportedConfig(v)
 	}
 
 	if len(obj.Driver) == 0 {

--- a/rancher2/structure_cluster_imported_config.go
+++ b/rancher2/structure_cluster_imported_config.go
@@ -1,0 +1,36 @@
+package rancher2
+
+import managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
+
+func expandClusterImportedConfig(p []interface{}) *managementClient.ImportedConfig {
+	obj := &managementClient.ImportedConfig{}
+	if len(p) == 0 || p[0] == nil {
+		return obj
+	}
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["private_registry_url"].(string); ok && len(v) > 0 {
+		obj.PrivateRegistryURL = v
+	}
+
+	return obj
+}
+
+func flattenClusterImportedConfig(in *managementClient.ImportedConfig, p []interface{}) ([]interface{}, error) {
+	var obj map[string]interface{}
+	if len(p) == 0 || p[0] == nil {
+		obj = make(map[string]interface{})
+	} else {
+		obj = p[0].(map[string]interface{})
+	}
+
+	if in == nil {
+		return []interface{}{}, nil
+	}
+
+	if len(in.PrivateRegistryURL) > 0 {
+		obj["private_registry_url"] = in.PrivateRegistryURL
+	}
+
+	return []interface{}{obj}, nil
+}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/terraform-provider-rancher2/issues/1523
 
## Problem
Terraform currently does not support setting the `ImportedConfig` field explicitly. The assumption has been that Rancher creates an imported cluster automatically when no configuration is provided.

However, this assumption no longer holds as a new required field for supporting private registries was introduced for imported clusters. As a result, explicit support for `ImportedConfig` is now necessary.
 
## Solution
Introduced support for `imported_config` in `rancher2_cluster`. As far as I know, imported clusters are not supported with `rancher2_cluster2` since these are handled via the `v3/clusters` endpoint.

The resulting state differs slightly when `imported_config` is used so added the new state to the expected state list. However, this is consistent with the behavior observed when creating imported clusters directly through the Rancher API. The difference is not significant as the registration URL is correctly generated in both cases and the cluster becomes active after a successful import.
 
## Engineering Testing
Manual testing, created cluster using both old and new format: 
```
resource "rancher2_cluster" "foo" {
  name        = "foo"
}

resource "rancher2_cluster" "bar" {
  name        = "bar"
  imported_config {
    private_registry_url = "test102.io"
  }
}
```
