### PR TITLE
Migrate login flow to /v1-public endpoint

### DIFF
--- a/rancher2/util_test.go
+++ b/rancher2/util_test.go
@@ -1,0 +1,169 @@
+package rancher2
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoUserLogin(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		tokenID := "token-xqmfl"
+		tokenValue := tokenID + ":fq4nsrx7tcqhbn6bnqlf74mlp8hn8q947nlxbcgv2hsctxnvncprmk"
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/v1-public/login", r.URL.Path)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			var reqBody map[string]string
+			err := json.NewDecoder(r.Body).Decode(&reqBody)
+			require.NoError(t, err)
+			assert.Equal(t, "localProvider", reqBody["type"])
+			assert.Equal(t, "admin", reqBody["username"])
+			assert.Equal(t, "secret", reqBody["password"])
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"token": tokenValue,
+			})
+		}))
+		defer srv.Close()
+
+		id, token, err := DoUserLogin(srv.URL, "admin", "secret", bootstrapDefaultTTL, bootstrapDefaultSessionDesc, "", true)
+		require.NoError(t, err)
+		assert.Equal(t, tokenID, id)
+		assert.Equal(t, tokenValue, token)
+	})
+
+	t.Run("success with ext prefix", func(t *testing.T) {
+		tokenID := "ext/saml-user-abc123"
+		tokenValue := tokenID + ":secrettoken"
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"token": tokenValue,
+			})
+		}))
+		defer srv.Close()
+
+		id, token, err := DoUserLogin(srv.URL, "admin", "secret", bootstrapDefaultTTL, bootstrapDefaultSessionDesc, "", true)
+		require.NoError(t, err)
+		assert.Equal(t, "saml-user-abc123", id, "ext/ prefix should be stripped from ID")
+		assert.Equal(t, tokenValue, token)
+	})
+
+	t.Run("missing token in response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"type": "error",
+				"code": "Unauthorized",
+			})
+		}))
+		defer srv.Close()
+
+		_, _, err := DoUserLogin(srv.URL, "admin", "wrongpass", bootstrapDefaultTTL, bootstrapDefaultSessionDesc, "", true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Unauthorized")
+	})
+
+	t.Run("invalid token format", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"token": "invalid-token-without-colon",
+			})
+		}))
+		defer srv.Close()
+
+		_, _, err := DoUserLogin(srv.URL, "admin", "secret", bootstrapDefaultTTL, bootstrapDefaultSessionDesc, "", true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid token format")
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"type":    "error",
+				"code":    "ServerError",
+				"message": "internal server error",
+			})
+		}))
+		defer srv.Close()
+
+		_, _, err := DoUserLogin(srv.URL, "admin", "secret", bootstrapDefaultTTL, bootstrapDefaultSessionDesc, "", true)
+		require.Error(t, err)
+	})
+
+	t.Run("fallback to v3-public on 404", func(t *testing.T) {
+		tokenID := "token-v3fallback"
+		tokenValue := tokenID + ":v3secrettoken"
+		callCount := 0
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+
+			if r.URL.Path == "/v1-public/login" {
+				// Simulate v1 endpoint not available
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"type": "error",
+					"code": "NotFound",
+				})
+				return
+			}
+
+			if r.URL.Path == "/v3-public/localProviders/local" {
+				assert.Equal(t, "login", r.URL.Query().Get("action"))
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"token": tokenValue,
+				})
+				return
+			}
+
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+		}))
+		defer srv.Close()
+
+		id, token, err := DoUserLogin(srv.URL, "admin", "secret", bootstrapDefaultTTL, bootstrapDefaultSessionDesc, "", true)
+		require.NoError(t, err)
+		assert.Equal(t, tokenID, id)
+		assert.Equal(t, tokenValue, token)
+		assert.Equal(t, 2, callCount, "should have made 2 requests (v1 then v3)")
+	})
+
+	t.Run("fallback to v3-public fails", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			if r.URL.Path == "/v1-public/login" {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"type": "error",
+					"code": "NotFound",
+				})
+				return
+			}
+
+			// v3 endpoint also fails with auth error
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"type": "error",
+				"code": "Unauthorized",
+			})
+		}))
+		defer srv.Close()
+
+		_, _, err := DoUserLogin(srv.URL, "admin", "wrongpass", bootstrapDefaultTTL, bootstrapDefaultSessionDesc, "", true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Unauthorized")
+	})
+}


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->
Addresses https://github.com/rancher/rancher/issues/52505

<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->

Migrates login flow to the new `/v1-public/login` (since Rancher v2.13) endpoint with automatic fallback to the deprecated `/v3-public` for backwards compatibility.

Changes:

- Switch primary login endpoint from `/v3-public` to `/v1-public/login`
- Add automatic fallback to `/v3-public` endpoint when 404 is returned by the new endpoint
- Use `json.Marsha`l to produce the request body instead of string concatenation
- Improve error handling with safe type assertions
- Handle the `ext/` prefix in token IDs (for new `tokens.ext.cattle.io` tokens)


## Testing

<!--- Please describe how you verified this change or why testing isn't relevant. --->
Added unit tests covering:

- Successful login via `/v1-public`
- Token ID with `ext/` prefix stripping
- Authentication failures
- Invalid token format handling
- Fallback to `/v3-public` on 404
- Fallback failure scenarios

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
