### PR TITLE
fix: registry configuration for clusters (#1596)

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -22,6 +22,8 @@ resource "rancher2_cluster" "foo-imported" {
 
 ### Creating Rancher v2 imported cluster with custom configuration. For Rancher v2.11.x and above.
 
+This configuration can be used to indicate that system images (such as the rancher-agent) should be pulled from an unauthenticated private registry. This can be used for all imported cluster types, including imported hosted clusters (AKS, EKS, GKE).
+
 ```hcl
 # Create a new rancher2 imported Cluster with custom configuration 
 resource "rancher2_cluster" "foo-imported" {
@@ -411,6 +413,32 @@ resource "rancher2_cluster" "foo" {
 }
 ```
 
+### Importing EKS cluster to Rancher v2, using `eks_config_v2`, while specifying an unauthenticated private registry. For Rancher v2.11.0 and above.
+
+```hcl
+resource "rancher2_cloud_credential" "foo" {
+  name = "foo"
+  description = "foo test"
+  amazonec2_credential_config {
+    access_key = "<aws-access-key>"
+    secret_key = "<aws-secret-key>"
+  }
+}
+resource "rancher2_cluster" "foo" {
+  name = "foo"
+  description = "Terraform EKS cluster"
+  eks_config_v2 {
+    cloud_credential_id = rancher2_cloud_credential.foo.id
+    name = "<cluster-name>"
+    region = "<eks-region>"
+    imported = true
+  }
+  imported_config {
+    private_registry_url = <private_registry>
+  }
+}
+```
+
 ### Creating EKS cluster from Rancher v2, using `eks_config_v2`. For Rancher v2.5.x and above.
 
 ```hcl
@@ -509,6 +537,32 @@ resource "rancher2_cluster" "foo" {
 }
 ```
 
+### Importing GKE cluster from Rancher v2, using `gke_config_v2`, while specifying an unauthenticated private registry. For Rancher v2.11.0 above.
+
+```hcl
+resource "rancher2_cloud_credential" "foo-google" {
+  name = "foo-google"
+  description= "Terraform cloudCredential acceptance test"
+  google_credential_config {
+    auth_encoded_json = file(<GOOGLE_AUTH_ENCODED_JSON>)
+  }
+}
+
+resource "rancher2_cluster" "foo" {
+  name = "foo"
+  description = "Terraform imported GKE cluster"
+  gke_config_v2 {
+    name = "foo"
+    google_credential_secret = rancher2_cloud_credential.foo-google.id
+    region = <region> # Zone argument could also be used instead of region
+    project_id = <project-id>
+    imported = true
+  }
+  imported_config {
+    private_registry_url = <private_registry>
+  }
+}
+```
 ### Creating GKE cluster from Rancher v2, using `gke_config_v2`. For Rancher v2.5.8 and above.
 
 **Note:** At the moment, routed-based GKE clusters are not supported due to [rancher/issues/32585](https://github.com/rancher/rancher/issues/32585)
@@ -567,6 +621,34 @@ resource "rancher2_cluster" "foo" {
   }
 }
 ```
+
+### Importing AKS cluster from Rancher v2, using `aks_config_v2`, while specifying an unauthenticated private registry. For Rancher v2.11.0 and above.
+
+```hcl
+resource "rancher2_cloud_credential" "foo-aks" {
+  name = "foo-aks"
+  azure_credential_config {
+    client_id = "<client-id>"
+    client_secret = "<client-secret>"
+    subscription_id = "<subscription-id>"
+  }
+}
+# For imported AKS clusters, don't add any other aks_config_v2 field
+resource "rancher2_cluster" "foo" {
+  name = <cluster-name>
+  description = "Terraform AKS cluster"
+  aks_config_v2 {
+    cloud_credential_id = rancher2_cloud_credential.foo-aks.id
+    resource_group = "<resource-group>"
+    resource_location = "<resource-location"
+    imported = true
+  }
+  imported_config {
+    private_registry_url = "<private_registry>"
+  }
+}
+```
+
 
 ### Creating AKS cluster from Rancher v2, using `aks_config_v2`. For Rancher v2.6.0 and above.
 

--- a/rancher2/data_source_rancher2_cluster.go
+++ b/rancher2/data_source_rancher2_cluster.go
@@ -194,6 +194,13 @@ func dataSourceRancher2Cluster() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
+			"imported_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: clusterImportedConfigFields(),
+				},
+			},
 		},
 	}
 }

--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -48,6 +48,15 @@ func resourceRancher2Cluster() *schema.Resource {
 				}
 			}
 
+			// Allow the configuration of the imported_config field only if the
+			// cluster is an imported generic cluster or an imported hosted cluster (e.g. AKS, GKE, EKS).
+			// Previously defined 'conflictsWith' entries already handle other cluster types (rke, rke2, k3s)
+			// so they do not need to be reconsidered here.
+			importCnf, ok := d.Get("imported_config").([]interface{})
+			if ok && len(importCnf) > 0 && !isImportedCluster(d) {
+				return fmt.Errorf("The rancher2_cluster.imported_config field can only be used when working with generic imported clusters or imported hosted clusters (e.g. AKS, GKE, EKS)")
+			}
+
 			return nil
 		},
 		Schema:        clusterFields(),
@@ -690,4 +699,33 @@ func getClusterKubeconfig(c *Config, id, origconfig string) (*managementClient.G
 			return nil, fmt.Errorf("Timeout getting cluster Kubeconfig: %v", err)
 		}
 	}
+}
+
+func isImportedCluster(d *schema.ResourceDiff) bool {
+	eks := d.Get("eks_config_v2")
+	newEksArray, ok := eks.([]interface{})
+	isEks := ok && len(newEksArray) > 0
+	if isEks {
+		return expandClusterEKSConfigV2(newEksArray).Imported
+	}
+
+	gke := d.Get("gke_config_v2")
+	newGkeArray, ok := gke.([]interface{})
+	isGke := ok && len(newGkeArray) > 0
+	if isGke {
+		return expandClusterGKEConfigV2(newGkeArray).Imported
+	}
+
+	aks := d.Get("aks_config_v2")
+	newAksArray, ok := aks.([]interface{})
+	isAks := ok && len(newAksArray) > 0
+	if isAks {
+		return expandClusterAKSConfigV2(newAksArray).Imported
+	}
+
+	// if this is a generic imported cluster,
+	// we should always allow for the field to be used.
+	// Other non-imported cluster types (rke, rke2, k3s, etc.)
+	// are already being blocked via the static ConflictsWith field.
+	return true
 }

--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -407,7 +407,7 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config"},
+			ConflictsWith: []string{"aks_config", "aks_config_v2", "eks_config", "eks_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config"},
 			Elem: &schema.Resource{
 				Schema: clusterGKEConfigV2Fields(),
 			},

--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -371,7 +371,7 @@ func clusterFields() map[string]*schema.Schema {
 			MaxItems:      1,
 			Optional:      true,
 			Computed:      true,
-			ConflictsWith: []string{"aks_config_v2", "gke_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config"},
+ConflictsWith: []string{"aks_config", "aks_config_v2", "eks_config", "gke_config", "gke_config_v2", "k3s_config", "oke_config", "rke_config", "rke2_config"},
 			Elem: &schema.Resource{
 				Schema: clusterEKSConfigV2Fields(),
 			},
@@ -389,7 +389,7 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"eks_config_v2", "gke_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config"},
+ConflictsWith: []string{"aks_config", "eks_config", "eks_config_v2", "gke_config", "gke_config_v2", "k3s_config", "oke_config", "rke_config", "rke2_config"},
 			Elem: &schema.Resource{
 				Schema: clusterAKSConfigV2Fields(),
 			},
@@ -425,7 +425,7 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"k3s_config", "rke_config", "oke_config", "rke2_config"},
+ConflictsWith: []string{"aks_config", "eks_config", "gke_config", "k3s_config", "oke_config", "rke_config", "rke2_config"},
 			Elem: &schema.Resource{
 				Schema: clusterImportedConfigFields(),
 			},

--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -371,7 +371,7 @@ func clusterFields() map[string]*schema.Schema {
 			MaxItems:      1,
 			Optional:      true,
 			Computed:      true,
-ConflictsWith: []string{"aks_config", "aks_config_v2", "eks_config", "gke_config", "gke_config_v2", "k3s_config", "oke_config", "rke_config", "rke2_config"},
+			ConflictsWith: []string{"aks_config", "aks_config_v2", "eks_config", "gke_config", "gke_config_v2", "k3s_config", "oke_config", "rke_config", "rke2_config"},
 			Elem: &schema.Resource{
 				Schema: clusterEKSConfigV2Fields(),
 			},
@@ -389,7 +389,7 @@ ConflictsWith: []string{"aks_config", "aks_config_v2", "eks_config", "gke_config
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-ConflictsWith: []string{"aks_config", "eks_config", "eks_config_v2", "gke_config", "gke_config_v2", "k3s_config", "oke_config", "rke_config", "rke2_config"},
+			ConflictsWith: []string{"aks_config", "eks_config", "eks_config_v2", "gke_config", "gke_config_v2", "k3s_config", "oke_config", "rke_config", "rke2_config"},
 			Elem: &schema.Resource{
 				Schema: clusterAKSConfigV2Fields(),
 			},
@@ -425,7 +425,7 @@ ConflictsWith: []string{"aks_config", "eks_config", "eks_config_v2", "gke_config
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-ConflictsWith: []string{"aks_config", "eks_config", "gke_config", "k3s_config", "oke_config", "rke_config", "rke2_config"},
+			ConflictsWith: []string{"aks_config", "eks_config", "gke_config", "k3s_config", "oke_config", "rke_config", "rke2_config"},
 			Elem: &schema.Resource{
 				Schema: clusterImportedConfigFields(),
 			},

--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -371,7 +371,7 @@ func clusterFields() map[string]*schema.Schema {
 			MaxItems:      1,
 			Optional:      true,
 			Computed:      true,
-			ConflictsWith: []string{"aks_config", "aks_config_v2", "eks_config", "gke_config", "gke_config_v2", "k3s_config", "oke_config", "rke_config", "rke2_config", "imported_config"},
+			ConflictsWith: []string{"aks_config_v2", "gke_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config"},
 			Elem: &schema.Resource{
 				Schema: clusterEKSConfigV2Fields(),
 			},
@@ -389,7 +389,7 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"aks_config", "eks_config", "eks_config_v2", "gke_config", "gke_config_v2", "k3s_config", "oke_config", "rke_config", "rke2_config", "imported_config"},
+			ConflictsWith: []string{"eks_config_v2", "gke_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config"},
 			Elem: &schema.Resource{
 				Schema: clusterAKSConfigV2Fields(),
 			},
@@ -407,7 +407,7 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"aks_config", "aks_config_v2", "eks_config", "eks_config_v2", "gke_config", "k3s_config", "oke_config", "rke_config", "rke2_config", "imported_config"},
+			ConflictsWith: []string{"aks_config_v2", "eks_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config"},
 			Elem: &schema.Resource{
 				Schema: clusterGKEConfigV2Fields(),
 			},
@@ -425,7 +425,7 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"aks_config", "aks_config_v2", "eks_config", "eks_config_v2", "gke_config", "gke_config_v2", "k3s_config", "oke_config", "rke_config", "rke2_config"},
+			ConflictsWith: []string{"k3s_config", "rke_config", "oke_config", "rke2_config"},
 			Elem: &schema.Resource{
 				Schema: clusterImportedConfigFields(),
 			},

--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -407,7 +407,7 @@ func clusterFields() map[string]*schema.Schema {
 			Type:          schema.TypeList,
 			MaxItems:      1,
 			Optional:      true,
-			ConflictsWith: []string{"aks_config", "aks_config_v2", "eks_config", "eks_config_v2", "k3s_config", "rke_config", "oke_config", "rke2_config"},
+			ConflictsWith: []string{"aks_config", "aks_config_v2", "eks_config", "eks_config_v2", "gke_config", "k3s_config", "rke_config", "oke_config", "rke2_config"},
 			Elem: &schema.Resource{
 				Schema: clusterGKEConfigV2Fields(),
 			},


### PR DESCRIPTION
Please review this carefully, there were merge conflicts in rancher2/schema_cluster.go that I resolved by accepting your change.

Backport #1596 (main PR) to release/v7
Addresses #1598 (backport issue) for #1523 (main issue)