### PR TITLE
Add support for AuthConfig Cognito

### DIFF
--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -32,3 +32,5 @@ backport
 GKE
 PDB
 PC
+AuthConfig
+Cognito

--- a/rancher2/config.go
+++ b/rancher2/config.go
@@ -1225,6 +1225,8 @@ func getAuthConfigObject(kind string) (interface{}, error) {
 		return &managementClient.KeyCloakConfig{}, nil
 	case managementClient.GenericOIDCConfigType:
 		return &managementClient.GenericOIDCConfig{}, nil
+	case managementClient.CognitoConfigType:
+		return &managementClient.CognitoConfig{}, nil
 	case managementClient.OIDCConfigType:
 		return &managementClient.OIDCConfig{}, nil
 	case managementClient.OKTAConfigType:

--- a/rancher2/provider.go
+++ b/rancher2/provider.go
@@ -117,6 +117,7 @@ func Provider() terraform.ResourceProvider {
 			"rancher2_auth_config_keycloak":                          resourceRancher2AuthConfigKeyCloak(),
 			"rancher2_auth_config_okta":                              resourceRancher2AuthConfigOKTA(),
 			"rancher2_auth_config_generic_oidc":                      resourceRancher2AuthConfigGenericOIDC(),
+			"rancher2_auth_config_cognito":                           resourceRancher2AuthConfigCognito(),
 			"rancher2_auth_config_openldap":                          resourceRancher2AuthConfigOpenLdap(),
 			"rancher2_auth_config_ping":                              resourceRancher2AuthConfigPing(),
 			"rancher2_bootstrap":                                     resourceRancher2Bootstrap(),

--- a/rancher2/resource_rancher2_auth_config_cognito.go
+++ b/rancher2/resource_rancher2_auth_config_cognito.go
@@ -1,0 +1,119 @@
+package rancher2
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
+)
+
+func resourceRancher2AuthConfigCognito() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceRancher2AuthConfigCognitoCreate,
+		Read:   resourceRancher2AuthConfigCognitoRead,
+		Update: resourceRancher2AuthConfigCognitoUpdate,
+		Delete: resourceRancher2AuthConfigCognitoDelete,
+
+		Schema: authConfigCognitoFields(),
+	}
+}
+
+func resourceRancher2AuthConfigCognitoCreate(d *schema.ResourceData, meta interface{}) error {
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return err
+	}
+
+	auth, err := client.AuthConfig.ByID(AuthConfigCognitoName)
+	if err != nil {
+		return fmt.Errorf("[ERROR] Failed to get Auth Config %s: %s", AuthConfigCognitoName, err)
+	}
+
+	log.Printf("[INFO] Creating Auth Config %s", AuthConfigCognitoName)
+
+	authOIDC, err := expandAuthConfigCognito(d)
+	if err != nil {
+		return fmt.Errorf("[ERROR] Failed expanding Auth Config %s: %s", AuthConfigCognitoName, err)
+	}
+
+	// Checking if other auth config is enabled
+	if authOIDC.Enabled {
+		err = meta.(*Config).CheckAuthConfigEnabled(AuthConfigCognitoName)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Checking to enable Auth Config %s: %s", AuthConfigCognitoName, err)
+		}
+	}
+
+	newAuth := &managementClient.CognitoConfig{}
+	err = meta.(*Config).UpdateAuthConfig(auth.Links["self"], authOIDC, newAuth)
+	if err != nil {
+		return fmt.Errorf("[ERROR] Updating Auth Config %s: %s", AuthConfigCognitoName, err)
+	}
+
+	return resourceRancher2AuthConfigCognitoRead(d, meta)
+}
+
+func resourceRancher2AuthConfigCognitoRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Refreshing Auth Config %s", AuthConfigCognitoName)
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return err
+	}
+
+	auth, err := client.AuthConfig.ByID(AuthConfigCognitoName)
+	if err != nil {
+		if IsNotFound(err) {
+			log.Printf("[INFO] Auth Config %s not found.", AuthConfigCognitoName)
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	authOIDC, err := meta.(*Config).GetAuthConfig(auth)
+	if err != nil {
+		return err
+	}
+
+	err = flattenAuthConfigCognito(d, authOIDC.(*managementClient.CognitoConfig))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceRancher2AuthConfigCognitoUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Updating Auth Config %s", AuthConfigCognitoName)
+	return resourceRancher2AuthConfigCognitoCreate(d, meta)
+}
+
+func resourceRancher2AuthConfigCognitoDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Disabling Auth Config %s", AuthConfigCognitoName)
+
+	client, err := meta.(*Config).ManagementClient()
+	if err != nil {
+		return err
+	}
+
+	auth, err := client.AuthConfig.ByID(AuthConfigCognitoName)
+	if err != nil {
+		if IsNotFound(err) {
+			log.Printf("[INFO] Auth Config %s not found.", AuthConfigCognitoName)
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	if auth.Enabled == true {
+		err = client.Post(auth.Actions["disable"], nil, nil)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Disabling Auth Config %s: %s", AuthConfigCognitoName, err)
+		}
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/rancher2/schema_auth_config_cognito.go
+++ b/rancher2/schema_auth_config_cognito.go
@@ -1,0 +1,24 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+const AuthConfigCognitoName = "cognito"
+
+//Schemas
+
+func authConfigCognitoFields() map[string]*schema.Schema {
+	fields := oidcSchemaFields()
+
+	fields["name_claim"].Default = "cognito:username"
+
+	// Terraform doesn't allow defaults for Computed fields.
+	//
+	// It's not clear why this field is Computed in the Schema, but we'll set it
+	// to false so we can provide a default.
+	fields["groups_field"].Computed = false
+	fields["groups_field"].Default = "cognito:groups"
+
+	return fields
+}

--- a/rancher2/schema_auth_config_cognito_test.go
+++ b/rancher2/schema_auth_config_cognito_test.go
@@ -1,0 +1,25 @@
+package rancher2
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func TestAuthConfigCognitoResourceDefaults(t *testing.T) {
+	r := resourceRancher2AuthConfigCognito()
+	d := schema.TestResourceDataRaw(t, r.Schema, map[string]any{
+		"client_id":     "client-id",
+		"client_secret": "client-secret",
+		"issuer":        "https://issuer.example.com",
+		"rancher_url":   "https://rancher.example.com/verify-auth",
+	})
+
+	if got := d.Get("name_claim"); got != "cognito:username" {
+		t.Fatalf("unexpected default for name_claim: got %v, want %q", got, "cognito:username")
+	}
+
+	if got := d.Get("group_search_enabled"); got != false {
+		t.Fatalf("unexpected default for group_search_enabled: got %v, want %v", got, false)
+	}
+}

--- a/rancher2/schema_auth_config_generic_oidc.go
+++ b/rancher2/schema_auth_config_generic_oidc.go
@@ -1,7 +1,10 @@
 package rancher2
 
 import (
+	"maps"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 const AuthConfigGenericOIDCName = "genericoidc"
@@ -9,6 +12,11 @@ const AuthConfigGenericOIDCName = "genericoidc"
 //Schemas
 
 func authConfigGenericOIDCFields() map[string]*schema.Schema {
+	return oidcSchemaFields()
+}
+
+// This is used by the Cognito and Generic OIDC providers.
+func oidcSchemaFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"client_id": {
 			Type:        schema.TypeString,
@@ -88,11 +96,37 @@ func authConfigGenericOIDCFields() map[string]*schema.Schema {
 			StateFunc:   TrimSpace,
 			Description: "A PEM-encoded private key for the OIDC provider.",
 		},
+		"name_claim": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			StateFunc:   TrimSpace,
+			Description: "The OIDC Claim to use for the user name.",
+		},
+		"email_claim": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			StateFunc:   TrimSpace,
+			Description: "The OIDC Claim to use for the user email.",
+		},
+		"logout_all_enabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Allow the user to choose whether or not to logout of their session with the IdP.",
+		},
+		"logout_all_forced": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Force the user to logout of their session with the IdP.",
+		},
+		"end_session_endpoint": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.IsURLWithHTTPS,
+			Description:  "The provider specific URL used for logging a user out of their session.",
+		},
 	}
 
-	for k, v := range authConfigFields() {
-		s[k] = v
-	}
+	maps.Copy(s, authConfigFields())
 
 	return s
 }

--- a/rancher2/schema_auth_config_generic_oidc_test.go
+++ b/rancher2/schema_auth_config_generic_oidc_test.go
@@ -1,0 +1,39 @@
+package rancher2
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthConfigGenericOIDCResourceValidateNoData(t *testing.T) {
+	r := resourceRancher2AuthConfigGenericOIDC()
+	d := terraform.NewResourceConfigRaw(map[string]any{})
+	warns, errs := r.Validate(d)
+
+	assert.Empty(t, warns)
+
+	assert.Len(t, errs, 4)
+	joined := errors.Join(errs...)
+	assert.ErrorContains(t, joined, "\"issuer\": required field is not set")
+	assert.ErrorContains(t, joined, "\"client_id\": required field is not set")
+	assert.ErrorContains(t, joined, "\"client_secret\": required field is not set")
+	assert.ErrorContains(t, joined, "\"rancher_url\": required field is not set")
+}
+
+func TestAuthConfigGenericOIDCResourceEndSessionEndpointValidation(t *testing.T) {
+	r := resourceRancher2AuthConfigGenericOIDC()
+	d := terraform.NewResourceConfigRaw(map[string]any{
+		"client_id":            "client-id",
+		"client_secret":        "client-secret",
+		"issuer":               "https://issuer.example.com",
+		"rancher_url":          "https://rancher.example.com/verify-auth",
+		"end_session_endpoint": "test",
+	})
+	warns, errs := r.Validate(d)
+
+	assert.Empty(t, warns)
+	assert.ErrorContains(t, errors.Join(errs...), `expected "end_session_endpoint" to have a host`)
+}

--- a/rancher2/structure_auth_config_cognito.go
+++ b/rancher2/structure_auth_config_cognito.go
@@ -1,0 +1,132 @@
+package rancher2
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
+)
+
+// Flatteners
+
+func flattenAuthConfigCognito(d *schema.ResourceData, in *managementClient.CognitoConfig) error {
+	d.SetId(AuthConfigCognitoName)
+	d.Set("name", AuthConfigCognitoName)
+	d.Set("type", managementClient.CognitoConfigType)
+
+	if err := flattenOIDCConfig(d, in); err != nil {
+		return fmt.Errorf("flattening AuthConfig for Cognito: %s", err)
+	}
+
+	return nil
+}
+
+// Expanders
+
+func expandAuthConfigCognito(in *schema.ResourceData) (*managementClient.CognitoConfig, error) {
+	obj := &managementClient.CognitoConfig{}
+	if in == nil {
+		return nil, fmt.Errorf("expanding :%s Auth Config: Input ResourceData is nil", AuthConfigCognitoName)
+	}
+
+	obj.Name = AuthConfigCognitoName
+	obj.Type = managementClient.CognitoConfigType
+
+	if v, ok := in.Get("access_mode").(string); ok && v != "" {
+		obj.AccessMode = v
+	}
+
+	if v, ok := in.Get("allowed_principal_ids").([]any); ok && len(v) > 0 {
+		obj.AllowedPrincipalIDs = toArrayString(v)
+	}
+
+	if (obj.AccessMode == "required" || obj.AccessMode == "restricted") && len(obj.AllowedPrincipalIDs) == 0 {
+		return nil, fmt.Errorf("expanding %s Auth Config: allowed_principal_ids is required on access_mode %s", AuthConfigCognitoName, obj.AccessMode)
+	}
+
+	if v, ok := in.Get("enabled").(bool); ok {
+		obj.Enabled = v
+	}
+
+	if v, ok := in.Get("annotations").(map[string]any); ok && len(v) > 0 {
+		obj.Annotations = toMapString(v)
+	}
+
+	if v, ok := in.Get("labels").(map[string]any); ok && len(v) > 0 {
+		obj.Labels = toMapString(v)
+	}
+
+	if v, ok := in.Get("client_id").(string); ok && v != "" {
+		obj.ClientID = v
+	}
+
+	if v, ok := in.Get("client_secret").(string); ok && v != "" {
+		obj.ClientSecret = v
+	}
+
+	if v, ok := in.Get("issuer").(string); ok && v != "" {
+		obj.Issuer = v
+	}
+
+	if v, ok := in.Get("rancher_url").(string); ok && v != "" {
+		obj.RancherURL = v
+	}
+
+	if v, ok := in.Get("auth_endpoint").(string); ok && v != "" {
+		obj.AuthEndpoint = v
+	}
+
+	if v, ok := in.Get("token_endpoint").(string); ok && v != "" {
+		obj.TokenEndpoint = v
+	}
+
+	if v, ok := in.Get("userinfo_endpoint").(string); ok && v != "" {
+		obj.UserInfoEndpoint = v
+	}
+
+	if v, ok := in.Get("jwks_url").(string); ok && v != "" {
+		obj.JWKSUrl = v
+	}
+
+	if v, ok := in.Get("scopes").(string); ok && v != "" {
+		obj.Scopes = v
+	}
+
+	if v, ok := in.Get("group_search_enabled").(bool); ok {
+		obj.GroupSearchEnabled = &v
+	}
+
+	if v, ok := in.Get("groups_field").(string); ok && v != "" {
+		obj.GroupsClaim = v
+	}
+
+	if v, ok := in.Get("certificate").(string); ok && v != "" {
+		obj.Certificate = v
+	}
+
+	if v, ok := in.Get("private_key").(string); ok && v != "" {
+		obj.PrivateKey = v
+	}
+
+	if v, ok := in.Get("name_claim").(string); ok && v != "" {
+		obj.NameClaim = v
+	}
+
+	if v, ok := in.Get("email_claim").(string); ok && v != "" {
+		obj.EmailClaim = v
+	}
+
+	if v, ok := in.Get("logout_all_enabled").(bool); ok {
+		obj.LogoutAllEnabled = v
+	}
+
+	if v, ok := in.Get("logout_all_forced").(bool); ok {
+		obj.LogoutAllForced = v
+	}
+
+	if v, ok := in.Get("end_session_endpoint").(string); ok && v != "" {
+		obj.EndSessionEndpoint = v
+	}
+
+	return obj, nil
+}

--- a/rancher2/structure_auth_config_cognito_test.go
+++ b/rancher2/structure_auth_config_cognito_test.go
@@ -1,0 +1,99 @@
+package rancher2
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testAuthConfigCognitoConf      *managementClient.CognitoConfig
+	testAuthConfigCognitoInterface map[string]any
+)
+
+func init() {
+	testAuthConfigCognitoConf = &managementClient.CognitoConfig{
+		Name:                AuthConfigCognitoName,
+		Type:                managementClient.CognitoConfigType,
+		AccessMode:          "access",
+		AllowedPrincipalIDs: []string{"allowed1", "allowed2"},
+		Enabled:             true,
+		Annotations:         map[string]string{"example.com/test": "test"},
+		Labels:              map[string]string{"example.com/label": "value"},
+		ClientID:            "client_id",
+		Issuer:              "issuer",
+		RancherURL:          "rancher_url",
+		AuthEndpoint:        "auth_endpoint",
+		TokenEndpoint:       "token_endpoint",
+		UserInfoEndpoint:    "userinfo_endpoint",
+		JWKSUrl:             "jwks_url",
+		Scopes:              "openid profile offline_access",
+		GroupSearchEnabled:  &groupSearchEnabled,
+		GroupsClaim:         "groups_field",
+		Certificate:         "certificate",
+		PrivateKey:          "private_key",
+		NameClaim:           "preferred_username",
+		EmailClaim:          "alt_email",
+		LogoutAllEnabled:    true,
+		LogoutAllForced:     true,
+		EndSessionEndpoint:  "https://example.com/end-session",
+	}
+	testAuthConfigCognitoInterface = map[string]any{
+		"name":                  AuthConfigCognitoName,
+		"type":                  managementClient.CognitoConfigType,
+		"access_mode":           "access",
+		"allowed_principal_ids": []any{"allowed1", "allowed2"},
+		"enabled":               true,
+		"client_id":             "client_id",
+		"annotations": map[string]any{
+			"example.com/test": "test",
+		},
+		"labels": map[string]any{
+			"example.com/label": "value",
+		},
+		"issuer":               "issuer",
+		"rancher_url":          "rancher_url",
+		"auth_endpoint":        "auth_endpoint",
+		"token_endpoint":       "token_endpoint",
+		"userinfo_endpoint":    "userinfo_endpoint",
+		"jwks_url":             "jwks_url",
+		"scopes":               "openid profile offline_access",
+		"group_search_enabled": true,
+		"groups_field":         "groups_field",
+		"certificate":          "certificate",
+		"private_key":          "private_key",
+		"name_claim":           "preferred_username",
+		"email_claim":          "alt_email",
+		"logout_all_enabled":   true,
+		"logout_all_forced":    true,
+		"end_session_endpoint": "https://example.com/end-session",
+	}
+}
+
+func TestFlattenAuthConfigCognito(t *testing.T) {
+	output := schema.TestResourceDataRaw(t, authConfigCognitoFields(), map[string]any{})
+	err := flattenAuthConfigCognito(output, testAuthConfigCognitoConf)
+	if err != nil {
+		assert.NoError(t, err, "flattenAuthConfigCognito failed")
+	}
+	expectedOutput := map[string]any{}
+	for k := range testAuthConfigCognitoInterface {
+		expectedOutput[k] = output.Get(k)
+	}
+	assert.Equal(t,
+		testAuthConfigCognitoInterface,
+		expectedOutput, "Unexpected output from flattener")
+}
+
+func TestExpandAuthConfigCognito(t *testing.T) {
+	inputResourceData := schema.TestResourceDataRaw(t, authConfigCognitoFields(),
+		testAuthConfigCognitoInterface)
+
+	output, err := expandAuthConfigCognito(inputResourceData)
+	if err != nil {
+		assert.NoError(t, err, "expandAuthConfigCognito failed")
+	}
+	assert.Equal(t, testAuthConfigCognitoConf, output, "Unexpected output from expander")
+}

--- a/rancher2/structure_auth_config_generic_oidc_test.go
+++ b/rancher2/structure_auth_config_generic_oidc_test.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	testAuthConfigGenericOIDCConf      *managementClient.GenericOIDCConfig
-	testAuthConfigGenericOIDCInterface map[string]interface{}
+	testAuthConfigGenericOIDCInterface map[string]any
 	groupSearchEnabled                 = true
 )
 
@@ -33,12 +33,17 @@ func init() {
 		GroupsClaim:         "groups_field",
 		Certificate:         "certificate",
 		PrivateKey:          "private_key",
+		NameClaim:           "preferred_username",
+		EmailClaim:          "alt_email",
+		LogoutAllEnabled:    true,
+		LogoutAllForced:     true,
+		EndSessionEndpoint:  "https://example.com/end-session",
 	}
-	testAuthConfigGenericOIDCInterface = map[string]interface{}{
+	testAuthConfigGenericOIDCInterface = map[string]any{
 		"name":                  AuthConfigGenericOIDCName,
 		"type":                  managementClient.GenericOIDCConfigType,
 		"access_mode":           "access",
-		"allowed_principal_ids": []interface{}{"allowed1", "allowed2"},
+		"allowed_principal_ids": []any{"allowed1", "allowed2"},
 		"enabled":               true,
 		"client_id":             "client_id",
 		"issuer":                "issuer",
@@ -52,51 +57,29 @@ func init() {
 		"groups_field":          "groups_field",
 		"certificate":           "certificate",
 		"private_key":           "private_key",
+		"name_claim":            "preferred_username",
+		"email_claim":           "alt_email",
+		"logout_all_enabled":    true,
+		"logout_all_forced":     true,
+		"end_session_endpoint":  "https://example.com/end-session",
 	}
 }
 
 func TestFlattenAuthConfigGenericOIDC(t *testing.T) {
-	cases := []struct {
-		Input          *managementClient.GenericOIDCConfig
-		ExpectedOutput map[string]interface{}
-	}{
-		{
-			testAuthConfigGenericOIDCConf,
-			testAuthConfigGenericOIDCInterface,
-		},
+	output := schema.TestResourceDataRaw(t, authConfigGenericOIDCFields(), map[string]any{})
+	err := flattenAuthConfigGenericOIDC(output, testAuthConfigGenericOIDCConf)
+	assert.NoError(t, err, "Error in flattenAuthConfigGenericOIDC")
+	expectedOutput := map[string]any{}
+	for k := range testAuthConfigGenericOIDCInterface {
+		expectedOutput[k] = output.Get(k)
 	}
-
-	for _, tc := range cases {
-		output := schema.TestResourceDataRaw(t, authConfigGenericOIDCFields(), map[string]interface{}{})
-		err := flattenAuthConfigGenericOIDC(output, tc.Input)
-		if err != nil {
-			assert.FailNow(t, "[ERROR] on flattener: %#v", err)
-		}
-		expectedOutput := map[string]interface{}{}
-		for k := range tc.ExpectedOutput {
-			expectedOutput[k] = output.Get(k)
-		}
-		assert.Equal(t, tc.ExpectedOutput, expectedOutput, "Unexpected output from flattener.")
-	}
+	assert.Equal(t, testAuthConfigGenericOIDCInterface, expectedOutput, "Unexpected output from flattenAuthConfigGenericOIDC")
 }
 
 func TestExpandAuthConfigGenericOIDC(t *testing.T) {
-	cases := []struct {
-		Input          map[string]interface{}
-		ExpectedOutput *managementClient.GenericOIDCConfig
-	}{
-		{
-			testAuthConfigGenericOIDCInterface,
-			testAuthConfigGenericOIDCConf,
-		},
-	}
+	inputResourceData := schema.TestResourceDataRaw(t, authConfigGenericOIDCFields(), testAuthConfigGenericOIDCInterface)
+	output, err := expandAuthConfigGenericOIDC(inputResourceData)
 
-	for _, tc := range cases {
-		inputResourceData := schema.TestResourceDataRaw(t, authConfigGenericOIDCFields(), tc.Input)
-		output, err := expandAuthConfigGenericOIDC(inputResourceData)
-		if err != nil {
-			assert.FailNow(t, "[ERROR] on expander: %#v", err)
-		}
-		assert.Equal(t, tc.ExpectedOutput, output, "Unexpected output from expander.")
-	}
+	assert.NoError(t, err, "Error in expandAuthConfigGenericOIDC")
+	assert.Equal(t, testAuthConfigGenericOIDCConf, output, "Unexpected output from expandAuthConfigGenericOIDC")
 }


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->
Addresses https://github.com/rancher/rancher/issues/51058

<!--- Add labels (eg. release/v13) for each release branch to target --->
<!--- Labels need to be added before PR is created for automation to run smoothly! --->

## Description

This adds a new `rancher2_auth_config_cognito` resource which can be used to configure the Cognito auth provider.

The Cognito config is almost identical to the Generic OIDC provider and the code has been refactored to reduce the duplication in adding this provider.

Also, support for the Name claim and Email claim fields has been added.

## Testing

I've tested configuring the provider with Terraform and it works fine.

Not a breaking change.
