### PR TITLE
fix: clear space on runners before release tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,24 @@ permissions:
   actions: read
 
 jobs:
+  clear-space:
+    runs-on: ubuntu-latest
+    outputs:
+      release_pr: ${{ steps.release-please.outputs.pr }}
+      release_version: ${{ steps.release-please.outputs.version }}
+    steps:
+      - name: 'Clear out GitHub Runner'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script
+        env:
+        with:
+          script: |
+            const scriptPath = '${{ github.workspace }}/.github/workflows/scripts/clear-runner.js';
+            const { default: script } = await import(scriptPath);
+            await script();
+
   release:
+    needs:
+      - clear-space
     runs-on: ubuntu-latest
     outputs:
       release_pr: ${{ steps.release-please.outputs.pr }}
@@ -57,6 +74,7 @@ jobs:
 
   test:
     needs:
+      - clear-space
       - release
     if: needs.release.outputs.release_pr
     runs-on: ubuntu-latest
@@ -105,6 +123,7 @@ jobs:
 
   cleanup:
     needs:
+      - clear-space
       - release
       - test
     if: always() && needs.release.outputs.release_pr
@@ -141,6 +160,7 @@ jobs:
 
   report:
     needs:
+      - clear-space
       - release
       - test
       - cleanup
@@ -180,6 +200,7 @@ jobs:
 
   rc-release:
     needs:
+      - clear-space
       - release
       - test
       - cleanup
@@ -223,6 +244,8 @@ jobs:
           # Create and push the new tag
           git tag "$NEXT_RC_TAG" -m "Release Candidate $NEXT_RC_TAG"
           git push origin "$NEXT_RC_TAG"
+          echo "RC_TAG=$NEXT_RC_TAG" >> $GITHUB_ENV
+          echo "RC_BRANCH=release/$BASE_VERSION" >> $GITHUB_ENV
       - name: retrieve GPG Credentials
         id: retrieve-gpg-credentials
         uses: rancher-eio/read-vault-secrets@main
@@ -259,10 +282,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+      - name: 'Find Issues and Create Comments'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script
+        env:
+          TAG: ${{ env.RC_TAG }}
+          BRANCH: ${{ env.RC_BRANCH }}
+        with:
+          script: |
+            const scriptPath = `${{ github.workspace }}/.github/workflows/scripts/notify-rc.js`;
+            const { default: script } = await import(scriptPath);
+            await script({github, process});
 
   # This runs after release-please generates a release, so when the release PR is merged
   publish:
     needs:
+      - clear-space
       - release
       - test
       - cleanup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,8 +241,8 @@ jobs:
           # Create and push the new tag
           git tag "$NEXT_RC_TAG" -m "Release Candidate $NEXT_RC_TAG"
           git push origin "$NEXT_RC_TAG"
-          echo "RC_TAG=$NEXT_RC_TAG" >> $GITHUB_ENV
-          echo "RC_BRANCH=release/$BASE_VERSION" >> $GITHUB_ENV
+          echo "RC_TAG=$NEXT_RC_TAG" >> "$GITHUB_ENV"
+          echo "RC_BRANCH=release/$BASE_VERSION" >> "$GITHUB_ENV"
       - name: retrieve GPG Credentials
         id: retrieve-gpg-credentials
         uses: rancher-eio/read-vault-secrets@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,6 @@ permissions:
 jobs:
   clear-space:
     runs-on: ubuntu-latest
-    outputs:
-      release_pr: ${{ steps.release-please.outputs.pr }}
-      release_version: ${{ steps.release-please.outputs.version }}
     steps:
       - name: 'Clear out GitHub Runner'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
     steps:
       - name: 'Clear out GitHub Runner'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script
-        env:
         with:
           script: |
             const scriptPath = '${{ github.workspace }}/.github/workflows/scripts/clear-runner.js';

--- a/.github/workflows/scripts/clear-runner.js
+++ b/.github/workflows/scripts/clear-runner.js
@@ -1,0 +1,34 @@
+async () => {
+  const pathsToRemove = [
+    '/usr/lib/jvm',
+    '/usr/share/dotnet',
+    '/usr/share/swift',
+    '/usr/local/.ghcup',
+    '/usr/local/julia*',
+    '/usr/local/lib/android',
+    '/usr/local/share/chromium',
+    '/opt/microsoft',
+    '/opt/google',
+    '/opt/az',
+    '/usr/local/share/powershell',
+    '/opt/hostedtoolcache'
+  ];
+
+  core.info('Disk space before cleanup:');
+  await exec.exec('df', ['-h']);
+
+  // Iterate over paths and remove them
+  for (const path of pathsToRemove) {
+    core.info(`Removing ${path}...`);
+    // We use 'bash -c' to ensure wildcards (like julia*) are expanded correctly
+    // We use ignoreReturnCode: true so the build doesn't fail if a folder is already missing
+    await exec.exec('sudo', ['bash', '-c', `rm -rf ${path}`], { ignoreReturnCode: true });
+  }
+
+  core.info('Pruning Docker...');
+  await exec.exec('docker', ['system', 'prune', '-af'], { ignoreReturnCode: true });
+  await exec.exec('docker', ['builder', 'prune', '-af'], { ignoreReturnCode: true });
+
+  core.info('Disk space after cleanup:');
+  await exec.exec('df', ['-h']);
+};

--- a/.github/workflows/scripts/notify-rc.js
+++ b/.github/workflows/scripts/notify-rc.js
@@ -1,18 +1,19 @@
-async ({ github, context }) => {
-  const release = context.payload.release;
-  const tagName = release.tag_name;
+async ({ github, process }) => {
+  const tagName = process.env.TAG;
+  const branchLabel = process.env.BRANCH;
+  const owner = github.repo.owner
+  const repo = github.repo.repo
   
   if (!tagName.toLowerCase().includes('rc')) {
     console.log(`Tag "${tagName}" does not appear to be an RC. Skipping notification.`);
     return; 
   }
-  const branchLabel = release.target_commitish;
   
   console.log(`RC Detected: ${tagName}`);
   console.log(`Searching for open issues with label: "${branchLabel}"`);
 
   const issues = await github.paginate(github.rest.search.issuesAndPullRequests, {
-    q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open label:${branchLabel} -label:internal/user -label:internal/tracking`
+    q: `repo:${owner}/${repo} is:issue is:open label:${branchLabel} -label:internal/user -label:internal/tracking`
   });
 
   if (issues.length === 0) {
@@ -20,7 +21,7 @@ async ({ github, context }) => {
     return;
   }
 
-  const releaseUrl = release.html_url;
+  const releaseUrl = `https://github.com/${owner}/${repo}/releases/tag/${tagName}`;
   const commentBody = `New Release Candidate Available for Validation: [${tagName}](${releaseUrl})\n\n`;
 
   let commentedCount = 0;
@@ -29,8 +30,8 @@ async ({ github, context }) => {
 
     try {
       await github.rest.issues.createComment({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
+        owner: owner,
+        repo: repo,
         issue_number: issue.number,
         body: commentBody
       });

--- a/.github/workflows/scripts/notify-rc.js
+++ b/.github/workflows/scripts/notify-rc.js
@@ -1,8 +1,8 @@
 async ({ github, process }) => {
   const tagName = process.env.TAG;
   const branchLabel = process.env.BRANCH;
-  const owner = github.repo.owner
-  const repo = github.repo.repo
+  const owner = github.repo.owner;
+  const repo = github.repo.repo;
   
   if (!tagName.toLowerCase().includes('rc')) {
     console.log(`Tag "${tagName}" does not appear to be an RC. Skipping notification.`);


### PR DESCRIPTION

<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description
This adds a js script to clear out the github runner.
It implements this script in the release workflow, clearing out space before running e2e tests.
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->

## Testing
actionlint, node, and eslint checks
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change. This doesn't affect the product.
