### PR TITLE
fix: change log from info to error

### DIFF
--- a/rancher2/import_rancher2_namespace.go
+++ b/rancher2/import_rancher2_namespace.go
@@ -19,7 +19,7 @@ func resourceRancher2NamespaceImport(d *schema.ResourceData, meta interface{}) (
 
 	client, err := meta.(*Config).ClusterClient(clusterID)
 	if err != nil {
-		log.Printf("[INFO] Problem getting cluster client for cluster with id \"%s\"", clusterID)
+		log.Printf("[ERROR] Problem getting cluster client for cluster with id \"%s\"", clusterID)
 		return []*schema.ResourceData{}, err
 	}
 


### PR DESCRIPTION
As suggested in https://github.com/rancher/terraform-provider-rancher2/pull/1515, the namespace import error log should be error level instead of info level.