### PR TITLE
Implement PC and PDB support for the fleet agent

### DIFF
--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -29,3 +29,5 @@ IPv4
 IPv6
 json
 backport
+PDB
+PC

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -447,7 +447,7 @@ The following attributes are exported:
 * `append_tolerations` - (Optional) User defined tolerations to append to agent (list)
 * `override_affinity` - (Optional) User defined affinity to override default agent affinity (string)
 * `override_resource_requirements` - (Optional) User defined resource requirements to set on the agent (list)
-* `scheduling_customization` - (Optional) Supported in Rancher 2.11.0 and above. Defines the configuration of a Priority Class and or Pod Disruption Budget. Currently only supported by the `cluster_agent_deployment_customization` field, and requires the `cattle_cluster_agent_scheduling_customization` feature to be enabled.
+* `scheduling_customization` - (Optional) Supported in Rancher 2.11.0 and above for `cluster_agent_deployment_customization`, and in Rancher 2.14.0 and above for `fleet_agent_deployment_customization`. Defines the configuration of a Priority Class and or Pod Disruption Budget, and requires the `cluster-agent-scheduling-customization` feature to be enabled.
 
 #### `append_tolerations`
 

--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -446,14 +446,14 @@ EOF
 
 #### Customize scheduling for the cluster agent
 
-This argument is available in Rancher 2.11.0 and above.
+This argument is available in Rancher 2.11.0 and above for the cluster agent. Support for the fleet agent is available in Rancher 2.14.0 and above.
 
-You can configure a Priority Class and or Pod Disruption Budget to be automatically deployed for the cattle cluster agent when provisioning or updating downstream clusters. 
+You can configure a Priority Class and or Pod Disruption Budget to be automatically deployed for the cattle cluster agent and fleet agent when provisioning or updating downstream clusters. 
 
 In order to use this field, you must ensure that the `cluster-agent-scheduling-customization` feature is enabled in the Rancher server. 
 
 
-The example below demonstrates how to set the `scheduling_customization` field to deploy a Priority Class and Pod Disruption Budget. Currently, this field is only supported for the cluster agent. 
+The example below demonstrates how to set the `scheduling_customization` field to deploy a Priority Class and Pod Disruption Budget for both the cattle cluster agent and fleet agent.
 
 ```hcl
 resource "rancher2_cluster_v2" "foo" {
@@ -477,15 +477,34 @@ resource "rancher2_cluster_v2" "foo" {
         # max_unavailable = "1"
       }
     }
-    
+  }
+
+  fleet_agent_deployment_customization {
+    scheduling_customization {
+      priority_class {
+        # The preemption_policy must be set to 'Never', 'PreemptLowerPriority', or omitted. 
+        # If omitted, the default of 'PreemptLowerPriority' is used.
+        preemption_policy = "PreemptLowerPriority"
+        # The value cannot be less than negative 1 billion, or greater than 1 billion
+        value = 999999999
+      }
+      pod_disruption_budget {
+        # min_available and max_unavailable must either be non-negative whole integers, 
+        # or whole number percentages greater than 0 and less than or equal to 100 (e.g. "50%").
+        # You cannot set both min_available and max_unavailable at the same time.
+        min_available = "1"
+        
+        # max_unavailable = "1"
+      }
+    }
   }
 
   rke_config {
     # In the case of a node-driver cluster
     machine_pools {
       # ...
-      }
-    } 
+    }
+  } 
 }
 ```
 
@@ -936,14 +955,14 @@ The following attributes are exported:
 
 ### `cluster_agent_deployment_customization` and `fleet_agent_deployment_customization`
 
-These arguments are available in Rancher v2.7.5 and above. The `scheduling_customization` argument is only available in Rancher 2.11 and above, may only be set within `cluster_agent_deployment_customization`, and requires that the `cattle-cluster-agent-scheduling-customization` feature be enabled.
+These arguments are available in Rancher v2.7.5 and above. The `scheduling_customization` argument is available in Rancher 2.11 and above for `cluster_agent_deployment_customization`, and in Rancher 2.14.0 and above for `fleet_agent_deployment_customization`. The `scheduling_customization` argument requires that the `cattle-cluster-agent-scheduling-customization` feature be enabled.
 
 #### Arguments
 
 * `append_tolerations` - (Optional, list) A list of tolerations to be appended to the default tolerations.
 * `override_affinity` - (Optional, string, JSON format) Override affinity overrides the global default affinity setting.
 * `override_resource_requirements` - (Optional, list) Override resource requirements overrides the default value for requests and/or limits. 
-+ `scheduling_customization` - (Optional, list) Supported in Rancher 2.11.0 and above. Defines the configuration of a Priority Class and or Pod Disruption Budget. Currently only supported in the `cluster_agent_deployment_customization` field, and requires the `cattle_cluster_agent_scheduling_customization` feature to be enabled.
++ `scheduling_customization` - (Optional, list) Supported in Rancher 2.11.0 and above for `cluster_agent_deployment_customization`, and in Rancher 2.14.0 and above for `fleet_agent_deployment_customization`. Defines the configuration of a Priority Class and or Pod Disruption Budget, and requires the `cluster-agent-scheduling-customization` feature to be enabled.
 
 ### `append_tolerations`
 

--- a/docs/resources/feature.md
+++ b/docs/resources/feature.md
@@ -4,7 +4,7 @@ page_title: "rancher2_feature Resource"
 
 # rancher2\_feature Resource
 
-Provides a Rancher v2 Feature resource. This can be used to enable/disable [experimental features](https://rancher.com/docs/rancher/v2.x/en/installation/resources/feature-flags/) for Rancher v2 environments.
+Provides a Rancher v2 Feature resource. This can be used to enable/disable [experimental features](https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/enable-experimental-features) for Rancher v2 environments.
 
 Experimental features already exist at Rancher v2.5.x systems, so they can just be updated: 
 * On create, provider will read Feature from Rancher and update its value. It will return an error if feature doesn't exist

--- a/rancher2/resource_rancher2_cluster.go
+++ b/rancher2/resource_rancher2_cluster.go
@@ -281,11 +281,11 @@ func resourceRancher2ClusterUpdate(d *schema.ResourceData, meta interface{}) err
 
 	enableNetworkPolicy := d.Get("enable_network_policy").(bool)
 
-	clusterAgentDeploymentCustomization, err := expandAgentDeploymentCustomization(d.Get("cluster_agent_deployment_customization").([]interface{}), true)
+	clusterAgentDeploymentCustomization, err := expandAgentDeploymentCustomization(d.Get("cluster_agent_deployment_customization").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("[ERROR] Updating Cluster ID %s: %s", d.Id(), err)
 	}
-	fleetAgentDeploymentCustomization, err := expandAgentDeploymentCustomization(d.Get("fleet_agent_deployment_customization").([]interface{}), false)
+	fleetAgentDeploymentCustomization, err := expandAgentDeploymentCustomization(d.Get("fleet_agent_deployment_customization").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("[ERROR] Updating Cluster ID %s: %s", d.Id(), err)
 	}
@@ -354,10 +354,10 @@ func resourceRancher2ClusterUpdate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("[INFO] Rancher v2.12+ does not support RKE1. Please migrate clusters to RKE2 or K3s, or delete the related resources. More info: https://www.suse.com/c/rke-end-of-life-by-july-2025-replatform-to-rke2-or-k3s")
 	case clusterDriverK3S:
 		update["k3sConfig"] = expandClusterK3SConfig(d.Get("k3s_config").([]interface{}))
-		replace = d.HasChange("cluster_agent_deployment_customization")
+		replace = d.HasChange("cluster_agent_deployment_customization") || d.HasChange("fleet_agent_deployment_customization")
 	case clusterDriverRKE2:
 		update["rke2Config"] = expandClusterRKE2Config(d.Get("rke2_config").([]interface{}))
-		replace = d.HasChange("cluster_agent_deployment_customization")
+		replace = d.HasChange("cluster_agent_deployment_customization") || d.HasChange("fleet_agent_deployment_customization")
 	}
 
 	// update the cluster; retry til timeout or non retryable error is returned. If api 500 error is received,

--- a/rancher2/schema_agent_deployment_customization.go
+++ b/rancher2/schema_agent_deployment_customization.go
@@ -32,11 +32,11 @@ func agentDeploymentCustomizationOverrideResourceRequirementFields() map[string]
 	return s
 }
 
-func agentDeploymentCustomizationFields(includeScheduling bool) map[string]*schema.Schema {
+func agentDeploymentCustomizationFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"append_tolerations": {
 			Type:        schema.TypeList,
-			Description: "User defined tolerations to append to agent",
+			Description: "User-defined tolerations to append to agent",
 			Optional:    true,
 			Elem: &schema.Resource{
 				Schema: tolerationFields(),
@@ -44,12 +44,12 @@ func agentDeploymentCustomizationFields(includeScheduling bool) map[string]*sche
 		},
 		"override_affinity": {
 			Type:        schema.TypeString,
-			Description: "User defined affinity to override default agent affinity",
+			Description: "User-defined affinity to override default agent affinity",
 			Optional:    true,
 		},
 		"override_resource_requirements": {
 			Type:        schema.TypeList,
-			Description: "User defined resource requirements to set on the agent",
+			Description: "User-defined resource requirements to set on the agent",
 			Optional:    true,
 			Elem: &schema.Resource{
 				Schema: agentDeploymentCustomizationOverrideResourceRequirementFields(),
@@ -57,15 +57,13 @@ func agentDeploymentCustomizationFields(includeScheduling bool) map[string]*sche
 		},
 	}
 
-	if includeScheduling {
-		s["scheduling_customization"] = &schema.Schema{
-			Type:        schema.TypeList,
-			Description: "User defined scheduling customization for the cattle cluster agent",
-			Optional:    true,
-			Elem: &schema.Resource{
-				Schema: agentSchedulingCustomizationFields(),
-			},
-		}
+	s["scheduling_customization"] = &schema.Schema{
+		Type:        schema.TypeList,
+		Description: "User-defined scheduling customization for the cattle or fleet cluster agent",
+		Optional:    true,
+		Elem: &schema.Resource{
+			Schema: agentSchedulingCustomizationFields(),
+		},
 	}
 
 	return s

--- a/rancher2/schema_agent_scheduling_customization.go
+++ b/rancher2/schema_agent_scheduling_customization.go
@@ -8,7 +8,7 @@ func agentSchedulingCustomizationFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"priority_class": {
 			Type:        schema.TypeList,
-			Description: "The Priority Class created for the cattle cluster agent",
+			Description: "The Priority Class created for the cattle cluster agent or fleet agent",
 			Optional:    true,
 			Elem: &schema.Resource{
 				Schema: priorityClassFields(),
@@ -16,7 +16,7 @@ func agentSchedulingCustomizationFields() map[string]*schema.Schema {
 		},
 		"pod_disruption_budget": {
 			Type:        schema.TypeList,
-			Description: "The Pod Disruption Budget created for the cattle cluster agent",
+			Description: "The Pod Disruption Budget created for the cattle cluster agent or fleet agent",
 			Optional:    true,
 			Elem: &schema.Resource{
 				Schema: podDisruptionBudgetFields(),
@@ -29,12 +29,12 @@ func priorityClassFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"value": {
 			Type:        schema.TypeInt,
-			Description: "The priority value for the cattle cluster agent. Must be between negative 1 billion and 1 billion.",
+			Description: "The priority value for the cattle cluster agent or fleet agent. Must be between negative 1 billion and 1 billion.",
 			Required:    true,
 		},
 		"preemption_policy": {
 			Type:        schema.TypeString,
-			Description: "The preemption behavior for the cattle cluster agent. Must be either 'PreemptLowerPriority' or 'Never'",
+			Description: "The preemption behavior for the cattle cluster agent or fleet agent. Must be either 'PreemptLowerPriority' or 'Never'",
 			Optional:    true,
 		},
 	}
@@ -44,12 +44,12 @@ func podDisruptionBudgetFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"min_available": {
 			Type:        schema.TypeString,
-			Description: "The minimum number of cattle cluster agent replicas that must be running at a given time.",
+			Description: "The minimum number of cattle cluster agent or fleet agent replicas that must be running at a given time.",
 			Optional:    true,
 		},
 		"max_unavailable": {
 			Type:        schema.TypeString,
-			Description: "The maximum number of cattle cluster agent replicas that can be down at a given time.",
+			Description: "The maximum number of cattle cluster agent or fleet agent replicas that can be down at a given time.",
 			Optional:    true,
 		},
 	}

--- a/rancher2/schema_cluster.go
+++ b/rancher2/schema_cluster.go
@@ -273,7 +273,7 @@ func clusterFields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Optional customization for cluster agent",
 			Elem: &schema.Resource{
-				Schema: agentDeploymentCustomizationFields(true),
+				Schema: agentDeploymentCustomizationFields(),
 			},
 		},
 		"fleet_agent_deployment_customization": {
@@ -281,7 +281,7 @@ func clusterFields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Optional customization for fleet agent",
 			Elem: &schema.Resource{
-				Schema: agentDeploymentCustomizationFields(false),
+				Schema: agentDeploymentCustomizationFields(),
 			},
 		},
 		"driver": {

--- a/rancher2/schema_cluster_v2.go
+++ b/rancher2/schema_cluster_v2.go
@@ -60,7 +60,7 @@ func clusterV2FieldsV0() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Optional customization for cluster agent",
 			Elem: &schema.Resource{
-				Schema: agentDeploymentCustomizationFields(true),
+				Schema: agentDeploymentCustomizationFields(),
 			},
 		},
 		"fleet_agent_deployment_customization": {
@@ -68,7 +68,7 @@ func clusterV2FieldsV0() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Optional customization for fleet agent",
 			Elem: &schema.Resource{
-				Schema: agentDeploymentCustomizationFields(false),
+				Schema: agentDeploymentCustomizationFields(),
 			},
 		},
 		"default_pod_security_admission_configuration_template_name": {
@@ -175,7 +175,7 @@ func clusterV2Fields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Optional customization for cluster agent",
 			Elem: &schema.Resource{
-				Schema: agentDeploymentCustomizationFields(true),
+				Schema: agentDeploymentCustomizationFields(),
 			},
 		},
 		"fleet_agent_deployment_customization": {
@@ -183,7 +183,7 @@ func clusterV2Fields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Optional customization for fleet agent",
 			Elem: &schema.Resource{
-				Schema: agentDeploymentCustomizationFields(false),
+				Schema: agentDeploymentCustomizationFields(),
 			},
 		},
 		"default_pod_security_admission_configuration_template_name": {

--- a/rancher2/structure_agent_deployment_customization.go
+++ b/rancher2/structure_agent_deployment_customization.go
@@ -8,7 +8,7 @@ import (
 
 // Flatteners
 
-func flattenAgentDeploymentCustomization(in *managementClient.AgentDeploymentCustomization, includeScheduling bool) []interface{} {
+func flattenAgentDeploymentCustomization(in *managementClient.AgentDeploymentCustomization) []interface{} {
 	if in == nil {
 		return []interface{}{}
 	}
@@ -28,16 +28,14 @@ func flattenAgentDeploymentCustomization(in *managementClient.AgentDeploymentCus
 		obj["override_resource_requirements"] = flattenResourceRequirements(in.OverrideResourceRequirements)
 	}
 
-	if includeScheduling {
-		obj["scheduling_customization"] = flattenAgentSchedulingCustomization(in.SchedulingCustomization)
-	}
+	obj["scheduling_customization"] = flattenAgentSchedulingCustomization(in.SchedulingCustomization)
 
 	return []interface{}{obj}
 }
 
 // Expanders
 
-func expandAgentDeploymentCustomization(p []interface{}, includeScheduling bool) (*managementClient.AgentDeploymentCustomization, error) {
+func expandAgentDeploymentCustomization(p []interface{}) (*managementClient.AgentDeploymentCustomization, error) {
 	if len(p) == 0 || p[0] == nil {
 		return nil, nil
 	}
@@ -62,10 +60,8 @@ func expandAgentDeploymentCustomization(p []interface{}, includeScheduling bool)
 		obj.OverrideResourceRequirements = expandResourceRequirements(v)
 	}
 
-	if includeScheduling {
-		if v, ok := in["scheduling_customization"].([]interface{}); ok {
-			obj.SchedulingCustomization = expandAgentSchedulingCustomization(v)
-		}
+	if v, ok := in["scheduling_customization"].([]interface{}); ok {
+		obj.SchedulingCustomization = expandAgentSchedulingCustomization(v)
 	}
 
 	return obj, nil

--- a/rancher2/structure_agent_deployment_customization_v2.go
+++ b/rancher2/structure_agent_deployment_customization_v2.go
@@ -3,13 +3,13 @@ package rancher2
 import (
 	"encoding/json"
 
-	"github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 // Flatteners
 
-func flattenAgentDeploymentCustomizationV2(in *v1.AgentDeploymentCustomization, includeScheduling bool) []interface{} {
+func flattenAgentDeploymentCustomizationV2(in *v1.AgentDeploymentCustomization) []interface{} {
 	if in == nil {
 		return []interface{}{}
 	}
@@ -28,16 +28,14 @@ func flattenAgentDeploymentCustomizationV2(in *v1.AgentDeploymentCustomization, 
 		obj["override_resource_requirements"] = in.OverrideResourceRequirements
 	}
 
-	if includeScheduling {
-		obj["scheduling_customization"] = flattenAgentSchedulingCustomizationV2(in.SchedulingCustomization)
-	}
+	obj["scheduling_customization"] = flattenAgentSchedulingCustomizationV2(in.SchedulingCustomization)
 
 	return []interface{}{obj}
 }
 
 // Expanders
 
-func expandAgentDeploymentCustomizationV2(p []interface{}, includeScheduling bool) (*v1.AgentDeploymentCustomization, error) {
+func expandAgentDeploymentCustomizationV2(p []interface{}) (*v1.AgentDeploymentCustomization, error) {
 	if len(p) == 0 || p[0] == nil {
 		return nil, nil
 	}
@@ -66,10 +64,8 @@ func expandAgentDeploymentCustomizationV2(p []interface{}, includeScheduling boo
 		obj.OverrideResourceRequirements = overrideResourceRequirements
 	}
 
-	if includeScheduling {
-		if v, ok := in["scheduling_customization"].([]interface{}); ok && len(v) > 0 {
-			obj.SchedulingCustomization = expandAgentSchedulingCustomizationV2(v)
-		}
+	if v, ok := in["scheduling_customization"].([]interface{}); ok && len(v) > 0 {
+		obj.SchedulingCustomization = expandAgentSchedulingCustomizationV2(v)
 	}
 
 	return obj, nil

--- a/rancher2/structure_cluster.go
+++ b/rancher2/structure_cluster.go
@@ -70,11 +70,11 @@ func flattenCluster(d *schema.ResourceData, in *Cluster, clusterRegToken *manage
 	}
 
 	if in.ClusterAgentDeploymentCustomization != nil {
-		d.Set("cluster_agent_deployment_customization", flattenAgentDeploymentCustomization(in.ClusterAgentDeploymentCustomization, true))
+		d.Set("cluster_agent_deployment_customization", flattenAgentDeploymentCustomization(in.ClusterAgentDeploymentCustomization))
 	}
 
 	if in.FleetAgentDeploymentCustomization != nil {
-		d.Set("fleet_agent_deployment_customization", flattenAgentDeploymentCustomization(in.FleetAgentDeploymentCustomization, false))
+		d.Set("fleet_agent_deployment_customization", flattenAgentDeploymentCustomization(in.FleetAgentDeploymentCustomization))
 	}
 
 	if len(in.ClusterTemplateID) > 0 {
@@ -394,7 +394,7 @@ func expandCluster(in *schema.ResourceData) (*Cluster, error) {
 	}
 
 	if v, ok := in.Get("cluster_agent_deployment_customization").([]interface{}); ok && len(v) > 0 {
-		clusterAgentDeploymentCustomization, err := expandAgentDeploymentCustomization(v, true)
+		clusterAgentDeploymentCustomization, err := expandAgentDeploymentCustomization(v)
 		if err != nil {
 			return nil, fmt.Errorf("[ERROR] expanding cluster: %w", err)
 		}
@@ -402,7 +402,7 @@ func expandCluster(in *schema.ResourceData) (*Cluster, error) {
 	}
 
 	if v, ok := in.Get("fleet_agent_deployment_customization").([]interface{}); ok && len(v) > 0 {
-		fleetAgentDeploymentCustomization, err := expandAgentDeploymentCustomization(v, false)
+		fleetAgentDeploymentCustomization, err := expandAgentDeploymentCustomization(v)
 		if err != nil {
 			return nil, fmt.Errorf("[ERROR] expanding cluster: %w", err)
 		}

--- a/rancher2/structure_cluster_v2.go
+++ b/rancher2/structure_cluster_v2.go
@@ -60,10 +60,10 @@ func flattenClusterV2(d *schema.ResourceData, in *ClusterV2) error {
 		d.Set("cloud_credential_secret_name", in.Spec.CloudCredentialSecretName)
 	}
 	if in.Spec.ClusterAgentDeploymentCustomization != nil {
-		d.Set("cluster_agent_deployment_customization", flattenAgentDeploymentCustomizationV2(in.Spec.ClusterAgentDeploymentCustomization, true))
+		d.Set("cluster_agent_deployment_customization", flattenAgentDeploymentCustomizationV2(in.Spec.ClusterAgentDeploymentCustomization))
 	}
 	if in.Spec.FleetAgentDeploymentCustomization != nil {
-		d.Set("fleet_agent_deployment_customization", flattenAgentDeploymentCustomizationV2(in.Spec.FleetAgentDeploymentCustomization, false))
+		d.Set("fleet_agent_deployment_customization", flattenAgentDeploymentCustomizationV2(in.Spec.FleetAgentDeploymentCustomization))
 	}
 	if len(in.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName) > 0 {
 		d.Set("default_pod_security_admission_configuration_template_name", in.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName)
@@ -121,7 +121,7 @@ func expandClusterV2(in *schema.ResourceData) (*ClusterV2, error) {
 	}
 
 	if v, ok := in.Get("cluster_agent_deployment_customization").([]interface{}); ok && len(v) > 0 {
-		clusterAgentDeploymentCustomization, err := expandAgentDeploymentCustomizationV2(v, true)
+		clusterAgentDeploymentCustomization, err := expandAgentDeploymentCustomizationV2(v)
 		if err != nil {
 			return nil, fmt.Errorf("[ERROR] expanding cluster: %w", err)
 		}
@@ -129,7 +129,7 @@ func expandClusterV2(in *schema.ResourceData) (*ClusterV2, error) {
 	}
 
 	if v, ok := in.Get("fleet_agent_deployment_customization").([]interface{}); ok && len(v) > 0 {
-		fleetAgentDeploymentCustomization, err := expandAgentDeploymentCustomizationV2(v, false)
+		fleetAgentDeploymentCustomization, err := expandAgentDeploymentCustomizationV2(v)
 		if err != nil {
 			return nil, fmt.Errorf("[ERROR] expanding cluster: %w", err)
 		}

--- a/rancher2/structure_cluster_v2_test.go
+++ b/rancher2/structure_cluster_v2_test.go
@@ -125,6 +125,15 @@ func init() {
 		AppendTolerations:            testClusterV2AppendTolerations,
 		OverrideAffinity:             testClusterV2OverrideAffinity,
 		OverrideResourceRequirements: testClusterV2OverrideResourceRequirements,
+		SchedulingCustomization: &provisionv1.AgentSchedulingCustomization{
+			PriorityClass: &provisionv1.PriorityClassSpec{
+				Value:            123,
+				PreemptionPolicy: &neverPreemption,
+			},
+			PodDisruptionBudget: &provisionv1.PodDisruptionBudgetSpec{
+				MinAvailable: "1",
+			},
+		},
 	}
 
 	testClusterV2Conf.Spec.ClusterAgentDeploymentCustomization = testClusterV2ClusterAgentDeploymentCustomizationConf
@@ -166,6 +175,22 @@ func init() {
 					"cpu_request":    "500",
 					"memory_limit":   "500",
 					"memory_request": "500",
+				},
+			},
+			"scheduling_customization": []interface{}{
+				map[string]interface{}{
+					"priority_class": []interface{}{
+						map[string]interface{}{
+							"value":             123,
+							"preemption_policy": "Never",
+						},
+					},
+					"pod_disruption_budget": []interface{}{
+						map[string]interface{}{
+							"min_available":   "1",
+							"max_unavailable": "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->
Addresses rancher/rancher#52437

<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

Rancher v2.13.2 introduces a new optional feature for configuring a Pod Disruption Budget and Priority Class for the cattle cluster agent. This includes new fields on the v3.Cluster and v1.Cluster objects. This feature is supported in Node Driver provisioned clusters, custom clusters, and imported clusters.

## Solution

Adapt flatteners and expanders, unit tests, and documentation. The schema has been updated to  support both agents.

## Testing

I've manually tested imported clusters.

## Engineering Testing
### Manual Testing
### Automated Testing
Several unit tests have been updated

## QA Testing Considerations
### Regressions Considerations
n/a


<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
