### PR TITLE
fix: make sure to only match the tag specified

### DIFF
--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -57,6 +57,12 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
           path: ${{ github.workspace }}/tags/${{ inputs.tag }}
+      - run: |
+          # remove any tags that are not the one specified (to avoid goreleaser confusion)
+          DIR="$(pwd)"
+          cd "${{ github.workspace }}/tags/${{ inputs.tag }}"
+          git tag | grep -v -e "^${{ inputs.tag }}$" | xargs git tag -d
+          cd "$DIR"
       - name: retrieve GPG Credentials
         id: retrieve-gpg-credentials
         uses: rancher-eio/read-vault-secrets@main

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -57,9 +57,10 @@ jobs:
           path: ${{ github.workspace }}/tags/${{ inputs.tag }}
       - run: |
           # remove any tags that are not the one specified (to avoid goreleaser confusion)
+          DIR="$(pwd)"
           cd "${{ github.workspace }}/tags/${{ inputs.tag }}"
-          git tag | grep -v "${{ inputs.tag }}" | xargs git tag -d
-          cd ../../
+          git tag | grep -v -e "^${{ inputs.tag }}$" | xargs git tag -d
+          cd "$DIR"
       - name: retrieve GPG Credentials
         id: retrieve-gpg-credentials
         uses: rancher-eio/read-vault-secrets@main


### PR DESCRIPTION
<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
This makes sure that the tag we leave for Goreleaser is only the tag specified.
There was a problem where the grep wasn't specific enough and all v8.3.0-rc tags were found when attempting to release v8.3.0.


## Testing
actionlint
This change doesn't effect the product.
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
