### PR TITLE
fix: add permissions to update issues

### DIFF
--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -16,6 +16,8 @@ on:
 permissions:
   contents: write
   id-token: write
+  issues: write
+  pull-requests: write
   actions: read
 
 jobs:


### PR DESCRIPTION
<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description
This adds permissions to the manual rc release workflow to enable notifying issues. 
This is addressing the error in https://github.com/rancher/terraform-provider-rancher2/actions/runs/19954654055/job/57221306270
```
RC Detected: v8.4.0-rc.5
Searching for open issues with label: "release/v8"
Failed to comment on issue #1824: Resource not accessible by integration
Failed to comment on issue #1818: Resource not accessible by integration
Failed to comment on issue #1815: Resource not accessible by integration
Success! Notified 0 issues.
```
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->

## Testing
actionlint
<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
