### PR TITLE
fix: ensure the correct workflow, users, and tags

### DIFF
--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -29,7 +29,9 @@ jobs:
             return isMaintainer;
       - run: |
           # if the tag doesn't contain "rc" we should not be in this workflow
-          if [[ "${{ inputs.tag }}" != *"rc"* ]]; then
+          if grep -q "rc" <<< "${{ inputs.tag }}"; then
+            echo "Tag contains 'rc', continuing with RC release"
+          else
             echo "Tag doesn't contain 'rc', please use the manual-release workflow"
             exit 1
           fi

--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -19,6 +19,20 @@ jobs:
   rc-release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script/commits/main
+        id: check-user-in-maintainers
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const isMaintainer = ${{ vars.TERRAFORM_MAINTAINERS }}.includes(context.actor);
+            return isMaintainer;
+      - run: |
+          # if the tag doesn't contain "rc" we should not be in this workflow
+          if [[ "${{ inputs.tag }}" != *"rc"* ]]; then
+            echo "Tag doesn't contain 'rc', please use the manual-release workflow"
+            exit 1
+          fi
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout
         with:
           fetch-depth: 0

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -19,6 +19,20 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script/commits/main
+        id: check-user-in-maintainers
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const isMaintainer = ${{ vars.TERRAFORM_MAINTAINERS }}.includes(context.actor);
+            return isMaintainer;
+      - run: |
+          # if the tag contains "rc" we should not be in this workflow
+          if [[ "${{ inputs.tag }}" == *"rc"* ]]; then
+            echo "Tag contains 'rc', please use the manual-rc-release workflow"
+            exit 1
+          fi
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout
         with:
           fetch-depth: 0
@@ -41,6 +55,11 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
           path: ${{ github.workspace }}/tags/${{ inputs.tag }}
+      - run: |
+          # remove any tags that are not the one specified (to avoid goreleaser confusion)
+          cd "${{ github.workspace }}/tags/${{ inputs.tag }}"
+          git tag | grep -v "${{ inputs.tag }}" | xargs git tag -d
+          cd ../../
       - name: retrieve GPG Credentials
         id: retrieve-gpg-credentials
         uses: rancher-eio/read-vault-secrets@main

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -29,7 +29,7 @@ jobs:
             return isMaintainer;
       - run: |
           # if the tag contains "rc" we should not be in this workflow
-          if [[ "${{ inputs.tag }}" == *"rc"* ]]; then
+          if grep -q "rc" <<< "${{ inputs.tag }}"; then
             echo "Tag contains 'rc', please use the manual-rc-release workflow"
             exit 1
           fi


### PR DESCRIPTION
<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
This makes sure that the release workflows can only be run by someone in the maintainers group.
This also makes sure that someone doesn't accidentally trigger the wrong workflow, if there is an rc in the tag you should be using the release candidate workflow, if not you shoul dbe using the full release workflow.
This removes all local tags on the checked out sha that don't match the one we generate so that Goreleaser only finds the one tag on the sha.

## Testing
actionlint
This doesn't affect the product.
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
