### PR TITLE
fix: specify signing key

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,9 +28,9 @@ jobs:
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
-            secret/data/github/repo/${{ github.repository }}/key/app-credentials passphrase | GPG_PASSPHRASE ;
-            secret/data/github/repo/${{ github.repository }}/key/app-credentials privateKeyId | GPG_KEY_ID ;
-            secret/data/github/repo/${{ github.repository }}/key/app-credentials privateKey | GPG_KEY
+            secret/data/github/repo/${{ github.repository }}/signing/gpg passphrase | GPG_PASSPHRASE ;
+            secret/data/github/repo/${{ github.repository }}/signing/gpg privateKeyId | GPG_KEY_ID ;
+            secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
 
       - name: sign shasum
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,19 +29,22 @@ jobs:
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/key/app-credentials passphrase | GPG_PASSPHRASE ;
+            secret/data/github/repo/${{ github.repository }}/key/app-credentials privateKeyId | GPG_KEY_ID ;
             secret/data/github/repo/${{ github.repository }}/key/app-credentials privateKey | GPG_KEY
 
       - name: sign shasum
         env:
           GPG_KEY: ${{ env.GPG_KEY }}
+          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
         run: |
           echo "Importing gpg key"
           echo -n '${{ env.GPG_KEY }}' | gpg --import --batch > /dev/null
+
           echo "signing SHASUM file"
           VERSION_NO_V="$(echo ${{ github.ref_name }} | tr -d 'v')"
           SHASUM_FILE="dist/artifacts/${{ github.ref_name }}/terraform-provider-rancher2_${VERSION_NO_V}_SHA256SUMS"
-          echo '${{ env.GPG_PASSPHRASE }}' | gpg --detach-sig --pinentry-mode loopback --passphrase-fd 0 --output "${SHASUM_FILE}.sig" --sign "${SHASUM_FILE}"
+          echo '${{ env.GPG_PASSPHRASE }}' | gpg --detach-sig --pinentry-mode loopback --passphrase-fd 0 --local-user "${{ env.GPG_KEY_ID }}" --output "${SHASUM_FILE}.sig" --sign "${SHASUM_FILE}"
 
           echo "Validating signature..."
 


### PR DESCRIPTION
Release is blocked due to a signing error, seems like the secret key is not being selected appropriately by default.
This change specifies the key to use for signing, it relies on a new secret privateKeyId. 