### PR TITLE
fix: use separate goreleaser files for manual

### DIFF
--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -99,9 +99,9 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
         with:
-          args: release --clean --config ../../.goreleaser_rc.yml
+          args: release --clean --config ../../.goreleaser_rc_manual.yml
+          workdir: ${{ github.workspace }}/tags/${{ inputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-          MANIFEST_PATH: ../../terraform-registry-manifest.json

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -97,10 +97,9 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
         with:
-          args: release --clean --config ../../.goreleaser.yml
+          args: release --clean --config ../../.goreleaser_manual.yml
           workdir: ${{ github.workspace }}/tags/${{ inputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-          MANIFEST_PATH: ../../terraform-registry-manifest.json

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,7 @@ archives:
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:
-    - glob: '{{ .Env.MANIFEST_PATH }}'
+    - glob: './terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
@@ -57,7 +57,7 @@ signs:
       - "${artifact}"
 release:
   extra_files:
-    - glob: '{{ .Env.MANIFEST_PATH }}'
+    - glob: './terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   prerelease: auto
 changelog:

--- a/.goreleaser_manual.yml
+++ b/.goreleaser_manual.yml
@@ -3,6 +3,9 @@ version: 2
 before:
   hooks:
     - go mod tidy
+git:
+  ignore_tags:
+    - "*rc*"
 builds:
   - binary: '{{ .ProjectName }}_v{{ .Version }}'
     env:
@@ -34,7 +37,7 @@ archives:
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:
-    - glob: './terraform-registry-manifest.json'
+    - glob: '../../terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
@@ -54,7 +57,7 @@ signs:
       - "${artifact}"
 release:
   extra_files:
-    - glob: './terraform-registry-manifest.json'
+    - glob: '../../terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   prerelease: auto
 changelog:

--- a/.goreleaser_rc_manual.yml
+++ b/.goreleaser_rc_manual.yml
@@ -34,7 +34,7 @@ archives:
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:
-    - glob: './terraform-registry-manifest.json'
+    - glob: './../../terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
@@ -54,7 +54,7 @@ signs:
       - "${artifact}"
 release:
   extra_files:
-    - glob: './terraform-registry-manifest.json'
+    - glob: './../../terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   prerelease: auto
 changelog:


### PR DESCRIPTION
<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
This hard codes the terraform registry file in the goreleaser config.
To accomplish this for the manual releases we needed a new config for each type of manual run.

## Testing

<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
