### PR TITLE
fix: support exceptions in diff suppression

### DIFF
--- a/rancher2/schema_common.go
+++ b/rancher2/schema_common.go
@@ -11,35 +11,47 @@ const (
 	commonAnnotationLabelRancher = "rancher.io/"
 )
 
+// exceptions is a list of annotation/label keys that should not be suppressed.
+var exceptions = []string{
+	"rancher.io/imported-cluster-version-management",
+}
+
+// supressFunc is a DiffSuppressFunc that prevents Terraform from trying to remove Rancher-managed annotations/labels;
+// it ignores the annotation from a predefined list of annotation/label keys.
+var supressFunc = func(k, old, new string, d *schema.ResourceData) bool {
+	for _, exception := range exceptions {
+		// The key `k` is prefixed with "annotations." or "labels."
+		// suppress the diff if the key contains the exception
+		if strings.Contains(k, exception) {
+			return false
+		}
+	}
+
+	// Suppress the diff for Rancher-managed annotations/labels
+	if (strings.Contains(k, commonAnnotationLabelCattle) || strings.Contains(k, commonAnnotationLabelRancher)) && new == "" {
+		return true
+	}
+
+	return false
+}
+
 // Schemas
 
 func commonAnnotationLabelFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"annotations": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Annotations of the resource",
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				// Suppressing diff for annotations containing cattle.io/
-				if (strings.Contains(k, commonAnnotationLabelCattle) || strings.Contains(k, commonAnnotationLabelRancher)) && new == "" {
-					return true
-				}
-				return false
-			},
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Computed:         true,
+			Description:      "Annotations of the resource",
+			DiffSuppressFunc: supressFunc,
 		},
 		"labels": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Computed:    true,
-			Description: "Labels of the resource",
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				// Suppressing diff for labels containing cattle.io/
-				if (strings.Contains(k, commonAnnotationLabelCattle) || strings.Contains(k, commonAnnotationLabelRancher)) && new == "" {
-					return true
-				}
-				return false
-			},
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Computed:         true,
+			Description:      "Labels of the resource",
+			DiffSuppressFunc: supressFunc,
 		},
 	}
 	return s

--- a/rancher2/schema_common_test.go
+++ b/rancher2/schema_common_test.go
@@ -1,0 +1,73 @@
+package rancher2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSupressFunc(t *testing.T) {
+	cases := []struct {
+		Name           string
+		K              string
+		Old            string
+		New            string
+		ExpectedResult bool
+	}{
+		{
+			Name:           "Exception key change should not be suppressed",
+			K:              "annotations.rancher.io/imported-cluster-version-management",
+			Old:            "true",
+			New:            "false",
+			ExpectedResult: false,
+		},
+		{
+			Name:           "Exception key removal should not be suppressed",
+			K:              "labels.rancher.io/imported-cluster-version-management",
+			Old:            "false",
+			New:            "",
+			ExpectedResult: false,
+		},
+		{
+			Name:           "Rancher.io annotation/label removal should be suppressed",
+			K:              "annotations.rancher.io/creator",
+			Old:            "user-123",
+			New:            "",
+			ExpectedResult: true,
+		},
+		{
+			Name:           "Cattle.io annotation/label removal should be suppressed",
+			K:              "annotations.cattle.io/some-state",
+			Old:            "some-val",
+			New:            "",
+			ExpectedResult: true,
+		},
+		{
+			Name:           "User-managed change to a rancher.io annotation should not be suppressed",
+			K:              "annotations.rancher.io/creator",
+			Old:            "user-123",
+			New:            "user-456",
+			ExpectedResult: false,
+		},
+		{Name: "User-managed change to a cattle.io annotation should not be suppressed",
+			K:              "annotations.cattle.io/creator",
+			Old:            "user-123",
+			New:            "user-456",
+			ExpectedResult: false,
+		},
+		{
+			Name:           "Non-Rancher annotation should not be suppressed",
+			K:              "annotations.my-custom-annotation",
+			Old:            "old-val",
+			New:            "new-val",
+			ExpectedResult: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := supressFunc(tc.K, tc.Old, tc.New, nil)
+			assert.Equal(t, tc.ExpectedResult, result)
+		})
+	}
+}

--- a/rancher2/schema_common_test.go
+++ b/rancher2/schema_common_test.go
@@ -29,6 +29,13 @@ func TestSupressFunc(t *testing.T) {
 			ExpectedResult: false,
 		},
 		{
+			Name:           "Exception key but not as suffix should not be suppressed",
+			K:              "labels.rancher.io/imported-cluster-version-management-new",
+			Old:            "old_val",
+			New:            "new_val",
+			ExpectedResult: false,
+		},
+		{
 			Name:           "Rancher.io annotation/label removal should be suppressed",
 			K:              "annotations.rancher.io/creator",
 			Old:            "user-123",
@@ -41,6 +48,13 @@ func TestSupressFunc(t *testing.T) {
 			Old:            "some-val",
 			New:            "",
 			ExpectedResult: true,
+		},
+		{
+			Name:           "Cattle.io annotation/label addition should not be suppressed",
+			K:              "annotations.cattle.io/some-state",
+			Old:            "",
+			New:            "some_val",
+			ExpectedResult: false,
 		},
 		{
 			Name:           "User-managed change to a rancher.io annotation should not be suppressed",
@@ -62,11 +76,18 @@ func TestSupressFunc(t *testing.T) {
 			New:            "new-val",
 			ExpectedResult: false,
 		},
+		{
+			Name:           "Non-Rancher annotation removal should not be suppressed",
+			K:              "annotations.my-custom-annotation",
+			Old:            "old-val",
+			New:            "",
+			ExpectedResult: false,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			result := supressFunc(tc.K, tc.Old, tc.New, nil)
+			result := suppressFunc(tc.K, tc.Old, tc.New, nil)
 			assert.Equal(t, tc.ExpectedResult, result)
 		})
 	}


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->
Addresses  https://github.com/rancher/terraform-provider-rancher2/issues/1807 


<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

Please see https://github.com/rancher/terraform-provider-rancher2/issues/1807 for details. 

This PR adds support for exceptions when computing the diff of Rancher-managed labels and annotations. 

## Testing

Following the same steps provided in the issue, I can confirm that Terraform detects the removal of the annotation, and after applying the changes, the annotation on the cluster is set to its default value by rancher-webhook. 


Output: 
```
Terraform will perform the following actions:

  # rancher2_cluster.my-imported-cluster-tf will be updated in-place
  ~ resource "rancher2_cluster" "my-imported-cluster-tf" {
      ~ annotations                = {
          - "rancher.io/imported-cluster-version-management"              = "false" -> null
            # (9 unchanged elements hidden)
        }
        id                         = "c-zcwc9"
        name                       = "jiaqi-imported-cluster-tf"
        # (13 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
...
```

Rancher side: 
<img width="1008" height="621" alt="Screenshot 2025-11-14 at 11 55 09 AM" src="https://github.com/user-attachments/assets/feb34c84-36e1-4c41-936b-0edcd9ff4b6f" />




 
