### PR TITLE
fix: break out the config pkg for better testing

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764733908,
-        "narHash": "sha256-QJiih52NU+nm7XQWCj+K8SwUdIEayDQ1FQgjkYISt4I=",
+        "lastModified": 1764794580,
+        "narHash": "sha256-UMVihg0OQ980YqmOAPz+zkuCEb9hpE5Xj2v+ZGNjQ+M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cadcc8de247676e4751c9d4a935acb2c0b059113",
+        "rev": "ebc94f855ef25347c314258c10393a92794e7ab9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
               gitleaks
               gnupg
               go
+              golangci-lint
               goreleaser
               gotestfmt
               gotestsum

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -1,4 +1,4 @@
-package test
+package config
 
 import (
 	"os"
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/git"
 	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	util "github.com/rancher/terraform-provider-rancher2/test"
 )
 
 type TestConfig struct {
@@ -19,6 +20,7 @@ type TestConfig struct {
 	ExampleDir              string
 	TestDir                 string
 	KeyPair                 *aws.Ec2Keypair
+	KP                      *ssh.KeyPair
 	SshAgent                ssh.SshAgent
 	Rke2Version             string
 	RancherVersion          string
@@ -32,12 +34,12 @@ type TestConfig struct {
 
 func NewTestConfig(t *testing.T, directory string) *TestConfig {
 
-	id := GetId()
-	region := GetRegion()
+	id := util.GetId()
+	region := util.GetRegion()
 	owner := "terraform-ci@suse.com"
 	dnsZone := os.Getenv("ZONE")
 
-	SetAcmeServer()
+	util.SetAcmeServer()
 
 	repoRoot, err := filepath.Abs(git.GetRepoRoot(t))
 	if err != nil {
@@ -47,19 +49,20 @@ func NewTestConfig(t *testing.T, directory string) *TestConfig {
 	testDir := filepath.Join(repoRoot, "test", "data", id)
 	kubeconfigPath := filepath.Join(testDir, "kubeconfig")
 
-	err = CreateTestDirectories(t, id)
+	err = util.CreateTestDirectories(t, id)
 	if err != nil {
 		os.RemoveAll(testDir)
 		t.Fatalf("Error creating test data directories: %s", err)
 	}
 
-	keyPair, err := CreateKeypair(t, region, owner, id)
+	keyPair, err := util.CreateKeypair(t, region, owner, id)
 	if err != nil {
 		os.RemoveAll(testDir)
 		t.Fatalf("Error creating test key pair: %s", err)
 	}
+	kp := keyPair.KeyPair
 
-	err = os.WriteFile(filepath.Join(testDir, "id_rsa"), []byte(keyPair.KeyPair.PrivateKey), 0600)
+	err = os.WriteFile(filepath.Join(testDir, "id_rsa"), []byte(kp.PrivateKey), 0600)
 	if err != nil {
 		err = aws.DeleteEC2KeyPairE(t, keyPair)
 		if err != nil {
@@ -69,21 +72,21 @@ func NewTestConfig(t *testing.T, directory string) *TestConfig {
 		t.Fatalf("Error creating test key pair: %s", err)
 	}
 
-	sshAgent := ssh.SshAgentWithKeyPair(t, keyPair.KeyPair)
+	sshAgent := ssh.SshAgentWithKeyPair(t, kp)
 	t.Logf("Key %s created and added to agent", keyPair.Name)
 
-	backendTerraformOptions, err := CreateObjectStorageBackend(t, id, owner, region)
+	backendTerraformOptions, err := util.CreateObjectStorageBackend(t, id, owner, region)
 	tfOptions := []*terraform.Options{backendTerraformOptions}
 	if err != nil {
 		t.Log("Test failed, tearing down...")
-		Teardown(t, testDir, exampleDir, tfOptions, keyPair, sshAgent)
+		util.Teardown(t, testDir, exampleDir, tfOptions, keyPair, sshAgent)
 		t.Fatalf("Error creating cluster: %s", err)
 	}
 
 	// use oldest RKE2, remember it releases much more than Rancher
-	_, _, rke2Version, err := GetRke2Releases()
+	_, _, rke2Version, err := util.GetRke2Releases()
 	if err != nil {
-		Teardown(t, testDir, exampleDir, tfOptions, keyPair, sshAgent)
+		util.Teardown(t, testDir, exampleDir, tfOptions, keyPair, sshAgent)
 		t.Fatalf("Error getting Rke2 release version: %s", err)
 	}
 
@@ -91,17 +94,17 @@ func NewTestConfig(t *testing.T, directory string) *TestConfig {
 	if rancherVersion == "" {
 		// use stable version if not specified
 		// using stable prevents problems where the Rancher provider hasn't released to fit the latest Rancher
-		_, rancherVersion, _, err = GetRancherReleases()
+		_, rancherVersion, _, err = util.GetRancherReleases()
 	}
 	if err != nil {
-		Teardown(t, testDir, exampleDir, tfOptions, keyPair, sshAgent)
+		util.Teardown(t, testDir, exampleDir, tfOptions, keyPair, sshAgent)
 		t.Fatalf("Error getting Rancher release version: %s", err)
 	}
 
 	terraformRcPath := filepath.Join(testDir, ".terraformrc")
-	err = WriteTerraformRc(t, terraformRcPath)
+	err = util.WriteTerraformRc(t, terraformRcPath)
 	if err != nil {
-		Teardown(t, testDir, exampleDir, tfOptions, keyPair, sshAgent)
+		util.Teardown(t, testDir, exampleDir, tfOptions, keyPair, sshAgent)
 		t.Fatalf("Error writing Terraform RC file: %s", err)
 	}
 
@@ -113,7 +116,7 @@ func NewTestConfig(t *testing.T, directory string) *TestConfig {
 			"identifier":      id,
 			"owner":           owner,
 			"key_name":        keyPair.Name,
-			"key":             keyPair.KeyPair.PublicKey,
+			"key":             kp.PublicKey,
 			"zone":            dnsZone,
 			"rke2_version":    rke2Version,
 			"rancher_version": rancherVersion,
@@ -127,7 +130,7 @@ func NewTestConfig(t *testing.T, directory string) *TestConfig {
 			"TF_IN_AUTOMATION":   "1",
 			"TF_CLI_CONFIG_FILE": terraformRcPath,
 		},
-		RetryableTerraformErrors: GetRetryableTerraformErrors(),
+		RetryableTerraformErrors: util.GetRetryableTerraformErrors(),
 		NoColor:                  true,
 		SshAgent:                 sshAgent,
 		BackendConfig: map[string]interface{}{
@@ -147,6 +150,7 @@ func NewTestConfig(t *testing.T, directory string) *TestConfig {
 		ExampleDir:              exampleDir,
 		TestDir:                 testDir,
 		KeyPair:                 keyPair,
+		KP:                      kp,
 		SshAgent:                *sshAgent,
 		BackendTerraformOptions: backendTerraformOptions,
 		TerraformOptions:        terraformOptions,
@@ -160,19 +164,19 @@ func NewTestConfig(t *testing.T, directory string) *TestConfig {
 }
 
 func (config *TestConfig) Teardown(t *testing.T) {
-	Teardown(t, config.TestDir, config.ExampleDir, config.TfOptions, config.KeyPair, &config.SshAgent)
+	util.Teardown(t, config.TestDir, config.ExampleDir, config.TfOptions, config.KeyPair, &config.SshAgent)
 }
 
 func (config *TestConfig) GetErrorLogs(t *testing.T) {
-	GetErrorLogs(t, config.KubeconfigPath)
+	util.GetErrorLogs(t, config.KubeconfigPath)
 }
 
 func (config *TestConfig) CheckReady(t *testing.T) {
-	CheckReady(t, config.KubeconfigPath)
+	util.CheckReady(t, config.KubeconfigPath)
 }
 
 func (config *TestConfig) CheckRunning(t *testing.T) {
-	CheckRunning(t, config.KubeconfigPath)
+	util.CheckRunning(t, config.KubeconfigPath)
 }
 
 func (config *TestConfig) AddVars(vars map[string]interface{}) {

--- a/test/one/basic_test.go
+++ b/test/one/basic_test.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	util "github.com/rancher/terraform-provider-rancher2/test"
+	cfg "github.com/rancher/terraform-provider-rancher2/test/config"
 )
 
 func TestOneBasic(t *testing.T) {
 	t.Parallel()
-	config := util.NewTestConfig(t, "use-cases/one")
+	config := cfg.NewTestConfig(t, "use-cases/one")
 
 	defer config.Teardown(t)
 	defer config.GetErrorLogs(t)
@@ -33,7 +34,7 @@ func TestOneBasic(t *testing.T) {
 
 	// Running the apply again should re-create everything from state in S3
 	// This should only recreate the files, the AWS and Rancher resources should be untouched
-	err = os.WriteFile(filepath.Join(config.TestDir, "id_rsa"), []byte(config.KeyPair.KeyPair.PrivateKey), 0600)
+	err = os.WriteFile(filepath.Join(config.TestDir, "id_rsa"), []byte(config.KP.PrivateKey), 0600)
 	if err != nil {
 		t.Log("Test failed, tearing down...")
 		t.Fatalf("Error creating cluster: %s", err)

--- a/test/production/basic_test.go
+++ b/test/production/basic_test.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	util "github.com/rancher/terraform-provider-rancher2/test"
+	cfg "github.com/rancher/terraform-provider-rancher2/test/config"
 )
 
 func TestProductionBasic(t *testing.T) {
 	t.Parallel()
-	config := util.NewTestConfig(t, "use-cases/production")
+	config := cfg.NewTestConfig(t, "use-cases/production")
 
 	config.AddVars(map[string]interface{}{
 		"aws_access_key_id":     util.GetAwsAccessKey(),

--- a/test/three/basic_test.go
+++ b/test/three/basic_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	util "github.com/rancher/terraform-provider-rancher2/test"
+	cfg "github.com/rancher/terraform-provider-rancher2/test/config"
 )
 
 func TestThreeBasic(t *testing.T) {
 	t.Parallel()
-	config := util.NewTestConfig(t, "use-cases/three")
+	config := cfg.NewTestConfig(t, "use-cases/three")
 
 	defer config.Teardown(t)
 	defer config.GetErrorLogs(t)

--- a/test/util.go
+++ b/test/util.go
@@ -113,7 +113,7 @@ func filterPrimeOnly(r *[]*github.RepositoryRelease) {
 	*r = fr
 }
 
-// this effectively removes release candidates as well as pending releases
+// this effectively removes release candidates as well as pending releases.
 func filterPrerelease(r *[]*github.RepositoryRelease) {
 	var fr []*github.RepositoryRelease
 	releases := *r
@@ -286,7 +286,7 @@ func CreateKeypair(t *testing.T, region string, owner string, id string) (*aws.E
 	input = &ec2.DescribeKeyPairsInput{
 		Filters: []ec2types.Filter{keyNameFilter},
 	}
-	result, err = client.DescribeKeyPairs(context.Background(), input)
+	_, err = client.DescribeKeyPairs(context.Background(), input)
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +299,7 @@ func CreateKeypair(t *testing.T, region string, owner string, id string) (*aws.E
 	input = &ec2.DescribeKeyPairsInput{
 		Filters: []ec2types.Filter{keyNameFilter},
 	}
-	result, err = client.DescribeKeyPairs(context.Background(), input)
+	_, err = client.DescribeKeyPairs(context.Background(), input)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description
Added golangci-lint and compile tests for all of the go modules in the test directory.
I separated out the config pkg because it makes compilation testing easier.
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->

## Testing

<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
