### PR TITLE
fix: goreleaser needs git state at the new tag

### DIFF
--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -36,6 +36,11 @@ jobs:
             git tag "$TAG" -m "Release Candidate $TAG"
           fi
           git push origin "$TAG"
+      - name: Check out new tag into a new directory
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout
+        with:
+          ref: ${{ inputs.tag }}
+          path: ${{ github.workspace }}/tags/${{ inputs.tag }}
       - name: retrieve GPG Credentials
         id: retrieve-gpg-credentials
         uses: rancher-eio/read-vault-secrets@main
@@ -64,11 +69,16 @@ jobs:
 
           echo "Importing gpg key"
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go
+        with:
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
         with:
-          args: release --clean --config .goreleaser_rc.yml
+          args: release --clean --config ../../.goreleaser_rc.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+          MANIFEST_PATH: ../../terraform-registry-manifest.json

--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -71,7 +71,8 @@ jobs:
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go
         with:
-          go-version-file: 'go.mod'
+          go-version-file: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.mod
+          cache-dependency-path: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.sum
           cache: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -71,7 +71,8 @@ jobs:
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go
         with:
-          go-version-file: 'go.mod'
+          go-version-file: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.mod
+          cache-dependency-path: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.sum
           cache: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -36,6 +36,11 @@ jobs:
             git tag "$TAG" -m "Release $TAG"
           fi
           git push origin "$TAG"
+      - name: Check out new tag into a new directory
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout
+        with:
+          ref: ${{ inputs.tag }}
+          path: ${{ github.workspace }}/tags/${{ inputs.tag }}
       - name: retrieve GPG Credentials
         id: retrieve-gpg-credentials
         uses: rancher-eio/read-vault-secrets@main
@@ -64,11 +69,17 @@ jobs:
 
           echo "Importing gpg key"
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go
+        with:
+          go-version-file: 'go.mod'
+          cache: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
         with:
-          args: release --clean --config .goreleaser.yml
+          args: release --clean --config ../../.goreleaser.yml
+          workdir: ${{ github.workspace }}/tags/${{ inputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+          MANIFEST_PATH: ../../terraform-registry-manifest.json

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,7 @@ archives:
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:
-    - glob: 'terraform-registry-manifest.json'
+    - glob: '{{ .Env.MANIFEST_PATH | default "terraform-registry-manifest.json" }}'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
@@ -57,7 +57,7 @@ signs:
       - "${artifact}"
 release:
   extra_files:
-    - glob: 'terraform-registry-manifest.json'
+    - glob: '{{ .Env.MANIFEST_PATH | default "terraform-registry-manifest.json" }}'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   prerelease: auto
 changelog:

--- a/.goreleaser_rc.yml
+++ b/.goreleaser_rc.yml
@@ -34,7 +34,7 @@ archives:
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:
-    - glob: 'terraform-registry-manifest.json'
+    - glob: '{{ .Env.MANIFEST_PATH | default "terraform-registry-manifest.json" }}'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
@@ -54,7 +54,7 @@ signs:
       - "${artifact}"
 release:
   extra_files:
-    - glob: 'terraform-registry-manifest.json'
+    - glob: '{{ .Env.MANIFEST_PATH | default "terraform-registry-manifest.json" }}'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   prerelease: auto
 changelog:

--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -8,6 +8,7 @@ eks
 globbing
 git
 github
+goreleaser
 kubeconfig
 kubernetes
 oci


### PR DESCRIPTION
<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
GoReleaser needs to be checked out at the location in Git history of the tag to be released.
This is tricky because that point in history might not have the GoReleaser config or the Terraform registry config.
This checks out the new tag for manual releases into its own directory, then uses the workdir key in the GoReleaser action to tell goreleaser to use that new directory. We also pass an environment variable pointing to the proper terraform registry config and tell goreleaser to use the parent directory's goreleaser config.

## Testing
actionlint, goreleaser check
This change doesn't affect the product.
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
