### PR TITLE
fix: set bootstrap sha and release version

### DIFF
--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -19,6 +19,7 @@ rancher
 rc
 rke
 rke2
+sha
 terraform
 variablize
 IPv

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762156382,
-        "narHash": "sha256-Yg7Ag7ov5+36jEFC1DaZh/12SEXo6OO3/8rqADRxiqs=",
+        "lastModified": 1762286042,
+        "narHash": "sha256-OD5HsZ+sN7VvNucbrjiCz7CHF5zf9gP51YVJvPwYIH8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7241bcbb4f099a66aafca120d37c65e8dda32717",
+        "rev": "12c1f0253aa9a54fdf8ec8aecaafada64a111e24",
         "type": "github"
       },
       "original": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,14 @@
 {
+  "bootstrap-sha": "ab77bd4030512387b04480079c38aa54f8590eb9",
+  "release-as": "v13.0.0",
+  "always-update": true,
+  "commit-search-depth": 100,
+  "prerelease": true,
+  "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "packages": {
     ".": {
-      "release-type": "go",
-      "prerelease": true,
-      "include-v-in-tag": true,
-      "include-component-in-tag": false,
-      "always-update": true,
-      "initial-version": "v13.0.0"
+      "release-type": "go"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
Straighten out release please initial PR.
This will tell release-please to release as v13.0.0, we will need create a PR every release to change this number.
Explicitly generating a PR to set the release version is a good thing since our versioning is not based on semantic changes.
In the future we can remove this line to have release-please calculate the version, but on the initial run it needs to be set.
We tell release please which commit sha in the release/v13 branch is the first we should consider for this release.
The SHA I have placed is the first commit added since the release/v13 branch was created, we can remove this for the next release as it is only used once.

## Testing
actionlint
This doesn't effect the product.
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
