### PR TITLE
fix: remove the default template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,7 @@ archives:
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:
-    - glob: '{{ .Env.MANIFEST_PATH | default "terraform-registry-manifest.json" }}'
+    - glob: '{{ .Env.MANIFEST_PATH }}'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
@@ -57,7 +57,7 @@ signs:
       - "${artifact}"
 release:
   extra_files:
-    - glob: '{{ .Env.MANIFEST_PATH | default "terraform-registry-manifest.json" }}'
+    - glob: '{{ .Env.MANIFEST_PATH }}'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   prerelease: auto
 changelog:

--- a/.goreleaser_rc.yml
+++ b/.goreleaser_rc.yml
@@ -34,7 +34,7 @@ archives:
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:
-    - glob: '{{ .Env.MANIFEST_PATH | default "terraform-registry-manifest.json" }}'
+    - glob: '{{ .Env.MANIFEST_PATH }}'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
@@ -54,7 +54,7 @@ signs:
       - "${artifact}"
 release:
   extra_files:
-    - glob: '{{ .Env.MANIFEST_PATH | default "terraform-registry-manifest.json" }}'
+    - glob: '{{ .Env.MANIFEST_PATH }}'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   prerelease: auto
 changelog:


### PR DESCRIPTION
## Description
This removes the invalid "default" call in the template for goreleaser.
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->

## Testing
actionlint, goreleaser check
This doesn't affect the product.
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
