### PR TITLE
fix: rc release calculator for new branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,8 +343,12 @@ jobs:
           echo "Latest rc num: $LATEST_RC_NUM"
           if [ -z "$LATEST_RC_NUM" ]; then
             # the last minor was a full release, we need to start the next minor release candidate
-            # this sort of assumes there wont be a patch release
-            LATEST_MINOR_NUM=$((LATEST_MINOR_NUM + 1))
+            if [ -z "$LATEST_MINOR_NUM" ]; then
+              # this is a new minor branch
+              LATEST_MINOR_NUM=0
+            else
+              LATEST_MINOR_NUM=$((LATEST_MINOR_NUM + 1))
+            fi
             LATEST_PATCH_NUM=0
             NEXT_RC_NUM=0
           else


### PR DESCRIPTION
## Description

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
There is a problem where on new branch creation the script that calculates the rc release version skips v0.
This results in eg. v14.1.0-rc.0 as the first rc release for v14 instead of v14.0.0-rc.0 as expected.

## Testing

<!--- Please describe how you verified this change or why testing isn't relevant. --->
This is a change in the release automation, no testing is really possible.
Workflow linting is run.
<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
