### PR TITLE
fix: update label field to match latest version

### DIFF
--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -343,7 +343,7 @@ The following attributes are exported:
 * `disk_type` - (Required) GCE Instance Disk Type (string)
 * `external_firewall_rule_prefix` - (Optional) A prefix to be added to firewall rules created when exposing ports publicly. Required if exposing ports publicly via the `open_port` field. (string)
 * `internal_firewall_rule_prefix` - (Optional) A prefix to be added to an internal firewall rule created to ensure virtual machines can communicate with one another. Omitting this field will result in an internal firewall rule not being created. (string)
-* `labels` - (Optional) A set of labels to be added to each VM, in the format of 'key1,value1,key2,value2' (string)
+* `vm_labels` - (Optional) A set of labels to be added to each VM, in the format of 'key1,value1,key2,value2' (string)
 * `machine_image` - (Required) GCE instance image absolute URL (string)
 * `machine_type` - (Required) GCE instance type (string)
 * `network` - (Required) The network to provision virtual machines within (string)

--- a/rancher2/schema_machine_config_v2_googlegce.go
+++ b/rancher2/schema_machine_config_v2_googlegce.go
@@ -35,7 +35,7 @@ func machineConfigV2GoogleGCEFields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "A prefix to be added to an internal firewall rule created to ensure virtual machines can communicate with one another.",
 		},
-		"labels": {
+		"vm_labels": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "A set of labels to be added to each VM, in the format of 'key1,value1,key2,value2'",

--- a/rancher2/structure_machine_config_v2_googlegce.go
+++ b/rancher2/structure_machine_config_v2_googlegce.go
@@ -20,7 +20,7 @@ type machineConfigV2GoogleGCE struct {
 	DiskType                   string   `json:"diskType,omitempty" yaml:"diskType,omitempty"`
 	ExternalFirewallRulePrefix string   `json:"externalFirewallRulePrefix,omitempty" yaml:"externalFirewallRulePrefix,omitempty"`
 	InternalFirewallRulePrefix string   `json:"internalFirewallRulePrefix,omitempty" yaml:"internalFirewallRulePrefix,omitempty"`
-	Labels                     string   `json:"labels,omitempty" yaml:"labels,omitempty"`
+	VMLabels                   string   `json:"vmLabels,omitempty" yaml:"vmLabels,omitempty"`
 	MachineImage               string   `json:"machineImage,omitempty" yaml:"machineImage,omitempty"`
 	MachineType                string   `json:"machineType,omitempty" yaml:"machineType,omitempty"`
 	Network                    string   `json:"network,omitempty" yaml:"network,omitempty"`
@@ -73,8 +73,8 @@ func flattenMachineConfigV2GoogleGCE(in *MachineConfigV2GoogleGCE) []interface{}
 		obj["internal_firewall_rule_prefix"] = in.InternalFirewallRulePrefix
 	}
 
-	if len(in.Labels) > 0 {
-		obj["labels"] = in.Labels
+	if len(in.VMLabels) > 0 {
+		obj["vm_labels"] = in.VMLabels
 	}
 
 	if len(in.MachineImage) > 0 {
@@ -177,8 +177,8 @@ func expandMachineConfigV2GoogleGCE(p []interface{}, source *MachineConfigV2) *M
 		obj.InternalFirewallRulePrefix = v
 	}
 
-	if v, ok := in["labels"].(string); ok && len(v) > 0 {
-		obj.Labels = v
+	if v, ok := in["vm_labels"].(string); ok && len(v) > 0 {
+		obj.VMLabels = v
 	}
 
 	if v, ok := in["machine_image"].(string); ok && len(v) > 0 {


### PR DESCRIPTION
Update GCE label field to match latest rancher-machine version #1580

Backport #1580  (main PR) to release/v8
Addresses #1582 (backport issue) for #1581 (main issue)