### PR TITLE
fix: do not check out branch that we tag

### DIFF
--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -40,7 +40,6 @@ jobs:
           fi
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout
         with:
-          ref: ${{ inputs.branch }}
           fetch-depth: 0
       - name: Create and Push RC Tag with Git
         id: create-push-rc-tag

--- a/.github/workflows/scripts/backport-issues.js
+++ b/.github/workflows/scripts/backport-issues.js
@@ -29,7 +29,7 @@ async ({ github, context, core, process }) => {
     response = await github.rest.issues.create({
       owner: owner,
       repo: repo,
-      title: `[Backport][${labelName}] ${parentIssueTitle}`,
+      title: `[${labelName}] ${parentIssueTitle}`,
       body:  [
         `Backport #${prNumber} to ${labelName} for #${parentIssueNumber}`,
         `Copied from PR:`,

--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -28,3 +28,4 @@ IPv
 IPv4
 IPv6
 json
+backport


### PR DESCRIPTION
<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description
The manual rc release workflow doesn't need to check out the branch that we are releasing, the sha will handle that.
This is causing an issue where goreleaser won't work on branches that don't have the goreleaser config.
This way we can use the goreleaser config in main, and tag and release the sha we want.
We still need the branch name so that we can handle notifications.
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->

## Testing
actionlint
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
