### PR TITLE
fix: [v8] change launch template version

### DIFF
--- a/rancher2/schema_cluster_eks_config_v2.go
+++ b/rancher2/schema_cluster_eks_config_v2.go
@@ -58,7 +58,7 @@ func clusterEKSConfigV2NodeGroupsLaunchTemplateFields() map[string]*schema.Schem
 		"version": {
 			Type:        schema.TypeInt,
 			Optional:    true,
-			Default:     1,
+			Computed:    true,
 			Description: "The EKS node group launch template version",
 		},
 	}


### PR DESCRIPTION
change EKS node group launch template version

(cherry picked from commit 8ccd8ec600bd469ce055534a749fd16c5a75c731)

Cherry-pick #1616 (main PR) to release/v8
Addresses #1620 (backport issue) for #730 (main issue)