### PR TITLE
Adding resource `cluster_proxy_config_v2` for managing JWT token enabling for clusters

### DIFF
--- a/rancher2/import_rancher2_cluster_proxy_config.go
+++ b/rancher2/import_rancher2_cluster_proxy_config.go
@@ -1,0 +1,18 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+const (
+	clusterProxyConfigV2Name = "clusterproxyconfig"
+)
+
+func resourceRancher2ClusterProxyConfigV2Import(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	err := resourceRancher2ClusterProxyConfigV2Read(d, meta)
+	if err != nil || d.Id() == "" {
+		return []*schema.ResourceData{}, err
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/rancher2/provider.go
+++ b/rancher2/provider.go
@@ -124,6 +124,7 @@ func Provider() terraform.ResourceProvider {
 			"rancher2_cluster":                                       resourceRancher2Cluster(),
 			"rancher2_cluster_v2":                                    resourceRancher2ClusterV2(),
 			"rancher2_cluster_driver":                                resourceRancher2ClusterDriver(),
+			"rancher2_cluster_proxy_config_v2":                       resourceRancher2ClusterProxyConfigV2(),
 			"rancher2_cluster_role_template_binding":                 resourceRancher2ClusterRoleTemplateBinding(),
 			"rancher2_cluster_sync":                                  resourceRancher2ClusterSync(),
 			"rancher2_cluster_template":                              resourceRancher2ClusterTemplate(),

--- a/rancher2/resource_rancher2_cluster_proxy_config_v2.go
+++ b/rancher2/resource_rancher2_cluster_proxy_config_v2.go
@@ -1,0 +1,253 @@
+package rancher2
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/rancher/norman/types"
+)
+
+func resourceRancher2ClusterProxyConfigV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceRancher2ClusterProxyConfigV2Create,
+		Read:   resourceRancher2ClusterProxyConfigV2Read,
+		Update: resourceRancher2ClusterProxyConfigV2Update,
+		Delete: resourceRancher2ClusterProxyConfigV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: resourceRancher2ClusterProxyConfigV2Import,
+		},
+		Schema: clusterProxyConfigV2Fields(),
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+	}
+}
+
+func resourceRancher2ClusterProxyConfigV2Create(d *schema.ResourceData, meta interface{}) error {
+	clusterID := d.Get("cluster_id").(string)
+
+	log.Printf("[INFO] Creating ClusterProxyConfig for cluster %s", clusterID)
+
+	clusterProxyConfigV2, err := expandClusterProxyConfigV2(d)
+	if err != nil {
+		return err
+	}
+
+	newClusterProxyConfigV2, err := createClusterProxyConfigV2(meta.(*Config), clusterID, clusterProxyConfigV2)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(clusterID + "/" + clusterProxyConfigV2Name)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"creating"},
+		Target:     []string{"active"},
+		Refresh:    clusterProxyConfigV2StateRefreshFunc(meta.(*Config), clusterID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      1 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, waitErr := stateConf.WaitForState()
+	if waitErr != nil {
+		return fmt.Errorf("[ERROR] waiting for cluster proxy config (%s) to be active: %s", newClusterProxyConfigV2.ID, waitErr)
+	}
+
+	return resourceRancher2ClusterProxyConfigV2Read(d, meta)
+}
+
+func resourceRancher2ClusterProxyConfigV2Read(d *schema.ResourceData, meta interface{}) error {
+	clusterID := d.Get("cluster_id").(string)
+
+	log.Printf("[INFO] Refreshing ClusterProxyConfig for cluster %s", clusterID)
+
+	config := meta.(*Config)
+	clusterProxyConfigV2Id := clusterID + "/" + clusterProxyConfigV2Name
+	resp := &ClusterProxyConfigV2{}
+	err := config.getObjectV2ByID(rancher2DefaultLocalClusterID, clusterProxyConfigV2Id, clusterProxyConfigV2ApiType, resp)
+	if err != nil {
+		if IsNotFound(err) || IsForbidden(err) || IsNotAccessibleByID(err) {
+			log.Printf("[INFO] Cluster V2 %s not found", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+	return flattenClusterProxyConfigV2(d, resp)
+}
+
+func resourceRancher2ClusterProxyConfigV2Update(d *schema.ResourceData, meta interface{}) error {
+	clusterID := d.Get("cluster_id").(string)
+	clusterProxyConfigV2Id := clusterID + "/" + clusterProxyConfigV2Name
+
+	log.Printf("[INFO] Updating ClusterProxyConfig for cluster %s", clusterID)
+
+	clusterProxyConfigV2, err := expandClusterProxyConfigV2(d)
+	if err != nil {
+		return err
+	}
+
+	_, err = updateClusterProxyConfigV2(meta.(*Config), clusterID, clusterProxyConfigV2Id, clusterProxyConfigV2)
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"updating"},
+		Target:     []string{"active"},
+		Refresh:    clusterProxyConfigV2StateRefreshFunc(meta.(*Config), clusterID),
+		Timeout:    d.Timeout(schema.TimeoutUpdate),
+		Delay:      1 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, waitErr := stateConf.WaitForState()
+	if waitErr != nil {
+		return fmt.Errorf("[ERROR] waiting for cluster proxy config (%s) to be updated: %s", clusterProxyConfigV2Id, waitErr)
+	}
+
+	return resourceRancher2ClusterProxyConfigV2Read(d, meta)
+}
+
+func resourceRancher2ClusterProxyConfigV2Delete(d *schema.ResourceData, meta interface{}) error {
+	clusterID := d.Get("cluster_id").(string)
+	clusterProxyConfigV2Id := clusterID + "/" + clusterProxyConfigV2Name
+
+	log.Printf("[INFO] Deleting ClusterProxyConfig for cluster %s", clusterID)
+
+	// First, get the current object to have the resource info for deletion
+	obj := &ClusterProxyConfigV2{}
+	err := meta.(*Config).getObjectV2ByID(rancher2DefaultLocalClusterID, clusterProxyConfigV2Id, clusterProxyConfigV2ApiType, obj)
+	if err != nil {
+		if IsNotFound(err) || IsForbidden(err) {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	err = deleteClusterProxyConfigV2(meta.(*Config), clusterID, obj)
+	if err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"removing"},
+		Target:     []string{"removed"},
+		Refresh:    clusterProxyConfigV2StateRefreshFunc(meta.(*Config), clusterID),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      1 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	_, waitErr := stateConf.WaitForState()
+	if waitErr != nil {
+		return fmt.Errorf("[ERROR] waiting for cluster proxy config (%s) to be removed: %s", clusterProxyConfigV2Id, waitErr)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+// clusterProxyConfigV2StateRefreshFunc returns a resource.StateRefreshFunc, used to watch a ClusterProxyConfig.
+func clusterProxyConfigV2StateRefreshFunc(c *Config, clusterID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		clusterProxyConfigV2Id := clusterID + "/" + clusterProxyConfigV2Name
+		obj := &ClusterProxyConfigV2{}
+		err := c.getObjectV2ByID(rancher2DefaultLocalClusterID, clusterProxyConfigV2Id, clusterProxyConfigV2ApiType, obj)
+		if err != nil {
+			if IsNotFound(err) || IsForbidden(err) {
+				return obj, "removed", nil
+			}
+			return nil, "", err
+		}
+		return obj, "active", nil
+	}
+}
+
+// Helper functions for Norman API operations
+
+func createClusterProxyConfigV2(c *Config, clusterID string, obj *ClusterProxyConfigV2) (*ClusterProxyConfigV2, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Creating ClusterProxyConfig V2: Provider config is nil")
+	}
+	if len(clusterID) == 0 {
+		return nil, fmt.Errorf("Creating ClusterProxyConfig V2: Cluster ID is empty")
+	}
+	if obj == nil {
+		return nil, fmt.Errorf("Creating ClusterProxyConfig V2: ClusterProxyConfig V2 is nil")
+	}
+
+	resp := &ClusterProxyConfigV2{}
+	err := c.createObjectV2(rancher2DefaultLocalClusterID, clusterProxyConfigV2ApiType, obj, resp)
+	if err != nil {
+		return nil, fmt.Errorf("Creating ClusterProxyConfig V2: %s", err)
+	}
+	return resp, nil
+}
+
+func updateClusterProxyConfigV2(c *Config, clusterID, id string, obj *ClusterProxyConfigV2) (*ClusterProxyConfigV2, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Updating ClusterProxyConfig V2: Provider config is nil")
+	}
+	if len(clusterID) == 0 {
+		return nil, fmt.Errorf("Updating ClusterProxyConfig V2: Cluster ID is empty")
+	}
+	if len(id) == 0 {
+		return nil, fmt.Errorf("Updating ClusterProxyConfig V2: ID is empty")
+	}
+	if obj == nil {
+		return nil, fmt.Errorf("Updating ClusterProxyConfig V2: ClusterProxyConfig V2 is nil")
+	}
+
+	resp := &ClusterProxyConfigV2{}
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	for {
+		err := c.updateObjectV2(rancher2DefaultLocalClusterID, id, clusterProxyConfigV2ApiType, obj, resp)
+		if err == nil {
+			return resp, err
+		}
+		if !IsServerError(err) && !IsUnknownSchemaType(err) && !IsConflict(err) {
+			return nil, err
+		}
+		if IsConflict(err) {
+			// Read object again and update ObjectMeta.ResourceVersion before retry
+			newObj := &ClusterProxyConfigV2{}
+			err = c.getObjectV2ByID(rancher2DefaultLocalClusterID, id, clusterProxyConfigV2ApiType, newObj)
+			if err != nil {
+				return nil, err
+			}
+			obj.ObjectMeta.ResourceVersion = newObj.ObjectMeta.ResourceVersion
+		}
+		select {
+		case <-time.After(rancher2RetriesWait * time.Second):
+		case <-ctx.Done():
+			return nil, fmt.Errorf("Timeout updating ClusterProxyConfig V2 ID %s: %v", id, err)
+		}
+	}
+}
+
+func deleteClusterProxyConfigV2(c *Config, clusterID string, obj *ClusterProxyConfigV2) error {
+	if c == nil {
+		return fmt.Errorf("Deleting ClusterProxyConfig V2: Provider config is nil")
+	}
+	if len(clusterID) == 0 {
+		return fmt.Errorf("Deleting ClusterProxyConfig V2: Cluster ID is empty")
+	}
+	if obj == nil {
+		return fmt.Errorf("Deleting ClusterProxyConfig V2: ClusterProxyConfig V2 is nil")
+	}
+
+	resource := &types.Resource{
+		ID:      obj.ID,
+		Type:    clusterProxyConfigV2ApiType,
+		Links:   obj.Links,
+		Actions: obj.Actions,
+	}
+	return c.deleteObjectV2(rancher2DefaultLocalClusterID, resource)
+}

--- a/rancher2/resource_rancher2_cluster_proxy_config_v2_test.go
+++ b/rancher2/resource_rancher2_cluster_proxy_config_v2_test.go
@@ -1,0 +1,119 @@
+package rancher2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+const (
+	testAccRancher2ClusterProxyConfigV2Type   = "rancher2_cluster_proxy_config_v2"
+	testAccRancher2ClusterProxyConfigV2Config = `
+resource "` + testAccRancher2ClusterProxyConfigV2Type + `" "foo" {
+  cluster_id = rancher2_cluster.foo.id
+  enabled = true
+}
+`
+)
+
+func TestAccRancher2ClusterProxyConfigV2_basic(t *testing.T) {
+	var clusterProxyConfigV2 *ClusterProxyConfigV2
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancher2ClusterProxyConfigV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRancher2ClusterV2Config + testAccRancher2ClusterProxyConfigV2Config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2ClusterProxyConfigV2Exists(testAccRancher2ClusterProxyConfigV2Type+".foo", clusterProxyConfigV2),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterProxyConfigV2Type+".foo", "enabled", "true"),
+				),
+			},
+			{
+				Config: testAccRancher2ClusterV2Config + testAccRancher2ClusterProxyConfigV2UpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancher2ClusterProxyConfigV2Exists(testAccRancher2ClusterProxyConfigV2Type+".foo", clusterProxyConfigV2),
+					resource.TestCheckResourceAttr(testAccRancher2ClusterProxyConfigV2Type+".foo", "enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      testAccRancher2ClusterProxyConfigV2Type + ".foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccRancher2ClusterProxyConfigV2ImportStateIdFunc,
+			},
+		},
+	})
+}
+
+const testAccRancher2ClusterProxyConfigV2UpdateConfig = `
+resource "` + testAccRancher2ClusterProxyConfigV2Type + `" "foo" {
+  cluster_id = rancher2_cluster.foo.id
+  name = "test-cluster-proxy-config"
+  enabled = false
+}
+`
+
+func testAccRancher2ClusterProxyConfigV2ImportStateIdFunc(s *terraform.State) (string, error) {
+	resourceName := testAccRancher2ClusterProxyConfigV2Type + ".foo"
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return "", fmt.Errorf("Not found: %s", resourceName)
+	}
+	clusterID := rs.Primary.Attributes["cluster_id"]
+	return clusterID + "/" + clusterProxyConfigV2Name, nil
+}
+
+func testAccCheckRancher2ClusterProxyConfigV2Exists(n string, obj *ClusterProxyConfigV2) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ClusterProxyConfig ID is set")
+		}
+
+		meta := testAccProvider.Meta().(*Config)
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		clusterProxyConfigV2Id := clusterID + "/" + clusterProxyConfigV2Name
+
+		foundObj := &ClusterProxyConfigV2{}
+		err := meta.getObjectV2ByID(rancher2DefaultLocalClusterID, clusterProxyConfigV2Id, clusterProxyConfigV2ApiType, foundObj)
+		if err != nil {
+			return err
+		}
+
+		obj = foundObj
+		return nil
+	}
+}
+
+func testAccCheckRancher2ClusterProxyConfigV2Destroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccRancher2ClusterProxyConfigV2Type {
+			continue
+		}
+
+		meta := testAccProvider.Meta().(*Config)
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		clusterProxyConfigV2Id := clusterID + "/" + clusterProxyConfigV2Name
+
+		obj := &ClusterProxyConfigV2{}
+		err := meta.getObjectV2ByID(rancher2DefaultLocalClusterID, clusterProxyConfigV2Id, clusterProxyConfigV2ApiType, obj)
+		if err == nil {
+			return fmt.Errorf("ClusterProxyConfig still exists")
+		}
+
+		if !IsNotFound(err) && !IsForbidden(err) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/rancher2/schema_cluster_proxy_config_v2.go
+++ b/rancher2/schema_cluster_proxy_config_v2.go
@@ -1,0 +1,27 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func clusterProxyConfigV2Fields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"cluster_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "Cluster ID where the ClusterProxyConfig should be created",
+		},
+		"enabled": {
+			Type:        schema.TypeBool,
+			Required:    true,
+			Description: "Indicates whether downstream proxy requests for service account tokens is enabled",
+		},
+	}
+
+	for k, v := range commonAnnotationLabelFields() {
+		s[k] = v
+	}
+
+	return s
+}

--- a/rancher2/structure_cluster_proxy_config_v2.go
+++ b/rancher2/structure_cluster_proxy_config_v2.go
@@ -1,0 +1,56 @@
+package rancher2
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	norman "github.com/rancher/norman/types"
+	managementv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+)
+
+const (
+	clusterProxyConfigV2ApiType    = "management.cattle.io.clusterproxyconfig"
+	clusterProxyConfigV2Kind       = "ClusterProxyConfig"
+	clusterProxyConfigV2APIVersion = "management.cattle.io/v3"
+)
+
+type ClusterProxyConfigV2 struct {
+	norman.Resource
+	managementv3.ClusterProxyConfig
+}
+
+// Flatteners
+
+func flattenClusterProxyConfigV2(d *schema.ResourceData, in *ClusterProxyConfigV2) error {
+	if in == nil {
+		return fmt.Errorf("[ERROR] flattening cluster proxy config: Input unstructured is nil")
+	}
+
+	d.Set("cluster_id", (in.GetNamespace()))
+	d.Set("enabled", in.Enabled)
+
+	return nil
+}
+
+// Expanders
+
+func expandClusterProxyConfigV2(in *schema.ResourceData) (*ClusterProxyConfigV2, error) {
+	if in == nil {
+		return nil, fmt.Errorf("[ERROR] expanding cluster proxy config: Input ResourceData is nil")
+	}
+
+	obj := &ClusterProxyConfigV2{}
+
+	if len(in.Id()) > 0 {
+		obj.ID = in.Id()
+	}
+
+	obj.TypeMeta.Kind = clusterProxyConfigV2Kind
+	obj.TypeMeta.APIVersion = clusterProxyConfigV2APIVersion
+
+	obj.ObjectMeta.Namespace = in.Get("cluster_id").(string)
+	obj.ObjectMeta.Name = clusterProxyConfigV2Name
+	obj.Enabled = in.Get("enabled").(bool)
+
+	return obj, nil
+}

--- a/rancher2/structure_cluster_proxy_config_v2_test.go
+++ b/rancher2/structure_cluster_proxy_config_v2_test.go
@@ -1,0 +1,125 @@
+package rancher2
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	norman "github.com/rancher/norman/types"
+	managementv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	testClusterProxyConfigV2Conf      *ClusterProxyConfigV2
+	testClusterProxyConfigV2Interface map[string]interface{}
+)
+
+func init() {
+	testClusterProxyConfigV2Conf = &ClusterProxyConfigV2{
+		Resource: norman.Resource{
+			ID: "c-m-xxxxx",
+		},
+		ClusterProxyConfig: managementv3.ClusterProxyConfig{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       clusterProxyConfigV2Kind,
+				APIVersion: clusterProxyConfigV2APIVersion,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterProxyConfigV2Name,
+				Namespace: "c-m-xxxxx",
+			},
+			Enabled: true,
+		},
+	}
+
+	testClusterProxyConfigV2Interface = map[string]interface{}{
+		"cluster_id": "c-m-xxxxx",
+		"enabled":    true,
+	}
+}
+
+func TestFlattenClusterProxyConfigV2(t *testing.T) {
+	cases := []struct {
+		Input          *ClusterProxyConfigV2
+		ExpectedOutput map[string]interface{}
+	}{
+		{
+			testClusterProxyConfigV2Conf,
+			testClusterProxyConfigV2Interface,
+		},
+	}
+
+	for _, tc := range cases {
+		resourceData := schema.TestResourceDataRaw(t, clusterProxyConfigV2Fields(), map[string]interface{}{})
+		err := flattenClusterProxyConfigV2(resourceData, tc.Input)
+		if err != nil {
+			t.Fatalf("Error flattening ClusterProxyConfigV2: %v", err)
+		}
+
+		for k, v := range tc.ExpectedOutput {
+			actual := resourceData.Get(k)
+			if !reflect.DeepEqual(actual, v) {
+				t.Fatalf("flattenClusterProxyConfigV2: Expected %#v for key %s, got %#v", v, k, actual)
+			}
+		}
+	}
+}
+
+func TestFlattenClusterProxyConfigV2Nil(t *testing.T) {
+	resourceData := schema.TestResourceDataRaw(t, clusterProxyConfigV2Fields(), map[string]interface{}{})
+	err := flattenClusterProxyConfigV2(resourceData, nil)
+	if err == nil {
+		t.Fatal("Expected error when flattening nil ClusterProxyConfigV2, got nil")
+	}
+}
+
+func TestExpandClusterProxyConfigV2(t *testing.T) {
+	cases := []struct {
+		Input          map[string]interface{}
+		ExpectedOutput *ClusterProxyConfigV2
+	}{
+		{
+			testClusterProxyConfigV2Interface,
+			testClusterProxyConfigV2Conf,
+		},
+	}
+
+	for _, tc := range cases {
+		resourceData := schema.TestResourceDataRaw(t, clusterProxyConfigV2Fields(), tc.Input)
+		output, err := expandClusterProxyConfigV2(resourceData)
+		if err != nil {
+			t.Fatalf("Error expanding ClusterProxyConfigV2: %v", err)
+		}
+
+		// Check basic fields
+		if output.TypeMeta.APIVersion != tc.ExpectedOutput.TypeMeta.APIVersion {
+			t.Fatalf("expandClusterProxyConfigV2: Expected APIVersion %s, got %s", tc.ExpectedOutput.TypeMeta.APIVersion, output.TypeMeta.APIVersion)
+		}
+
+		if output.TypeMeta.Kind != tc.ExpectedOutput.TypeMeta.Kind {
+			t.Fatalf("expandClusterProxyConfigV2: Expected Kind %s, got %s", tc.ExpectedOutput.TypeMeta.Kind, output.TypeMeta.Kind)
+		}
+
+		if output.ObjectMeta.Name != tc.ExpectedOutput.ObjectMeta.Name {
+			t.Fatalf("expandClusterProxyConfigV2: Expected Name %s, got %s", tc.ExpectedOutput.ObjectMeta.Name, output.ObjectMeta.Name)
+		}
+
+		if output.ObjectMeta.Namespace != tc.ExpectedOutput.ObjectMeta.Namespace {
+			t.Fatalf("expandClusterProxyConfigV2: Expected Namespace %s, got %s", tc.ExpectedOutput.ObjectMeta.Namespace, output.ObjectMeta.Namespace)
+		}
+
+		// Check enabled field
+		if output.Enabled != tc.ExpectedOutput.Enabled {
+			t.Fatalf("expandClusterProxyConfigV2: Expected enabled %v, got %v", tc.ExpectedOutput.Enabled, output.Enabled)
+		}
+
+	}
+}
+
+func TestExpandClusterProxyConfigV2Nil(t *testing.T) {
+	_, err := expandClusterProxyConfigV2(nil)
+	if err == nil {
+		t.Fatal("Expected error when expanding nil ResourceData, got nil")
+	}
+}


### PR DESCRIPTION
Since Rancher v2.9, it is possible to enable JWT tokens for clusters, this feature was not yet implemented in the Rancher2 provider. This PR aims at providing that feature through the usage of a specific resource called `cluster_proxy_config_v2` since the Kuberntes resource in Rancher has a kind `ClusterProxyConfig` and it is only exposed using the Norman API.

Fixes #1466