### PR TITLE
Fix broken tests in project structure

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -7,7 +7,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_OWNER: ${{ github.repository_owner }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,7 +18,22 @@ jobs:
           VERSION: ${{ github.ref_name }}
         run: |
           make build
-
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0 https://github.com/actions/checkout
+        with:
+          fetch-depth: 0
+      - name: install-nix
+        run: |
+          curl -L https://nixos.org/nix/install | sh
+          source /home/runner/.nix-profile/etc/profile.d/nix.sh
+          nix --version
+          which nix
+      - name: Run make test
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
+        run: |
+          make test
   terraform:
     name: 'Terraform'
     runs-on: ubuntu-latest

--- a/rancher2/structure_project.go
+++ b/rancher2/structure_project.go
@@ -40,7 +40,7 @@ func flattenProjectResourceQuotaLimit(in *managementClient.ResourceQuotaLimit) [
 	}
 
 	if len(in.Extended) > 0 {
-		obj["extended"] = in.Extended
+		obj["extended"] = mapStringToAny(in.Extended)
 	}
 
 	if len(in.LimitsCPU) > 0 {
@@ -150,7 +150,6 @@ func flattenProject(d *schema.ResourceData, in *managementClient.Project) error 
 	}
 
 	return nil
-
 }
 
 // Expanders
@@ -310,4 +309,13 @@ func expandProject(in *schema.ResourceData) *managementClient.Project {
 	}
 
 	return obj
+}
+
+func mapStringToAny(m map[string]string) map[string]any {
+	result := map[string]any{}
+	for k, v := range m {
+		result[k] = v
+	}
+
+	return result
 }


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->
Addresses: #2002 

<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

This fixes the tests which where asserting that the result was `map[string]string` by fixing the flattening of the values.

Because the `extended` field is a `TypeMap` it's stored in the Terraform schema as `map[string]any`.

This would only impact on the tests, because the values are passing through the Terraform schema, so being converted internally as `TestFlattenProject` shows.

There was also a bug where the calls to `assert.FailNow()` were setup incorrectly which was causing a panic, I've replaced these with `assert.Equal`.

**Finally:** I added support for running the tests pre-integration (in the pull_request workflow).

## Testing

These changes only impact on tests. 

Not a breaking change.
