### PR TITLE
support AWS node-driver IPv6/dual-stack downstream clusters 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ terraform.tfstate
 *.tfstate.*
 tf-*
 *.env
+*/*.tfvars
+*/*.pem
+*.tgz
+main.tf
+terraform-provider-rancher2

--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -20,3 +20,6 @@ rke
 rke2
 terraform
 variablize
+IPv
+IPv4
+IPv6

--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -1001,6 +1001,7 @@ see more information on [Resource Management for Pods and Containers](https://ku
 * `machine_selector_files` - (Optional/computed, list) Machine selector files provide a means to deliver files to nodes so that the files can be in place before initiating RKE2/K3s server or agent processes. Please refer to Rancher documentation for [RKE2 Cluster Configuration Reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration#machineselectorfiles) and [K3s Cluster Configuration Reference](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/k3s-cluster-configuration#machineselectorfiles). This argument is available in Rancher v2.7.2 and later.
 * `registries` - (Optional, list, max length: 1) Docker registries from which the cluster pulls images. 
 * `etcd` - (Optional/computed, list, max length: 1) Etcd configures the behavior of the automatic etcd snapshot feature.
+* `networking` - (Optional, list, max length: 1) The networking stack used by the cluster.
 * `rotate_certificates` (Optional, list, max length: 1) Cluster V2 certificate rotation.
 * `etcd_snapshot_create` (Optional, list, max length: 1) Cluster V2 etcd snapshot create.
 * `etcd_snapshot_restore` (Optional, list, max length: 1) Cluster V2 etcd snapshot restore.
@@ -1225,6 +1226,12 @@ This argument is available in Rancher v2.7.2 and later.
 * `name` - (Required, string) ETCD snapshot name to restore.
 * `generation` (Required, int) ETCD snapshot desired generation.
 * `restore_rke_config` (Optional, string) ETCD restore RKE config (set to none, all, or kubernetesVersion).
+
+#### `networking`
+
+##### Arguments
+
+* `stack_preference` - (Optional, string) The networking stack used by the cluster. The selected value configures the address used for health and readiness probes of calico, etcd, kube-apiserver, kube-scheduler, kube-controller-manager, and kubelet. It also defines the server URL in the authentication-token-webhook-config-file for the Authorized Cluster Endpoint and the advertise-client-urls for etcd during snapshot restore.  When set to `dual`, the cluster uses `localhost`; when set to `ipv6`, it uses `[::1]`; when set to `ipv4`, it uses `127.0.0.1`.
 
 ### `cluster_registration_token`
 

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -150,6 +150,10 @@ The following attributes are exported:
 * `use_private_address` - (Optional) Force the usage of private IP address. Default `false` (bool)
 * `userdata` - (Optional) Path to file with cloud-init user data (string)
 * `volume_type` - (Optional) Amazon EBS volume type. Default `gp2` (string)
+* `http_protocol_ipv6` - (Optional) Enables or disables the IPv6 endpoint for the instance metadata service. Options: enabled, disabled (string)
+* `ipv6_address_count` - (Optional) The number of IPv6 addresses to assign to the network interface. It must be greater than zero when Ipv6AddressOnly is true (string)
+* `ipv6_address_only` - (Optional) Indicates whether the instance has only IPv6 address. Useful when the VPC or subnet is configured as IPv6-only (bool)
+* `enable_primary_ipv6` - (Optional) Indicates whether the instance’s first assigned IPv6 address is set as the primary IPv6 address (bool)
 
 ### `azure_config`
 

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -151,7 +151,7 @@ The following attributes are exported:
 * `userdata` - (Optional) Path to file with cloud-init user data (string)
 * `volume_type` - (Optional) Amazon EBS volume type. Default `gp2` (string)
 * `http_protocol_ipv6` - (Optional) Enables or disables the IPv6 endpoint for the instance metadata service. Options: enabled, disabled (string)
-* `ipv6_address_count` - (Optional) The number of IPv6 addresses to assign to the network interface. It must be greater than zero when Ipv6AddressOnly is true (string)
+* `ipv6_address_count` - (Optional) The number of IPv6 addresses to assign to the network interface. It must be greater than zero when `ipv6_address_only` is true (string)
 * `ipv6_address_only` - (Optional) Indicates whether the instance has only IPv6 address. Useful when the VPC or subnet is configured as IPv6-only (bool)
 * `enable_primary_ipv6` - (Optional) Indicates whether the instance’s first assigned IPv6 address is set as the primary IPv6 address (bool)
 

--- a/rancher2/schema_cluster_v2_rke_config.go
+++ b/rancher2/schema_cluster_v2_rke_config.go
@@ -5,9 +5,15 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 // Types
+
+var (
+	// StackPreference is the networking stack used by the cluster
+	StackPreference = []string{"dual", "ipv6", "ipv4"}
+)
 
 func clusterV2RKEConfigFieldsV0() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
@@ -140,6 +146,16 @@ func clusterV2RKEConfigFieldsV0() map[string]*schema.Schema {
 				Schema: clusterV2RKEConfigETCDFields(),
 			},
 		},
+		"networking": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Computed:    true,
+			Description: "Cluster V2 networking",
+			Elem: &schema.Resource{
+				Schema: clusterV2Networking(),
+			},
+		},
 		"rotate_certificates": {
 			Type:        schema.TypeList,
 			MaxItems:    1,
@@ -166,6 +182,25 @@ func clusterV2RKEConfigFieldsV0() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: clusterV2RKEConfigETCDSnapshotRestoreFields(),
 			},
+		},
+	}
+
+	return s
+}
+
+func clusterV2Networking() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"stack_preference": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Specify the networking stack used by the cluster. The selected value configures the address " +
+				"used for health and readiness probes of calico, etcd, kube-apiserver, kube-scheduler, kube-controller-manager, and kubelet. " +
+				"It also defines the server URL in the authentication-token-webhook-config-file for " +
+				"the Authorized Cluster Endpoint and the advertise-client-urls for etcd during snapshot restore. " +
+				"When set to dual, the cluster uses localhost; " +
+				"when set to ipv6, it uses [::1]; " +
+				"when set to ipv4, it uses 127.0.0.1",
+			ValidateFunc: validation.StringInSlice(StackPreference, false),
 		},
 	}
 
@@ -309,6 +344,16 @@ func clusterV2RKEConfigFields() map[string]*schema.Schema {
 			Description: "Cluster V2 etcd",
 			Elem: &schema.Resource{
 				Schema: clusterV2RKEConfigETCDFields(),
+			},
+		},
+		"networking": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Optional:    true,
+			Computed:    true,
+			Description: "Cluster V2 networking",
+			Elem: &schema.Resource{
+				Schema: clusterV2Networking(),
 			},
 		},
 		"rotate_certificates": {

--- a/rancher2/schema_machine_config_v2.go
+++ b/rancher2/schema_machine_config_v2.go
@@ -15,7 +15,7 @@ var allMachineDriverConfigFields = []string{
 	"google_config",
 }
 
-//Schemas
+// Schemas
 
 func machineConfigV2Fields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{

--- a/rancher2/schema_machine_config_v2_amazonec2.go
+++ b/rancher2/schema_machine_config_v2_amazonec2.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-//Schemas
+// Schemas
 
 func machineConfigV2Amazonec2Fields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
@@ -202,6 +202,36 @@ func machineConfigV2Amazonec2Fields() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     "gp2",
 			Description: "Amazon EBS volume type",
+		},
+		"http_protocol_ipv6": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  "",
+			Description: "Enables or disables the IPv6 endpoint for the instance metadata service. " +
+				"Options: enabled, disabled",
+		},
+		"ipv6_address_count": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  "0",
+			Description: "The number of IPv6 addresses to assign to the network interface (default: 0). " +
+				"Must be greater than zero when ipv6_address_only is true.",
+		},
+		"enable_primary_ipv6": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+			Description: "Indicates whether the first IPv6 address assigned to the instance should be marked as the primary IPv6 address. " +
+				"Enable this option if the instance requires a stable, non-changing IPv6 address. " +
+				"This option does not affect whether IPv6 addresses are assigned to the instance.",
+		},
+		"ipv6_address_only": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+			Description: "Indicates whether the instance has only IPv6 address. Useful when the VPC or subnet is configured as IPv6-only." +
+				" When set to true, the instance will have IPv6 as its sole address." +
+				" When set to true, ipv6_address_count must be greater than zero.",
 		},
 	}
 

--- a/rancher2/structure_cluster_v2_rke_config.go
+++ b/rancher2/structure_cluster_v2_rke_config.go
@@ -46,6 +46,9 @@ func flattenClusterV2RKEConfig(in *provisionv1.RKEConfig) []interface{} {
 	if in.ETCD != nil {
 		obj["etcd"] = flattenClusterV2RKEConfigETCD(in.ETCD)
 	}
+	if in.Networking != nil {
+		obj["networking"] = flattenClusterV2Networking(in.Networking)
+	}
 
 	if in.RotateCertificates != nil {
 		obj["rotate_certificates"] = flattenClusterV2RKEConfigRotateCertificates(in.RotateCertificates)
@@ -107,6 +110,9 @@ func expandClusterV2RKEConfig(p []interface{}) *provisionv1.RKEConfig {
 	}
 	if v, ok := in["etcd"].([]interface{}); ok && len(v) > 0 {
 		obj.ETCD = expandClusterV2RKEConfigETCD(v)
+	}
+	if v, ok := in["networking"].([]interface{}); ok && len(v) > 0 {
+		obj.Networking = expandClusterV2Networking(v)
 	}
 
 	if v, ok := in["rotate_certificates"].([]interface{}); ok && len(v) > 0 {

--- a/rancher2/structure_cluster_v2_rke_config_etcd_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_etcd_test.go
@@ -12,6 +12,8 @@ var (
 	testClusterV2RKEConfigETCDSnapshotS3Interface []interface{}
 	testClusterV2RKEConfigETCDConf                *rkev1.ETCD
 	testClusterV2RKEConfigETCDInterface           []interface{}
+	testClusterV2RKEConfigNetworkingConf          *rkev1.Networking
+	testClusterV2RKEConfigNetworkingInterface     []interface{}
 )
 
 func init() {
@@ -49,6 +51,15 @@ func init() {
 			"snapshot_schedule_cron": "snapshot_schedule_cron",
 			"snapshot_retention":     10,
 			"s3_config":              testClusterV2RKEConfigETCDSnapshotS3Interface,
+		},
+	}
+
+	testClusterV2RKEConfigNetworkingConf = &rkev1.Networking{
+		StackPreference: rkev1.SingleStackIPv4Preference,
+	}
+	testClusterV2RKEConfigNetworkingInterface = []interface{}{
+		map[string]interface{}{
+			"stack_preference": "ipv4",
 		},
 	}
 }

--- a/rancher2/structure_cluster_v2_rke_config_network.go
+++ b/rancher2/structure_cluster_v2_rke_config_network.go
@@ -1,0 +1,38 @@
+package rancher2
+
+import (
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+)
+
+// Flatteners
+
+func flattenClusterV2Networking(in *rkev1.Networking) []interface{} {
+	if in == nil {
+		return nil
+	}
+
+	obj := make(map[string]interface{})
+
+	if len(in.StackPreference) > 0 {
+		obj["stack_preference"] = string(in.StackPreference)
+	}
+	return []interface{}{obj}
+}
+
+// Expanders
+
+func expandClusterV2Networking(p []interface{}) *rkev1.Networking {
+	if p == nil || len(p) == 0 || p[0] == nil {
+		return nil
+	}
+
+	obj := &rkev1.Networking{}
+
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["stack_preference"].(string); ok && len(v) > 0 {
+		obj.StackPreference = rkev1.NetworkingStackPreference(v)
+	}
+
+	return obj
+}

--- a/rancher2/structure_cluster_v2_rke_config_network_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_network_test.go
@@ -1,0 +1,153 @@
+package rancher2
+
+import (
+	"testing"
+
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenClusterV2RKEConfigNetwork(t *testing.T) {
+	cases := []struct {
+		Name           string
+		Input          *rkev1.Networking
+		ExpectedOutput []interface{}
+	}{
+		{
+			Name: "ipv4 stack",
+			Input: &rkev1.Networking{
+				StackPreference: rkev1.NetworkingStackPreference("ipv4"),
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{
+					"stack_preference": "ipv4",
+				},
+			},
+		},
+		{
+			Name: "ipv6 stack",
+			Input: &rkev1.Networking{
+				StackPreference: rkev1.NetworkingStackPreference("ipv6"),
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{
+					"stack_preference": "ipv6",
+				},
+			},
+		},
+		{
+			Name:           "nil input",
+			Input:          nil,
+			ExpectedOutput: nil,
+		},
+		{
+			Name: "empty stack_preference",
+			Input: &rkev1.Networking{
+				StackPreference: "",
+			},
+			ExpectedOutput: []interface{}{
+				map[string]interface{}{},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			output := flattenClusterV2Networking(tc.Input)
+			assert.Equal(t, tc.ExpectedOutput, output, "Unexpected output from flattener.")
+		})
+	}
+}
+
+func TestExpandClusterV2RKEConfigNetwork(t *testing.T) {
+	cases := []struct {
+		Name           string
+		Input          []interface{}
+		ExpectedOutput *rkev1.Networking
+	}{
+		{
+			Name: "ipv4 stack",
+			Input: []interface{}{
+				map[string]interface{}{
+					"stack_preference": "ipv4",
+				},
+			},
+			ExpectedOutput: &rkev1.Networking{
+				StackPreference: rkev1.NetworkingStackPreference("ipv4"),
+			},
+		},
+		{
+			Name: "ipv6 stack",
+			Input: []interface{}{
+				map[string]interface{}{
+					"stack_preference": "ipv6",
+				},
+			},
+			ExpectedOutput: &rkev1.Networking{
+				StackPreference: rkev1.NetworkingStackPreference("ipv6"),
+			},
+		},
+		{
+			Name: "dualstack",
+			Input: []interface{}{
+				map[string]interface{}{
+					"stack_preference": "dualstack",
+				},
+			},
+			ExpectedOutput: &rkev1.Networking{
+				StackPreference: rkev1.NetworkingStackPreference("dualstack"),
+			},
+		},
+		{
+			Name:           "nil input",
+			Input:          nil,
+			ExpectedOutput: nil,
+		},
+		{
+			Name:           "empty slice",
+			Input:          []interface{}{},
+			ExpectedOutput: nil,
+		},
+		{
+			Name: "empty stack_preference",
+			Input: []interface{}{
+				map[string]interface{}{
+					"stack_preference": "",
+				},
+			},
+			ExpectedOutput: &rkev1.Networking{},
+		},
+		{
+			Name: "invalid type for stack_preference",
+			Input: []interface{}{
+				map[string]interface{}{
+					"stack_preference": 123,
+				},
+			},
+			ExpectedOutput: &rkev1.Networking{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			output := expandClusterV2Networking(tc.Input)
+			assert.Equal(t, tc.ExpectedOutput, output, "Unexpected output from expander.")
+		})
+	}
+}
+
+func TestRoundTripClusterV2RKEConfigNetwork(t *testing.T) {
+	input := &rkev1.Networking{
+		StackPreference: rkev1.NetworkingStackPreference("ipv6"),
+	}
+
+	// Flatten then Expand
+	flat := flattenClusterV2Networking(input)
+	expanded := expandClusterV2Networking(flat)
+	assert.Equal(t, input, expanded, "Round-trip flatten to expand failed.")
+
+	// Expand then Flatten
+	expandedAgain := expandClusterV2Networking(flat)
+	flatAgain := flattenClusterV2Networking(expandedAgain)
+	assert.Equal(t, flat, flatAgain, "Round-trip expand to flatten failed.")
+}

--- a/rancher2/structure_cluster_v2_rke_config_z_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_z_test.go
@@ -37,6 +37,7 @@ func init() {
 	testClusterV2RKEConfigConf.MachineSelectorFiles = testClusterV2RKEConfigMachineSelectorFilesConf
 	testClusterV2RKEConfigConf.Registries = testClusterV2RKEConfigRegistryConf
 	testClusterV2RKEConfigConf.ETCD = testClusterV2RKEConfigETCDConf
+	testClusterV2RKEConfigConf.Networking = testClusterV2RKEConfigNetworkingConf
 	testClusterV2RKEConfigConf.RotateCertificates = testClusterV2RKEConfigRotateCertificatesConf
 	testClusterV2RKEConfigConf.ETCDSnapshotCreate = testClusterV2RKEConfigETCDSnapshotCreateConf
 	testClusterV2RKEConfigConf.ETCDSnapshotRestore = testClusterV2RKEConfigETCDSnapshotRestoreConf
@@ -54,6 +55,7 @@ func init() {
 			"machine_selector_files":  testClusterV2RKEConfigMachineSelectorFilesInterface,
 			"registries":              testClusterV2RKEConfigRegistryInterface,
 			"etcd":                    testClusterV2RKEConfigETCDInterface,
+			"networking":              testClusterV2RKEConfigNetworkingInterface,
 			"rotate_certificates":     testClusterV2RKEConfigRotateCertificatesInterface,
 			"etcd_snapshot_create":    testClusterV2RKEConfigETCDSnapshotCreateInterface,
 			"etcd_snapshot_restore":   testClusterV2RKEConfigETCDSnapshotRestoreInterface,

--- a/rancher2/structure_machine_config_v2_amazonec2.go
+++ b/rancher2/structure_machine_config_v2_amazonec2.go
@@ -52,22 +52,22 @@ type machineConfigV2Amazonec2 struct {
 	VpcID                   string   `json:"vpcId,omitempty" yaml:"vpcId,omitempty"`
 	Zone                    string   `json:"zone,omitempty" yaml:"zone,omitempty"`
 
-	// Enables or disables the IPv6 endpoint for the instance metadata service.
+	// HttpProtocolIpv6 enables or disables the IPv6 endpoint for the instance metadata service.
 	// Options: enabled, disabled
 	HttpProtocolIpv6 string `json:"httpProtocolIpv6,omitempty" yaml:"httpProtocolIpv6,omitempty"`
 
-	// Indicates whether the instance’s first assigned IPv6 address is set as the primary IPv6 address.
+	// EnablePrimaryIpv6 indicates whether the instance’s first assigned IPv6 address is set as the primary IPv6 address.
 	// Enable this option if the instance requires a stable, persistent IPv6 address.
 	// This option does not affect whether IPv6 addresses are assigned to the instance.
 	// For more information, see EnablePrimaryIpv6 on
 	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html
 	EnablePrimaryIpv6 bool `json:"enablePrimaryIpv6,omitempty" yaml:"enablePrimaryIpv6,omitempty"`
 
-	// The number of IPv6 addresses to assign to the network interface.
+	// Ipv6AddressCount sets the number of IPv6 addresses to assign to the network interface.
 	// It must be greater than zero when Ipv6AddressOnly is true
 	Ipv6AddressCount string `json:"ipv6AddressCount,omitempty" yaml:"ipv6AddressCount,omitempty"`
 
-	// Indicates whether the instance has only IPv6 address.
+	// Ipv6AddressOnly indicates whether the instance has only IPv6 address.
 	// Useful when the VPC or subnet is configured as IPv6-only.
 	Ipv6AddressOnly bool `json:"ipv6AddressOnly,omitempty" yaml:"ipv6AddressOnly,omitempty"`
 }

--- a/rancher2/structure_machine_config_v2_amazonec2.go
+++ b/rancher2/structure_machine_config_v2_amazonec2.go
@@ -12,7 +12,7 @@ const (
 	machineConfigV2Amazonec2ClusterIDsep = "."
 )
 
-//Types
+// Types
 
 type machineConfigV2Amazonec2 struct {
 	metav1.TypeMeta         `json:",inline"`
@@ -51,6 +51,25 @@ type machineConfigV2Amazonec2 struct {
 	VolumeType              string   `json:"volumeType,omitempty" yaml:"volumeType,omitempty"`
 	VpcID                   string   `json:"vpcId,omitempty" yaml:"vpcId,omitempty"`
 	Zone                    string   `json:"zone,omitempty" yaml:"zone,omitempty"`
+
+	// Enables or disables the IPv6 endpoint for the instance metadata service.
+	// Options: enabled, disabled
+	HttpProtocolIpv6 string `json:"httpProtocolIpv6,omitempty" yaml:"httpProtocolIpv6,omitempty"`
+
+	// Indicates whether the instance’s first assigned IPv6 address is set as the primary IPv6 address.
+	// Enable this option if the instance requires a stable, persistent IPv6 address.
+	// This option does not affect whether IPv6 addresses are assigned to the instance.
+	// For more information, see EnablePrimaryIpv6 on
+	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html
+	EnablePrimaryIpv6 bool `json:"enablePrimaryIpv6,omitempty" yaml:"enablePrimaryIpv6,omitempty"`
+
+	// The number of IPv6 addresses to assign to the network interface.
+	// It must be greater than zero when Ipv6AddressOnly is true
+	Ipv6AddressCount string `json:"ipv6AddressCount,omitempty" yaml:"ipv6AddressCount,omitempty"`
+
+	// Indicates whether the instance has only IPv6 address.
+	// Useful when the VPC or subnet is configured as IPv6-only.
+	Ipv6AddressOnly bool `json:"ipv6AddressOnly,omitempty" yaml:"ipv6AddressOnly,omitempty"`
 }
 
 type MachineConfigV2Amazonec2 struct {
@@ -176,6 +195,18 @@ func flattenMachineConfigV2Amazonec2(in *MachineConfigV2Amazonec2) []interface{}
 	if len(in.Zone) > 0 {
 		obj["zone"] = in.Zone
 	}
+
+	if len(in.HttpProtocolIpv6) > 0 {
+		obj["http_protocol_ipv6"] = in.HttpProtocolIpv6
+	}
+
+	if len(in.Ipv6AddressCount) > 0 {
+		obj["ipv6_address_count"] = in.Ipv6AddressCount
+	}
+
+	obj["enable_primary_ipv6"] = in.EnablePrimaryIpv6
+
+	obj["ipv6_address_only"] = in.Ipv6AddressOnly
 
 	return []interface{}{obj}
 }
@@ -322,6 +353,21 @@ func expandMachineConfigV2Amazonec2(p []interface{}, source *MachineConfigV2) *M
 
 	if v, ok := in["zone"].(string); ok && len(v) > 0 {
 		obj.Zone = v
+	}
+
+	if v, ok := in["http_protocol_ipv6"].(string); ok && len(v) > 0 {
+		obj.HttpProtocolIpv6 = v
+	}
+
+	if v, ok := in["ipv6_address_count"].(string); ok && len(v) > 0 {
+		obj.Ipv6AddressCount = v
+	}
+
+	if v, ok := in["enable_primary_ipv6"].(bool); ok {
+		obj.EnablePrimaryIpv6 = v
+	}
+	if v, ok := in["ipv6_address_only"].(bool); ok {
+		obj.Ipv6AddressOnly = v
 	}
 
 	return obj


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
 
- https://github.com/rancher/rancher/issues/52174
- https://github.com/rancher/terraform-provider-rancher2/issues/1500


## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
We would like to enhance rancher-terraform-provider to support AWS node-driver IPv6 downstream clusters 


## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

This PR introduces the new fields to the corresponding resources:

- Add new fields to machineConfigV2Amazonec2Fields
- Add the networking field to ClusterV2RKEConfig

 
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Using the rancher-terraform-provider binary built from this PR, I was able to successfully provision AWS node-driver IPv6 / dual-stack downstream clusters.

<img width="1407" height="430" alt="image" src="https://github.com/user-attachments/assets/b5325df2-3ee1-48bb-8828-54b71b0f2abf" />


### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

Unit tests are added at proper levels. 

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
We should be able to provision AWS node-driver IPv6/ dual-stack downstream clusters. 


### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

We should be able to provision AWS node-driver IPv4 downstream clusters. 

