### PR TITLE
Fix import of ClusterProxyConfigs

### DIFF
--- a/rancher2/import_rancher2_cluster_proxy_config.go
+++ b/rancher2/import_rancher2_cluster_proxy_config.go
@@ -9,7 +9,7 @@ const (
 )
 
 func resourceRancher2ClusterProxyConfigV2Import(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	err := resourceRancher2ClusterProxyConfigV2Read(d, meta)
+	err := readClusterProxyConfigV2(d.Id(), d, meta)
 	if err != nil || d.Id() == "" {
 		return nil, err
 	}

--- a/rancher2/resource_rancher2_cluster_proxy_config_v2.go
+++ b/rancher2/resource_rancher2_cluster_proxy_config_v2.go
@@ -65,13 +65,17 @@ func resourceRancher2ClusterProxyConfigV2Create(d *schema.ResourceData, meta int
 
 func resourceRancher2ClusterProxyConfigV2Read(d *schema.ResourceData, meta interface{}) error {
 	clusterID := d.Get("cluster_id").(string)
+	clusterProxyConfigV2Id := clusterID + "/" + clusterProxyConfigV2Name
 
 	log.Printf("[INFO] Refreshing ClusterProxyConfig for cluster %s", clusterID)
 
+	return readClusterProxyConfigV2(clusterProxyConfigV2Id, d, meta)
+}
+
+func readClusterProxyConfigV2(id string, d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	clusterProxyConfigV2Id := clusterID + "/" + clusterProxyConfigV2Name
 	resp := &ClusterProxyConfigV2{}
-	err := config.getObjectV2ByID(rancher2DefaultLocalClusterID, clusterProxyConfigV2Id, clusterProxyConfigV2ApiType, resp)
+	err := config.getObjectV2ByID(rancher2DefaultLocalClusterID, id, clusterProxyConfigV2ApiType, resp)
 	if err != nil {
 		if IsNotFound(err) || IsNotAccessibleByID(err) {
 			log.Printf("[INFO] Cluster V2 %s not found", d.Id())
@@ -80,6 +84,7 @@ func resourceRancher2ClusterProxyConfigV2Read(d *schema.ResourceData, meta inter
 		}
 		return err
 	}
+
 	return flattenClusterProxyConfigV2(d, resp)
 }
 


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->
Addresses #1960

<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

This fixes a bug where the requested ID to import was not being used in the import process, which was causing an incorrect URL to be queried for and the desired resource not to be loaded correctly.

## Testing

<!--- Please describe how you verified this change or why testing isn't relevant. --->
Reproduced using the instructions in the bug and confirmed that after the fix the resource is loaded correctly.

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
