### PR TITLE
fix: improve cleanup and skip in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
           export AWS_RETRY_MODE="adaptive"
           export ACME_SERVER_URL="https://acme-v02.api.letsencrypt.org/directory"
           export RANCHER_INSECURE="false"
-          ./run_tests.sh -t ${{matrix.test_name}}
+          ./run_tests.sh -t ${{matrix.test_name}} -d
   audit:
     needs:
       - setup

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# This script is run by the run_tests.sh script to clean up AWS resources created during testing.
+# It can also be run independently to clean up resources by providing a cleanup ID.
+cleanup_id="$1"
+if [ -z "$cleanup_id" ]; then
+  echo "No cleanup Id provided. Exiting."
+  exit 1
+fi
+echo "Starting cleanup for Id: $cleanup_id"
+IDENTIFIER="$cleanup_id"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+
+resources_to_clear="$(leftovers -d --iaas=aws --aws-region="$AWS_REGION" --filter="Id:$IDENTIFIER" | grep -v 'AccessDenied')"
+resources_ids="$(echo "$resources_to_clear" | awk -F"Id:" '{print $2}' | awk -F"," '{print $1}' | awk -F")" '{print $1}' | sort | uniq)"
+max_attempts=3
+
+echo "   resources found:"
+while IFS= read -r r; do
+  echo "    $r"
+done <<<"$resources_to_clear"
+
+echo "   resources ids:"
+for r in $resources_ids; do
+  echo "    $r"
+done
+
+if [ -z "$resources_ids" ]; then resources_ids=$IDENTIFIER; fi
+
+for id in $resources_ids; do
+  IDENTIFIER=$id
+  echo "Clearing leftovers with Id $IDENTIFIER in $AWS_REGION..."
+  attempts=0
+
+  resources_to_clear="$(leftovers -d --iaas=aws --aws-region="$AWS_REGION" --filter="Id:$IDENTIFIER" | grep -v 'AccessDenied' || true)"
+  while [ -n "$resources_to_clear" ] && [ $attempts -lt $max_attempts ]; do
+    echo -e "found these resources to clear:\n $resources_to_clear\n"
+    leftovers --iaas=aws --aws-region="$AWS_REGION" --filter="Id:$IDENTIFIER" --no-confirm | grep -v 'AccessDenied' || true
+    sleep 10
+    resources_to_clear="$(leftovers -d --iaas=aws --aws-region="$AWS_REGION" --filter="Id:$IDENTIFIER" | grep -v 'AccessDenied' || true)"
+    if [ -n "$resources_to_clear" ]; then
+      echo "Some resources failed to clear, retrying in $((attempts * 10)) seconds..."
+    fi
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+
+  if [ $attempts -eq $max_attempts ]; then
+    echo "Warning: Failed to clear all resources after $max_attempts attempts."
+  fi
+
+  # remove secrets
+  echo "Clearing out secrets if they were missed..."
+  attempts=0
+  while [ $attempts -lt $max_attempts ]; do
+    while read -r arn; do
+      if [ -z "$arn" ]; then
+        continue
+      fi
+      echo "removing secret $arn..."
+      aws secretsmanager delete-secret --secret-id "$arn" --force-delete-without-recovery
+    done <<<"$(aws resourcegroupstaggingapi get-resources --no-cli-pager --resource-type-filters "secretsmanager:secret" --tag-filters "Key=Id,Values=$IDENTIFIER" | jq -r '.ResourceTagMappingList[]?.ResourceARN')"
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+
+  # remove s3 storage
+  echo "Clearing out s3 buckets if they were missed..."
+  attempts=0
+  while [ $attempts -lt $max_attempts ]; do
+    while read -r id; do
+      if [ -z "$id" ]; then
+        continue
+      fi
+      echo "   removing s3 bucket $id..."
+      echo "   clearing out versions..."
+      while read -r v; do
+        if [ -z "$v" ]; then continue; fi;
+        aws s3api delete-object --bucket "$id" --key "tfstate" --version-id="$v" > /dev/null 2>&1;
+      done <<<"$(aws s3api list-object-versions --bucket "$id" | jq -r '.DeleteMarkers[]?.VersionId' || true)"
+      while read -r v; do
+        if [ -z "$v" ]; then continue; fi;
+        aws s3api delete-object --bucket "$id" --key "tfstate" --version-id="$v" > /dev/null 2>&1;
+      done <<<"$(aws s3api list-object-versions --bucket "$id" | jq -r '.Versions[]?.VersionId' || true)"
+      echo "   removing bucket..."
+      aws s3 rb "s3://$id" --force
+    done <<<"$(aws resourcegroupstaggingapi get-resources --no-cli-pager --resource-type-filters "s3:bucket" --tag-filters "Key=Id,Values=$IDENTIFIER" | jq -r '.ResourceTagMappingList[]?.ResourceARN' | awk -F'arn:aws:s3:::' '{print $2}' || true)"
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+
+  # remove key pairs
+  echo "Clearing out key pairs if they were missed..."
+  attempts=0
+  while [ $attempts -lt $max_attempts ]; do
+    while read -r id; do
+      if [ -z "$id" ]; then
+        continue
+      fi
+      echo "   removing ec2 key pair $id..."
+      aws ec2 delete-key-pair --key-pair-id "$id" || true
+    done <<<"$(aws resourcegroupstaggingapi get-resources --no-cli-pager --resource-type-filters "ec2:key-pair" --tag-filters "Key=Id,Values=$IDENTIFIER" | jq -r '.ResourceTagMappingList[]?.ResourceARN' | awk -F'/' '{print $2}')"
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+
+  # remove server certificates
+  # unfortunately get-resources doesn't support iam server certificates
+  echo "Clearing out server certificates if they were missed..."
+  attempts=0
+  while [ $attempts -lt $max_attempts ]; do
+    while read -r name; do
+      if [ -z "$name" ]; then
+        continue
+      fi
+      if aws iam list-server-certificate-tags --server-certificate-name "$name" | jq -e --arg ID "$IDENTIFIER" '.Tags[] | select(.Key=="Id" and (.Value | contains($ID)))' > /dev/null; then
+        echo "   removing iam server certificate $name..."
+        aws iam delete-server-certificate --server-certificate-name "$name" || true
+      fi
+    done <<<"$(aws iam list-server-certificates | jq -r '.ServerCertificateMetadataList[].ServerCertificateName')"
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+
+  # remove load balancer target groups
+  echo "Clearing out load balancer target groups if they were missed..."
+  attempts=0
+  while [ $attempts -lt $max_attempts ]; do
+    while read -r arn; do
+      if [ -z "$arn" ]; then
+        continue
+      fi
+      echo "   removing load balancer target group $arn..."
+      aws elbv2 delete-target-group --target-group-arn "$arn" || true;
+    done <<<"$(aws resourcegroupstaggingapi get-resources --no-cli-pager --resource-type-filters "elasticloadbalancing:targetgroup" --tag-filters "Key=Id,Values=$IDENTIFIER" | jq -r '.ResourceTagMappingList[]?.ResourceARN')"
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+done
+
+echo "Cleanup completed."
+
+# These examples find Ids that need to be cleaned up by looking for resources owned by CI and extracting their Id tags.
+# This is useful if you happen to come across leftover resources and want to clean up anything that might have been missed with their specific Id.
+# For example, if you hit a quota limit and notice there a bunch of leftover secrets or target groups, you can run these commands to clean up all resources with the same Id as the leftover resources.
+# for id in $(aws resourcegroupstaggingapi get-resources --no-cli-pager --resource-type-filters "elasticloadbalancing:targetgroup" --tag-filters "Key=Owner,Values=terraform-ci@suse.com" | jq -r '.ResourceTagMappingList[]?.Tags[] | select(.Key=="Id") | .Value'); do ./cleanup.sh "$id"; done
+# for id in $(aws resourcegroupstaggingapi get-resources --no-cli-pager --resource-type-filters "secretsmanager:secret" --tag-filters "Key=Owner,Values=terraform-ci@suse.com" | jq -r '.ResourceTagMappingList[]?.Tags[] | select(.Key=="Id") | .Value'); do ./cleanup.sh "$id"; done
+# for id in $(for name in $(aws iam list-server-certificates | jq -r '.ServerCertificateMetadataList[].ServerCertificateName'); do echo "$(aws iam list-server-certificate-tags --server-certificate-name "$name" | jq -r '.Tags[] | select(.Key=="Id").Value')"; done); do ./cleanup.sh "$id"; done

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,20 +1,26 @@
 #!/bin/bash
 
+rerun_failed=false
 specific_test=""
 specific_package=""
 cleanup_id=""
 slow_mode=false
+dirty_mode=false
 
-while getopts ":st:p:c:" opt; do
+while getopts ":rsdt:p:c:" opt; do
   case $opt in
+    r) rerun_failed=true ;;
     t) specific_test="$OPTARG" ;;
     p) specific_package="$OPTARG" ;;
     c) cleanup_id="$OPTARG" ;;
+    d) dirty_mode=true ;;
     s) slow_mode=true ;;
     \?) cat <<EOT >&2 && exit 1 ;;
 Invalid option -$OPTARG, valid options are
+  -r to re-run failed tests
   -s to run tests in slow mode (one at a time to avoid AWS rate limiting)
   -c to run clean up only with the given id (eg. abc123)
+  -d to skip cleanup (dirty mode)
   -t to specify a specific test (eg. TestBase)
   -p to specify a specific test package (eg. one)
 Only one of -c, -t, or -p can be used at a time.
@@ -26,6 +32,11 @@ if [ $slow_mode == true ]; then
   echo "Running in slow mode: tests will be run one at a time to avoid AWS rate limiting."
 elif [ $slow_mode == false ]; then
   echo "Running in normal mode: tests will be run in parallel."
+fi
+if [ $rerun_failed == true ]; then
+  echo "Rerun failed tests is enabled."
+elif [ $rerun_failed == false ]; then
+  echo "Rerun failed tests is disabled."
 fi
 if [ -n "$specific_test" ]; then
   echo "Specific test to run: $specific_test"
@@ -52,6 +63,11 @@ if [ -n "$specific_package" ] && { [ -n "$specific_test" ] || [ -n "$cleanup_id"
   echo "Error: Only one of -c, -t, or -p can be used at a time." >&2
   exit 1
 fi
+if [ $dirty_mode == true ]; then
+  echo "Running in dirty mode: skipping cleanup."
+elif [ $dirty_mode == false ]; then
+  echo "Running in normal mode: cleanup will try to remove all resources matching ID."
+fi
 
 # shellcheck disable=SC2143
 if [ -n "$cleanup_id" ]; then
@@ -64,22 +80,39 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 TEST_DIR=""
 if [ -d "tests" ]; then
   TEST_DIR="tests"
-elif [ -d "test/tests" ]; then
-  TEST_DIR="test/tests"
-elif [ -d "test" ]; then
+fi
+if [ -d "test" ]; then
   TEST_DIR="test"
-else
+fi
+if [ -d "test/tests" ]; then
+  TEST_DIR="test/tests"
+fi
+if [ "$TEST_DIR" == "" ]; then
   echo "Error: Unable to find tests directory" >&2
   exit 1
 fi
 
 run_tests() {
-  local slow_mode=$1
-  local test_dir="$2"
+  local rerun=$1
+  local slow_mode=$2
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  cd "$REPO_ROOT" || exit 1
 
-  local repo_root
-  repo_root="$(git rev-parse --show-toplevel)"
-  cd "$repo_root" || exit 1
+  # Find the tests directory
+  TEST_DIR=""
+  if [ -d "tests" ]; then
+    TEST_DIR="tests"
+  fi
+  if [ -d "test" ]; then
+    TEST_DIR="test"
+  fi
+  if [ -d "test/tests" ]; then
+    TEST_DIR="test/tests"
+  fi
+  if [ "$TEST_DIR" == "" ]; then
+    echo "Error: Unable to find tests directory" >&2
+    exit 1
+  fi
 
   echo "" > "/tmp/${IDENTIFIER}_test.log"
   rm -f "/tmp/${IDENTIFIER}_failed_tests.txt"
@@ -101,7 +134,13 @@ EOF
   chmod +x "/tmp/${IDENTIFIER}_test-processor"
   export NO_COLOR=1
   echo "starting tests..."
-  cd "$test_dir" || return 1;
+  cd "$TEST_DIR" || return 1;
+
+  local rerun_flag=""
+  if [ "$rerun" = true ] && [ -f "/tmp/${IDENTIFIER}_failed_tests.txt" ]; then
+    # shellcheck disable=SC2002
+    rerun_flag="-run=$(cat "/tmp/${IDENTIFIER}_failed_tests.txt" | tr '\n' '|')"
+  fi
 
   local specific_test_flag=""
   # shellcheck disable=SC2143
@@ -131,34 +170,36 @@ EOF
 
   CMD=$(cat <<EOT
 gotestsum \
-  --format "standard-verbose" \
+  --format=standard-verbose \
   --jsonfile "/tmp/${IDENTIFIER}_test.log" \
   --post-run-command "sh /tmp/${IDENTIFIER}_test-processor" \
-  --packages "$repo_root/$test_dir/$package_pattern" \
+  --packages "$REPO_ROOT/$TEST_DIR/$package_pattern" \
   -- \
   -count=1 \
   -timeout=300m \
+  -failfast \
   $parallel_packages \
   $parallel_tests \
-  $specific_test_flag \
-  -failfast
+  $rerun_flag \
+  $specific_test_flag
 EOT
 )
   echo "Running command: $CMD"
 
   # shellcheck disable=SC2086
   gotestsum \
-    --format="standard-verbose" \
-    --jsonfile="/tmp/${IDENTIFIER}_test.log" \
-    --post-run-command="sh /tmp/${IDENTIFIER}_test-processor" \
-    --packages="$repo_root/$test_dir/$package_pattern" \
+    --format=standard-verbose \
+    --jsonfile "/tmp/${IDENTIFIER}_test.log" \
+    --post-run-command "sh /tmp/${IDENTIFIER}_test-processor" \
+    --packages "$REPO_ROOT/$TEST_DIR/$package_pattern" \
     -- \
     -count=1 \
     -timeout=300m \
+    -failfast \
     $parallel_packages \
     $parallel_tests \
-    $specific_test_flag \
-    -failfast
+    $rerun_flag \
+    $specific_test_flag
 
   return $?
 }
@@ -173,19 +214,28 @@ if [ -z "$GITHUB_OWNER" ]; then echo "GITHUB_OWNER isn't set"; else echo "GITHUB
 if [ -z "$ZONE" ]; then echo "ZONE isn't set"; else echo "ZONE is set"; fi
 
 if [ -z "$cleanup_id" ]; then
-  echo "checking tests for compile errors..."
+
   D="$(pwd)"
 
+  echo "tidying..."
   cd "$REPO_ROOT/$TEST_DIR" || exit
   if ! go mod tidy; then C=$?; echo "failed to tidy, exit code $C"; exit $C; fi
-  echo "completed tidy..."
 
+  echo "formatting tests..."
+  gofmt -s -w -e .
+  echo "done formatting"
+
+  echo "checking tests for compile errors..."
   while IFS= read -r file; do
     echo "found $file";
     if ! go test -c "$file" -o "${file}.test"; then C=$?; echo "failed to compile $file, exit code $C"; exit $C; fi
     rm -rf "${file}.test"
-  done <<< "$(find "$REPO_ROOT/$TEST_DIR" -not \( -path "$REPO_ROOT/$TEST_DIR/data" -prune \) -name '*_test.go')"
+  done <<< "$(find "$REPO_ROOT/$TEST_DIR" -not \( -path "$REPO_ROOT/$TEST_DIR/data" -prune \) -name '*.go')"
   echo "compile checks passed..."
+
+  echo "checking tests for go lint errors..."
+  if ! golangci-lint run; then echo "lint failed..."; exit 1; fi
+  echo "lint errors complete"
 
   cd "$D" || exit
 
@@ -193,80 +243,34 @@ if [ -z "$cleanup_id" ]; then
   if ! tflint --recursive; then C=$?; echo "tflint failed, exit code $C"; exit $C; fi
   echo "terraform configs valid..."
 
-  make build
-
-  run_tests $slow_mode "$TEST_DIR"
+  # Run tests initially
+  run_tests false "$slow_mode"
   sleep 60
+
+  # Check if we need to rerun failed tests
+  if [ "$rerun_failed" = true ] && [ -f "/tmp/${IDENTIFIER}_failed_tests.txt" ]; then
+    echo "Rerunning failed tests..."
+    run_tests true "$slow_mode"
+    sleep 60
+  fi
 fi
 
-echo "Clearing leftovers with Id $IDENTIFIER in $AWS_REGION..."
-
-# shellcheck disable=SC2143
-if [ -n "$IDENTIFIER" ]; then
-  attempts=0
-  # shellcheck disable=SC2143
-  while [ -n "$(leftovers -d --iaas=aws --aws-region="$AWS_REGION" --filter="Id:$IDENTIFIER" | grep -v 'AccessDenied')" ] && [ $attempts -lt 3 ]; do
-    leftovers --iaas=aws --aws-region="$AWS_REGION" --filter="Id:$IDENTIFIER" --no-confirm | grep -v 'AccessDenied' || true
-    sleep 10
-    attempts=$((attempts + 1))
-  done
-
-  if [ $attempts -eq 3 ]; then
-    echo "Warning: Failed to clear all resources after 3 attempts."
+if [ $dirty_mode == true ]; then
+  echo "Running in dirty mode, skipping cleanup..."
+else
+  echo "Starting cleanup..."
+  sh "$REPO_ROOT/cleanup.sh" "$IDENTIFIER"
+  C=$?
+  if [ $C -ne 0 ]; then
+    echo "Cleanup failed with exit code $C"
+    exit $C
   fi
+  echo "Cleanup completed successfully."
+fi
 
-  # remove key pairs
-  attempts=0
-  # shellcheck disable=SC2143
-  while [ -n "$(leftovers -d --iaas=aws --aws-region="$AWS_REGION" --type="ec2-key-pair" --filter="terraform-ci-$IDENTIFIER" | grep -v 'AccessDenied')" ] && [ $attempts -lt 3 ]; do
-    leftovers --iaas=aws --aws-region="$AWS_REGION" --type="ec2-key-pair" --filter="terraform-ci-$IDENTIFIER" --no-confirm | grep -v 'AccessDenied' || true
-    sleep 10
-    attempts=$((attempts + 1))
-  done
-
-  if [ $attempts -eq 3 ]; then
-    echo "Warning: Failed to clear all EC2 key pairs after 3 attempts."
-  fi
-
-  # remove s3 storage
-  attempts=0
-  ID="$(aws s3 ls | grep -i "$IDENTIFIER" | awk '{print $3}')"
-  # shellcheck disable=SC2143
-  while [ -n "$(aws s3 ls | grep -i "$IDENTIFIER")" ] && [ $attempts -lt 3 ]; do
-    echo "found s3 bucket $ID, removing..."
-    while read -r v; do
-      if [ -z "$v" ]; then continue; fi;
-      aws s3api delete-object --bucket "$(echo "$ID" | tr '[:upper:]' '[:lower:]')" --key "tfstate" --version-id="$v" > /dev/null 2>&1;
-    done <<<"$(aws s3api list-object-versions --bucket "$(echo "$ID" | tr '[:upper:]' '[:lower:]')" | jq -r '.Versions[]?.VersionId')"
-
-    while read -r v; do
-      if [ -z "$v" ]; then continue; fi;
-      aws s3api delete-object --bucket "$(echo "$ID" | tr '[:upper:]' '[:lower:]')" --key "tfstate" --version-id="$v" > /dev/null 2>&1;
-    done <<<"$(aws s3api list-object-versions --bucket "$(echo "$ID" | tr '[:upper:]' '[:lower:]')" | jq -r '.DeleteMarkers[]?.VersionId')"
-
-    aws s3api delete-bucket --bucket "$(echo "$ID" | tr '[:upper:]' '[:lower:]')" > /dev/null 2>&1;
-
-    sleep 10
-    attempts=$((attempts + 1))
-  done
-
-  # remove load balancer target groups
-  attempts=0
-  # shellcheck disable=SC2143
-  while [ $attempts -lt 3 ]; do
-    while read -r line; do
-      if [ -z "$line" ]; then continue; fi
-      echo "removing load balancer target group, $line..."
-      aws elbv2 delete-target-group --target-group-arn "$line" > /dev/null 2>&1;
-    done <<<"$(
-      while read -r line; do
-        if [ -z "$line" ]; then continue; fi
-        aws elbv2 describe-tags --resource-arns "$line" | jq -r --arg id "$IDENTIFIER" '.TagDescriptions[] | select(any(.Tags[]; .Key == "Id" and .Value == $id)) | .ResourceArn // ""';
-      done <<<"$(aws elbv2 describe-target-groups | jq -r '.TargetGroups[]?.TargetGroupArn')"
-    )"
-    sleep 10
-    attempts=$((attempts + 1))
-  done
+if [ -n "$cleanup_id" ]; then
+  # cleanup only mode
+  exit 0
 fi
 
 if [ -f "/tmp/${IDENTIFIER}_failed_tests.txt" ]; then


### PR DESCRIPTION
<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description
This revamps the cleanup process after running tests:
- it improves the search for resources
- it adds resources to clean up
- it separates out the cleanup to its own file that can be run on its own

This also adds a "dirty_mode" to the run_test script which disables the cleanup script.
- the reason for this is due to the way resources are found, the cleanup only has half of the full resource ID
- it therefore cleans up every resource that starts with that first half
- when only running the script at one time with the same ID this is fine
   - but when running the script multiple times with the same ID prefix there is an issue
   - the cleanup script will destroy tests in progress
- dirty mode allows the CI to skip cleanup for now and run it in a stand alone fashion after all tests complete.

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->

## Testing
actionlint, shellcheck
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
This doesn't affect the product.