### PR TITLE
fix: improve the documentation for cluster resources 

### DIFF
--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -4,9 +4,11 @@ page_title: "rancher2_cluster_v2 Resource"
 
 # rancher2\_cluster\_v2 Resource
 
-Provides a Rancher v2 Cluster v2 resource. This can be used to create RKE2 and K3s Clusters for Rancher v2 environments and retrieve their information. 
+Provides a Rancher v2 Cluster v2 resource. This can be used to create node-driver and custom RKE2 and K3s Clusters for Rancher v2 environments and retrieve their information. 
 
 This resource is available in Rancher v2.6.0 and above.
+
+**Hint**: To create an imported cluster for registering a standalone Kubernetes cluster into rancher, use the Rancher v2 Cluster resource instead.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->
Addresses  
- https://github.com/rancher/terraform-provider-rancher2/issues/1804
- https://github.com/rancher/terraform-provider-rancher2/issues/1738

<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

This PR adds the following missing information to the documentation:

1. Clarification on when to use the `rancher2_cluster` resource versus the `rancher2_cluster_v2` resource.
2. A notice that RKE1 clusters have been deprecated.
3. An example demonstrating how to enable and configure the version-management feature on an imported cluster.
4. Remove examples for creating RKE1 node-driver or custom clusters


## Testing
 
Not a breaking change. Need to ensure the documentation is displayed properly after release.  

----

**Note to reviews**

- The failure of the validate-commit-message workflow can be ignored 