### PR TITLE
fix: emit all response data for troubleshooting

### DIFF
--- a/.github/workflows/scripts/backport-issues.js
+++ b/.github/workflows/scripts/backport-issues.js
@@ -20,6 +20,7 @@ async ({ github, context, core, process }) => {
     core.setFailed(`Failed to retrieve PR #${extractedPrNumber}: ${error.message}`);
   }
   const pr = response.data;
+  core.info(`PR data: ${JSON.stringify(pr)}`);
   const prNumber = pr.number;
 
   // Note: can't get terraform-maintainers team, the default token can't access org level objects
@@ -41,6 +42,7 @@ async ({ github, context, core, process }) => {
     core.setFailed(`Failed to create backport issue: ${error.message}`);
   }
   const newIssue = response.data;
+  core.info(`New backport issue data: ${JSON.stringify(newIssue)}`);
   const subIssueId = newIssue.id;
 
   // Attach the sub-issue to the parent, use REST API because there isn't a github-script API yet.

--- a/.github/workflows/scripts/backport-pr.js
+++ b/.github/workflows/scripts/backport-pr.js
@@ -65,6 +65,11 @@ export default async ({ github, core, process }) => {
     core.setFailed(`Failed to fetch sub-issues for tracking issue #${trackingIssue.number}: ${error.message}`);
   }
   const subIssues = response.data;
+  core.info(`Sub-issues data: ${JSON.stringify(subIssues)}`);
+  if (!Array.isArray(subIssues)) {
+    core.warning(`Unexpected sub-issues data format: ${JSON.stringify(subIssues)}`);
+    return;
+  }
   if (subIssues.length === 0) {
     core.info(`No sub-issues found for issue #${trackingIssue.number}. Exiting.`);
     return;
@@ -117,6 +122,7 @@ export default async ({ github, core, process }) => {
       core.setFailed(`Failed to create pull request for branch ${newBranchName}: ${error.message}`);
     }
     const newPR = response.data;
+    core.info(`Created backport PR data: ${JSON.stringify(newPR)}`);
     const prNumber = newPR.number;
     try {
       await github.rest.issues.addAssignees({

--- a/.github/workflows/scripts/tracking-issue.js
+++ b/.github/workflows/scripts/tracking-issue.js
@@ -30,6 +30,7 @@ async ({ github, core, context, process }) => {
     core.setFailed(`Failed to create tracking issue: ${error.message}`);
   }
   const newIssue = response.data;
+  core.info(`New tracking issue data: ${JSON.stringify(newIssue)}`);
   if (releaseLabel) {
     // if release label detected, then add appropriate sub-issues
     const parentIssue = newIssue;
@@ -51,6 +52,7 @@ async ({ github, core, context, process }) => {
       core.setFailed(`Failed to create backport issue: ${error.message}`);
     }
     const newSubIssue = response.data;
+    core.info(`New backport issue data: ${JSON.stringify(newSubIssue)}`);
     const subIssueId = newSubIssue.id;
     // Attach the sub-issue to the parent using API request
     try {


### PR DESCRIPTION
<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
This creates an info message for all responses from the GitHub API to troubleshoot requests.

## Testing

<!--- Please describe how you verified this change or why testing isn't relevant. --->
actionlint, node --check, and eslint
This doesn't change the product.

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
