### PR TITLE
fix: allow specifying sha

### DIFF
--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -6,6 +6,9 @@ on:
       tag:
         description: 'The rc tag to create, e.g. v1.2.3-rc.1'
         required: true
+      sha:
+        description: 'The commit SHA to create the tag from, defaults to HEAD of the selected branch.'
+        required: false
 
 permissions:
   contents: write
@@ -22,15 +25,17 @@ jobs:
       - name: Create and Push RC Tag with Git
         id: create-push-rc-tag
         env:
-          NEXT_RC_TAG: ${{ inputs.tag }}
+          TAG: ${{ inputs.tag }}
+          SHA: ${{ inputs.sha }}
         run: |
-          # Configure git user
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-
-          # Create and push the new tag
-          git tag "$NEXT_RC_TAG" -m "Release Candidate $NEXT_RC_TAG"
-          git push origin "$NEXT_RC_TAG"
+          if [ -n "$SHA" ]; then
+            git tag "$TAG" -m "Release Candidate $TAG" "$SHA"
+          else
+            git tag "$TAG" -m "Release Candidate $TAG"
+          fi
+          git push origin "$TAG"
       - name: retrieve GPG Credentials
         id: retrieve-gpg-credentials
         uses: rancher-eio/read-vault-secrets@main

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -30,10 +30,11 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          if [ -n "${SHA}" ]; then
-            git checkout "$SHA"
+          if [ -n "$SHA" ]; then
+            git tag "$TAG" -m "Release $TAG" "$SHA"
+          else
+            git tag "$TAG" -m "Release $TAG"
           fi
-          git tag "$TAG" -m "Release $TAG"
           git push origin "$TAG"
       - name: retrieve GPG Credentials
         id: retrieve-gpg-credentials
@@ -66,7 +67,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
         with:
-          args: release --clean --config .goreleaser_rc.yml
+          args: release --clean --config .goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,8 @@ builds:
     ignore:
       - goos: windows
         goarch: arm
+      - goos: windows
+        goarch: arm64
 archives:
   - formats: [ 'zip' ]
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,6 +1,6 @@
 {
     "version": 1,
     "metadata": {
-        "protocol_versions": ["6.0"]
+        "protocol_versions": ["4.0"]
     }
 }


### PR DESCRIPTION
<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
This allows users to specify the sha of the release they want to tag.
This also includes a fix to the terraform registry manifest, we are on protocol 4 not 6.
This also includes an improvement to the manual release process we can specify the sha without checking it out.

## Testing

<!--- Please describe how you verified this change or why testing isn't relevant. --->
actionlint
This doesn't affect the actual product.
<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
