### PR TITLE
feat: add default value as true for azure managed_disks option

### DIFF
--- a/rancher2/schema_machine_config_v2_azure.go
+++ b/rancher2/schema_machine_config_v2_azure.go
@@ -75,8 +75,8 @@ func machineConfigV2AzureFields() map[string]*schema.Schema {
 		"managed_disks": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Default:     false,
-			Description: "Configures VM and availability set for managed disks",
+			Default:     true,
+			Description: "Configures VM and availability set for managed disks (unmanaged disks will be retired by Azure on March 31, 2026)",
 		},
 		"no_public_ip": {
 			Type:        schema.TypeBool,


### PR DESCRIPTION
## Issue: [#52464](https://github.com/rancher/rancher/issues/52464)

## Problem

The terraform provider default for Azure `managed_disks` was set to `false`. This does not match the desired behavior for Azure going forward and can lead to inconsistent defaults across Rancher components ([machine](https://github.com/rancher/machine/pull/355), Rancher UI/CRDs, and terraform provider).

Azure unmanaged disks are being retired, so `managed_disks` should default to `true` while still allowing users to explicitly set it to `false`.

## Solution

* Update the Azure machine config v2 schema for `managed_disks`:

  * Change `Default` from `false` to `true`.
  * Update the field description to warn about the Azure unmanaged disks retirement date (March 31, 2026).

## Testing

### Manual Testing

* Run `terraform plan` / `terraform apply` for an Azure cluster/machine pool **without** setting `managed_disks`.
* Verify the resulting Azure VM uses **managed disks** by default.
* Verify setting `managed_disks = false` still results in **unmanaged disks** (where still supported).

### Automated Testing

* No automated tests added (schema-only default change).

## QA Testing Considerations

* Confirm the default is applied when the field is omitted (no diff noise in plan beyond expected).
* Confirm explicit `managed_disks = false` is respected.
* Ensure behavior matches the corresponding changes in `rancher/machine` and `rancher/rancher` for consistent defaults end-to-end.
