### PR TITLE
fix: change EKS node group launch template version

### DIFF
--- a/rancher2/schema_cluster_eks_config_v2.go
+++ b/rancher2/schema_cluster_eks_config_v2.go
@@ -58,7 +58,7 @@ func clusterEKSConfigV2NodeGroupsLaunchTemplateFields() map[string]*schema.Schem
 		"version": {
 			Type:        schema.TypeInt,
 			Optional:    true,
-			Default:     1,
+			Computed:    true,
 			Description: "The EKS node group launch template version",
 		},
 	}


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
https://github.com/rancher/terraform-provider-rancher2/issues/730

## Problem
The Rancher2 provider does not reconcile computed launch template version values properly during Terraform runs. When the launch template version changes (e.g., due to new AMI or configuration updates), Terraform’s plan phase uses a default or stale version (0), but the apply phase sees the actual updated version (e.g., 4). This mismatch causes the provider to report an invalid new value error and fail the apply.

## Solution
The issue was resolved by updating the Rancher2 Terraform provider to mark the `launch_template.version` field as `computed = true` and removing the default value (`default = 1`). 

This change ensures that Terraform correctly waits for the actual launch template version value to be known during the apply phase, instead of relying on a hardcoded default or outdated value from the plan phase. 

With this fix, the provider can now handle dynamic version changes from the launch template (such as when a new version is triggered by configuration changes), preventing inconsistent plans and apply failures.

## Testing

### Manual Testing
- Created an EKS cluster using Rancher and Terraform with launch templates for node groups.
- Updated the launch template to trigger a new version.
- Verified that Terraform successfully planned and applied the changes without errors.
- Checked the AWS console and Rancher UI to confirm the node groups used the expected launch template version.
- Destroyed and recreated the cluster to ensure reproducibility.

### Automated Testing
No automated tests were added, as the fix primarily addresses a runtime inconsistency in Terraform provider behavior rather than a logic bug.

## QA Testing Considerations
- Verify EKS cluster provisioning via Terraform with launch template versions explicitly set.
- Confirm that updating the launch template version triggers the correct node group updates without plan/apply errors.
- Test cluster upgrades involving node group changes to ensure launch template versions remain consistent.
- Validate Rancher UI correctly displays node group configurations and launch template details.

## Regressions Considerations
- The fix addresses only the launch template version handling and should not impact unrelated Rancher or EKS features.
- High chance of regressions in scenarios where launch templates are used with EKS node groups, if the version is omitted or incorrectly specified.
- Low risk of regressions for clusters not using launch templates or unmanaged via Terraform.
