### PR TITLE
fix: add all protocols to metadata

### DIFF
--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -69,7 +69,7 @@ jobs:
           {
               "version": 1,
               "metadata": {
-                  "protocol_versions": ["4.0"]
+                  "protocol_versions": ["4.0", "5.0", "6.0"]
               }
           }
           EOF

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -67,7 +67,7 @@ jobs:
           {
               "version": 1,
               "metadata": {
-                  "protocol_versions": ["4.0"]
+                  "protocol_versions": ["4.0", "5.0", "6.0"]
               }
           }
           EOF


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->
Addresses #

<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
The terraform-registry-manifest.json only specifies the v4 protocol for the provider, which is accurate, but is causing all versions of Terraform to be unable to use the new release.

## Testing

<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
