### PR TITLE
fix: block use of deprecated RKE config

### DIFF
--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -76,6 +76,7 @@ func resourceRancher2ClusterResourceV0() *schema.Resource {
 
 func resourceRancher2ClusterStateUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	if rkeConfigs, ok := rawState["rke_config"].([]interface{}); ok && len(rkeConfigs) > 0 {
+		log.Printf("[INFO] Rancher v2.12+ does not support RKE1. Please migrate clusters to RKE2 or K3s, or delete the related resources. More info: https://www.suse.com/c/rke-end-of-life-by-july-2025-replatform-to-rke2-or-k3s")
 		for i1 := range rkeConfigs {
 			if rkeConfig, ok := rkeConfigs[i1].(map[string]interface{}); ok && len(rkeConfig) > 0 {
 				if services, ok := rkeConfig["services"].([]interface{}); ok && len(services) > 0 {
@@ -179,6 +180,8 @@ func resourceRancher2ClusterCreate(d *schema.ResourceData, meta interface{}) err
 		clusterMap, _ := jsonToMapInterface(clusterStr)
 		clusterMap["gkeConfig"] = fixClusterGKEConfigV2(structToMap(cluster.GKEConfig))
 		err = client.APIBaseClient.Create(managementClient.ClusterType, clusterMap, newCluster)
+	} else if cluster.Driver == clusterDriverRKE {
+		return fmt.Errorf("[INFO] Rancher v2.12+ does not support RKE1. Please migrate clusters to RKE2 or K3s, or delete the related resources. More info: https://www.suse.com/c/rke-end-of-life-by-july-2025-replatform-to-rke2-or-k3s")
 	} else {
 		err = client.APIBaseClient.Create(managementClient.ClusterType, cluster, newCluster)
 	}
@@ -327,12 +330,7 @@ func resourceRancher2ClusterUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 		update["okeEngineConfig"] = okeConfig
 	case ToLower(clusterDriverRKE):
-		rkeConfig, err := expandClusterRKEConfig(d.Get("rke_config").([]interface{}), d.Get("name").(string))
-		if err != nil {
-			return err
-		}
-		update["rancherKubernetesEngineConfig"] = rkeConfig
-		replace = d.HasChange("rke_config")
+		return fmt.Errorf("[INFO] Rancher v2.12+ does not support RKE1. Please migrate clusters to RKE2 or K3s, or delete the related resources. More info: https://www.suse.com/c/rke-end-of-life-by-july-2025-replatform-to-rke2-or-k3s")
 	case clusterDriverK3S:
 		update["k3sConfig"] = expandClusterK3SConfig(d.Get("k3s_config").([]interface{}))
 		replace = d.HasChange("cluster_agent_deployment_customization")


### PR DESCRIPTION
## Issue
https://github.com/rancher/rancher/issues/50459

## Problem
The Terraform provider currently allows the use of the `rke_config` field in the `rancher2_cluster` resource, which is used to provision RKE1 clusters. With the deprecation of RKE1 in Rancher v2.12, continuing to support this field can lead to unsupported configurations and unclear user experiences.

## Solution
This PR adds validation to explicitly block usage of `rke_config` during both create and update operations. When `rke_config` is detected, a clear error is returned, informing users of the deprecation. This mirrors Rancher's UI behavior and helps users transition away from RKE1. Full removal of the field is planned for a future release.

## Testing

### Engineering Testing

#### Manual Testing
- Applied a cluster config with `rke_config` and verified that the provider throws a clear, actionable error.
- Verified that other cluster types (EKS, GKE, AKS, etc.) continue to work unaffected.

#### Automated Testing
- No new test cases added, as the change introduces a hard failure path.
- Existing RKE1-related tests will be removed or skipped in a follow-up.

## QA Testing Considerations
- Confirm that creating or updating a `rancher2_cluster` using `rke_config` fails with the correct error message.
- Ensure other cluster drivers (e.g., `eks_config`, `gke_config`, `imported_config`) continue to work as expected.
- Test upgrade scenario:
  - Create an RKE1 cluster using an older version of the provider.
  - Upgrade to v2.12.
  - Run `terraform plan` or `apply` and confirm the new error behavior.

### Regressions Considerations
- Low regression risk due to the targeted nature of the change.
- Only affects users who define `rke_config` explicitly in config.
- Other parts of `rancher2_cluster` and `rancher2_cluster_v2` are unaffected.
