### PR TITLE
feat: implement support to nutanix machine config

### DIFF
--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -34,3 +34,4 @@ PDB
 PC
 AuthConfig
 Cognito
+nutanix

--- a/docs/resources/cloud_credential.md
+++ b/docs/resources/cloud_credential.md
@@ -6,7 +6,7 @@ page_title: "rancher2_cloud_credential Resource"
 
 Provides a Rancher v2 Cloud Credential resource. This can be used to create Cloud Credential for Rancher v2.2.x and retrieve their information.
 
-amazonec2, azure, digitalocean, harvester, linode, openstack and vsphere credentials config are supported for Cloud Credential.
+amazonec2, azure, digitalocean, harvester, linode, nutanix, openstack and vsphere credentials config are supported for Cloud Credential.
 
 ## Example Usage
 
@@ -51,6 +51,7 @@ The following arguments are supported:
 * `google_credential_config` - (Optional) Google config for the Cloud Credential (list maxitems:1)
 * `harvester_credential_config` - (Optional) Harvester config for the Cloud Credential (list maxitems:1)
 * `linode_credential_config` - (Optional) Linode config for the Cloud Credential (list maxitems:1)
+* `nutanix_credential_config` - (Optional) Nutanix config for the Cloud Credential (list maxitems:1)
 * `openstack_credential_config` - (Optional) OpenStack config for the Cloud Credential (list maxitems:1)
 * `s3_credential_config` - (Optional) S3 config for the Cloud Credential. For Rancher 2.6.0 and above (list maxitems:1)
 * `vsphere_credential_config` - (Optional) vSphere config for the Cloud Credential (list maxitems:1)
@@ -110,6 +111,15 @@ The following attributes are exported:
 
 * `token` - (Required/Sensitive) Linode API token (string)
 
+### `nutanix_credential_config`
+
+#### Arguments
+
+* `endpoint` - (Required) Nutanix management endpoint IP address/FQDN (string)
+* `username` - (Required) Nutanix management username (string)
+* `password` - (Required/Sensitive) Nutanix management password (string)
+* `port` - (Optional) Nutanix management endpoint port. Default `9440` (string)
+
 ### `openstack_credential_config`
 
 #### Arguments
@@ -162,6 +172,7 @@ The following drivers are supported:
 * digitalocean
 * googlekubernetesengine
 * linode
+* nutanix
 * openstack
 * s3
 * vmwarevsphere

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -6,7 +6,7 @@ page_title: "rancher2_machine_config_v2 Resource"
 
 Provides a Rancher v2 Machine config v2 resource. This can be used to create Machine Config v2 for Rancher v2 and retrieve their information. This resource is available from Rancher v2.6.0 and above.
 
-The supported cloud providers includes `amazonec2`, `azure`, `digitalocean`, `harvester`, `linode`, `openstack`, and `vsphere`.
+The supported cloud providers includes `amazonec2`, `azure`, `digitalocean`, `harvester`, `linode`, `nutanix`, `openstack`, and `vsphere`.
 
 
 Starting with Rancher v2.12.0 and above, `google` is also offered as a supported cloud provider.
@@ -90,14 +90,15 @@ The following arguments are supported:
 
 * `generate_name` - (Required/ForceNew) Cluster V2 generate name. The pattern to generate machine config name. e.g  generate_name=\"prod-pool1\" will generate \"nc-prod-pool1-?????\" name computed at `name` attribute (string)
 * `fleet_namespace` - (Optional/ForceNew) Cluster V2 fleet namespace
-* `amazonec2_config` - (Optional) AWS config for the Machine Config V2. Conflicts with `azure_config`, `digitalocean_config`, `harvester_config`, `linode_config`, `openstack_config`, `google_config` and `vsphere_config` (list maxitems:1)
-* `azure_config` - (Optional) Azure config for the Machine Config V2. Conflicts with `amazonec2_config`, `digitalocean_config`, `harvester_config`, `linode_config`, `openstack_config`, `google_config` and `vsphere_config` (list maxitems:1)
-* `digitalocean_config` - (Optional) Digitalocean config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `harvester_config`, `linode_config`, `openstack_config`, `google_config` and `vsphere_config` (list maxitems:1)
-* `harvester_config` - (Optional) Harvester config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `digitalocean_config`, `linode_config`, `openstack_config`, `google_config` and `vsphere_config` (list maxitems:1)
-* `linode_config` - (Optional) Linode config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `digitalocean_config`, `harvester_config`, `openstack_config`, `google_config` and `vsphere_config` (list maxitems:1)
-* `openstack_config` - (Optional) Openstack config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `digitalocean_config`, `harvester_config`, `linode_config`, `google_config` and `vsphere_config` (list maxitems:1)
-* `vsphere_config` - (Optional) vSphere config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `digitalocean_config`, `harvester_config`, `linode_config`, `google_config` and `openstack_config` (list maxitems:1)
-* `google_config` - (Optional) Google config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `digitalocean_config`, `harvester_config`, `linode_config`, `openstack_config` and `vsphere_config` (list maxitems:1)
+* `amazonec2_config` - (Optional) AWS config for the Machine Config V2. Conflicts with `azure_config`, `digitalocean_config`, `harvester_config`, `linode_config`, `nutanix_config`, `openstack_config`, `google_config` and `vsphere_config` (list maxitems:1)
+* `azure_config` - (Optional) Azure config for the Machine Config V2. Conflicts with `amazonec2_config`, `digitalocean_config`, `harvester_config`, `linode_config`, `nutanix_config`, `openstack_config`, `google_config` and `vsphere_config` (list maxitems:1)
+* `digitalocean_config` - (Optional) Digitalocean config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `harvester_config`, `linode_config`, `nutanix_config`, `openstack_config`, `google_config` and `vsphere_config` (list maxitems:1)
+* `harvester_config` - (Optional) Harvester config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `digitalocean_config`, `linode_config`, `nutanix_config`, `openstack_config`, `google_config` and `vsphere_config` (list maxitems:1)
+* `linode_config` - (Optional) Linode config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `digitalocean_config`, `harvester_config`, `nutanix_config`, `openstack_config`, `google_config` and `vsphere_config` (list maxitems:1)
+* `nutanix_config` - (Optional) Nutanix config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `digitalocean_config`, `harvester_config`, `linode_config`, `openstack_config`, `google_config` and `vsphere_config` (list maxitems:1)
+* `openstack_config` - (Optional) Openstack config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `digitalocean_config`, `harvester_config`, `linode_config`, `nutanix_config`, `google_config` and `vsphere_config` (list maxitems:1)
+* `vsphere_config` - (Optional) vSphere config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `digitalocean_config`, `harvester_config`, `linode_config`, `nutanix_config`, `google_config` and `openstack_config` (list maxitems:1)
+* `google_config` - (Optional) Google config for the Machine Config V2. Conflicts with `amazonec2_config`, `azure_config`, `digitalocean_config`, `harvester_config`, `linode_config`, `nutanix_config`, `openstack_config` and `vsphere_config` (list maxitems:1)
 * `annotations` - (Optional) Annotations for Machine Config V2 object (map)
 * `labels` - (Optional/Computed) Labels for Machine Config V2 object (map)
 
@@ -363,6 +364,33 @@ The following attributes are exported:
 * `user_data` - (Optional) GCE user-data file path (string)
 * `username` - (Optional) The username to be set when logging into the virtual machines (string)
 * `zone` - (Required) The region and zone to create virtual machines within (e.g. us-east1-b) (string)
+
+### `nutanix_config`
+
+#### Arguments
+
+* `endpoint` - (Required) Nutanix management endpoint IP address/FQDN (string)
+* `username` - (Required) Nutanix management username. Use `X-ntnx-api-key` when using Prism Central service accounts (string)
+* `password` - (Required/Sensitive) Nutanix management password or API key for service account mode (string)
+* `cluster` - (Required) Nutanix cluster where the VM is deployed (string)
+* `vm_network` - (Required) Network names or UUIDs to attach to the VM (list)
+* `vm_image` - (Required) Name of the VM disk image/template to clone from (string)
+* `port` - (Optional) Nutanix management endpoint port. Default `9440` (string)
+* `insecure` - (Optional) Allow insecure SSL requests. Default `false` (bool)
+* `vm_mem` - (Optional) Memory in MB of the VM to be created. Default `2048` (string)
+* `vm_cpus` - (Optional) Number of VCPUs of the VM to be created. Default `2` (string)
+* `vm_cores` - (Optional) Number of cores per VCPU of the VM to be created. Default `1` (string)
+* `vm_cpu_passthrough` - (Optional) Enable passthrough of host CPU features to the VM. Default `false` (bool)
+* `vm_image_size` - (Optional) Increase the size of the template image in GiB. Default `0` (string)
+* `vm_categories` - (Optional) Categories to apply to the VM (list)
+* `storage_container` - (Optional) UUID of the storage container for additional disk (string)
+* `disk_size` - (Optional) Size of the additional disk in GiB. Default `0` (string)
+* `cloud_init` - (Optional) Cloud-init configuration (string)
+* `vm_serial_port` - (Optional) Attach a serial port to the VM. Default `false` (bool)
+* `project` - (Optional) Name of the project to assign the VM (string)
+* `boot_type` - (Optional) Boot type of the VM. Supported values are `legacy` and `uefi`. Default `legacy` (string)
+* `timeout` - (Optional) Timeout for Nutanix operations in seconds. Default `300` (string)
+* `vm_gpu` - (Optional) GPU devices to attach to the VM (list)
 
 ## Timeouts
 

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -369,9 +369,9 @@ The following attributes are exported:
 
 #### Arguments
 
-* `endpoint` - (Required) Nutanix management endpoint IP address/FQDN (string)
-* `username` - (Required) Nutanix management username. Use `X-ntnx-api-key` when using Prism Central service accounts (string)
-* `password` - (Required/Sensitive) Nutanix management password or API key for service account mode (string)
+* `endpoint` - (Optional) Nutanix management endpoint IP address/FQDN. Mandatory if `rancher2_cloud_credential.nutanix_credential_config` is not used (string)
+* `username` - (Optional) Nutanix management username. Use `X-ntnx-api-key` when using Prism Central service accounts. Mandatory if `rancher2_cloud_credential.nutanix_credential_config` is not used (string)
+* `password` - (Optional/Sensitive) Nutanix management password or API key for service account mode. Mandatory if `rancher2_cloud_credential.nutanix_credential_config` is not used (string)
 * `cluster` - (Required) Nutanix cluster where the VM is deployed (string)
 * `vm_network` - (Required) Network names or UUIDs to attach to the VM (list)
 * `vm_image` - (Required) Name of the VM disk image/template to clone from (string)

--- a/rancher2/resource_rancher2_cloud_credential.go
+++ b/rancher2/resource_rancher2_cloud_credential.go
@@ -17,6 +17,7 @@ const (
 	digitaloceanConfigDriver  = "digitalocean"
 	harvesterConfigDriver     = "harvester"
 	linodeConfigDriver        = "linode"
+	nutanixConfigDriver       = "nutanix"
 	openstackConfigDriver     = "openstack"
 	vmwarevsphereConfigDriver = "vmwarevsphere"
 )
@@ -147,6 +148,8 @@ func resourceRancher2CloudCredentialUpdate(d *schema.ResourceData, meta interfac
 		update["harvestercredentialConfig"] = expandCloudCredentialHarvester(d.Get("harvester_credential_config").([]interface{}))
 	case linodeConfigDriver:
 		update["linodecredentialConfig"] = expandCloudCredentialLinode(d.Get("linode_credential_config").([]interface{}))
+	case nutanixConfigDriver:
+		update["nutanixcredentialConfig"] = expandCloudCredentialNutanix(d.Get("nutanix_credential_config").([]interface{}))
 	case openstackConfigDriver:
 		update["openstackcredentialConfig"] = expandCloudCredentialOpenstack(d.Get("openstack_credential_config").([]interface{}))
 	case s3ConfigDriver:

--- a/rancher2/resource_rancher2_machine_config_v2.go
+++ b/rancher2/resource_rancher2_machine_config_v2.go
@@ -234,6 +234,13 @@ func createMachineConfigV2(c *Config, obj *MachineConfigV2) (*MachineConfigV2, e
 		out.ID = resp.ID
 		out.TypeMeta = resp.TypeMeta
 		out.ObjectMeta = resp.ObjectMeta
+	case machineConfigV2NutanixKind:
+		resp := &MachineConfigV2Nutanix{}
+		err = c.createObjectV2(rancher2DefaultLocalClusterID, machineConfigV2NutanixAPIType, obj.NutanixConfig, resp)
+		out.NutanixConfig = resp
+		out.ID = resp.ID
+		out.TypeMeta = resp.TypeMeta
+		out.ObjectMeta = resp.ObjectMeta
 	default:
 		return nil, fmt.Errorf("[ERROR] Unsupported driver on node template: %s", kind)
 	}
@@ -349,6 +356,16 @@ func getMachineConfigV2ByID(c *Config, id, kind string) (*MachineConfigV2, error
 		out.Type = resp.Type
 		out.TypeMeta = resp.TypeMeta
 		out.ObjectMeta = resp.ObjectMeta
+	case machineConfigV2NutanixKind:
+		resp := &MachineConfigV2Nutanix{}
+		err = c.getObjectV2ByID(rancher2DefaultLocalClusterID, id, machineConfigV2NutanixAPIType, resp)
+		out.NutanixConfig = resp
+		out.ID = resp.ID
+		out.Links = resp.Links
+		out.Actions = resp.Actions
+		out.Type = resp.Type
+		out.TypeMeta = resp.TypeMeta
+		out.ObjectMeta = resp.ObjectMeta
 	default:
 		return nil, fmt.Errorf("[ERROR] Unsupported driver on node template: %s", kind)
 	}
@@ -425,6 +442,13 @@ func updateMachineConfigV2(c *Config, obj *MachineConfigV2) (*MachineConfigV2, e
 		resp := &MachineConfigV2GoogleGCE{}
 		err = c.updateObjectV2(rancher2DefaultLocalClusterID, obj.ID, machineConfigV2GoogleGCEAPIType, obj.GoogleGCEConfig, resp)
 		out.GoogleGCEConfig = resp
+		out.ID = resp.ID
+		out.TypeMeta = resp.TypeMeta
+		out.ObjectMeta = resp.ObjectMeta
+	case machineConfigV2NutanixKind:
+		resp := &MachineConfigV2Nutanix{}
+		err = c.updateObjectV2(rancher2DefaultLocalClusterID, obj.ID, machineConfigV2NutanixAPIType, obj.NutanixConfig, resp)
+		out.NutanixConfig = resp
 		out.ID = resp.ID
 		out.TypeMeta = resp.TypeMeta
 		out.ObjectMeta = resp.ObjectMeta

--- a/rancher2/schema_cloud_credential.go
+++ b/rancher2/schema_cloud_credential.go
@@ -15,6 +15,7 @@ type CloudCredential struct {
 	GoogleCredentialConfig        *googleCredentialConfig        `json:"googlecredentialConfig,omitempty" yaml:"googlecredentialConfig,omitempty"`
 	HarvesterCredentialConfig     *harvesterCredentialConfig     `json:"harvestercredentialConfig,omitempty" yaml:"harvestercredentialConfig,omitempty"`
 	LinodeCredentialConfig        *linodeCredentialConfig        `json:"linodecredentialConfig,omitempty" yaml:"linodecredentialConfig,omitempty"`
+	NutanixCredentialConfig       *nutanixCredentialConfig       `json:"nutanixcredentialConfig,omitempty" yaml:"nutanixcredentialConfig,omitempty"`
 	OpenstackCredentialConfig     *openstackCredentialConfig     `json:"openstackcredentialConfig,omitempty" yaml:"openstackcredentialConfig,omitempty"`
 	VmwarevsphereCredentialConfig *vmwarevsphereCredentialConfig `json:"vmwarevspherecredentialConfig,omitempty" yaml:"vmwarevspherecredentialConfig,omitempty"`
 }
@@ -26,6 +27,7 @@ var allCloudCredentialDriverConfigFields = []string{
 	"google_credential_config",
 	"harvester_credential_config",
 	"linode_credential_config",
+	"nutanix_credential_config",
 	"openstack_credential_config",
 	"s3_credential_config",
 	"vsphere_credential_config"}
@@ -98,6 +100,15 @@ func cloudCredentialFields() map[string]*schema.Schema {
 			ConflictsWith: getConflicts(allCloudCredentialDriverConfigFields, "linode_credential_config"),
 			Elem: &schema.Resource{
 				Schema: cloudCredentialLinodeFields(),
+			},
+		},
+		"nutanix_credential_config": {
+			Type:          schema.TypeList,
+			MaxItems:      1,
+			Optional:      true,
+			ConflictsWith: getConflicts(allCloudCredentialDriverConfigFields, "nutanix_credential_config"),
+			Elem: &schema.Resource{
+				Schema: cloudCredentialNutanixFields(),
 			},
 		},
 		"openstack_credential_config": {

--- a/rancher2/schema_cloud_credential_nutanix.go
+++ b/rancher2/schema_cloud_credential_nutanix.go
@@ -1,0 +1,43 @@
+package rancher2
+
+import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+// Types
+
+type nutanixCredentialConfig struct {
+	Endpoint string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+	Port     string `json:"port,omitempty" yaml:"port,omitempty"`
+}
+
+// Schemas
+
+func cloudCredentialNutanixFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"endpoint": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Nutanix management endpoint IP address/FQDN",
+		},
+		"username": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Nutanix management username",
+		},
+		"password": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Nutanix management password",
+		},
+		"port": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "9440",
+			Description: "Nutanix management endpoint port",
+		},
+	}
+
+	return s
+}

--- a/rancher2/schema_machine_config_v2.go
+++ b/rancher2/schema_machine_config_v2.go
@@ -13,6 +13,7 @@ var allMachineDriverConfigFields = []string{
 	"openstack_config",
 	"vsphere_config",
 	"google_config",
+	"nutanix_config",
 }
 
 // Schemas
@@ -109,6 +110,15 @@ func machineConfigV2Fields() map[string]*schema.Schema {
 			ConflictsWith: getConflicts(allMachineDriverConfigFields, "google_config"),
 			Elem: &schema.Resource{
 				Schema: machineConfigV2GoogleGCEFields(),
+			},
+		},
+		"nutanix_config": {
+			Type:          schema.TypeList,
+			MaxItems:      1,
+			Optional:      true,
+			ConflictsWith: getConflicts(allMachineDriverConfigFields, "nutanix_config"),
+			Elem: &schema.Resource{
+				Schema: machineConfigV2NutanixFields(),
 			},
 		},
 		"resource_version": {

--- a/rancher2/schema_machine_config_v2_nutanix.go
+++ b/rancher2/schema_machine_config_v2_nutanix.go
@@ -1,0 +1,147 @@
+package rancher2
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+var (
+	machineConfigV2NutanixBootTypes = []string{"legacy", "uefi"}
+)
+
+func machineConfigV2NutanixFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"endpoint": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Nutanix management endpoint IP address/FQDN",
+		},
+		"username": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Nutanix management username",
+		},
+		"password": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Sensitive:   true,
+			Description: "Nutanix management password",
+		},
+		"port": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "9440",
+			Description: "Nutanix management endpoint port",
+		},
+		"insecure": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Allow insecure SSL requests",
+		},
+		"cluster": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Nutanix cluster to install VM on",
+		},
+		"vm_mem": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "2048",
+			Description: "Memory in MB of the VM to be created",
+		},
+		"vm_cpus": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "2",
+			Description: "Number of VCPUs of the VM to be created",
+		},
+		"vm_cores": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "1",
+			Description: "Number of cores per VCPU of the VM to be created",
+		},
+		"vm_cpu_passthrough": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Enable passthrough of host CPU features to the VM",
+		},
+		"vm_network": {
+			Type:        schema.TypeList,
+			Required:    true,
+			Description: "Network names or UUIDs to attach to the VM",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"vm_image": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Name of the VM disk image to clone from",
+		},
+		"vm_image_size": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "0",
+			Description: "Increase the size of the template image (GiB)",
+		},
+		"vm_categories": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "Categories to apply to the VM",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"storage_container": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "UUID of the storage container for additional disk",
+		},
+		"disk_size": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "0",
+			Description: "Size of the additional disk (GiB)",
+		},
+		"cloud_init": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Cloud-init configuration",
+		},
+		"vm_serial_port": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Attach a serial port to the VM",
+		},
+		"project": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Name of the project to assign the VM",
+		},
+		"boot_type": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "legacy",
+			ValidateFunc: validation.StringInSlice(machineConfigV2NutanixBootTypes, true),
+			Description:  "Boot type of the VM. Supported values: legacy, uefi",
+		},
+		"timeout": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "300",
+			Description: "Timeout for Nutanix operations in seconds",
+		},
+		"vm_gpu": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "GPU devices to attach to the VM",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	}
+}

--- a/rancher2/schema_machine_config_v2_nutanix.go
+++ b/rancher2/schema_machine_config_v2_nutanix.go
@@ -13,17 +13,17 @@ func machineConfigV2NutanixFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"endpoint": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "Nutanix management endpoint IP address/FQDN",
 		},
 		"username": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "Nutanix management username",
 		},
 		"password": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Sensitive:   true,
 			Description: "Nutanix management password",
 		},

--- a/rancher2/structure_cloud_credential.go
+++ b/rancher2/structure_cloud_credential.go
@@ -81,6 +81,15 @@ func flattenCloudCredential(d *schema.ResourceData, in *CloudCredential) error {
 		if err != nil {
 			return err
 		}
+	case nutanixConfigDriver:
+		v, ok := d.Get("nutanix_credential_config").([]interface{})
+		if !ok {
+			v = []interface{}{}
+		}
+		err := d.Set("nutanix_credential_config", flattenCloudCredentialNutanix(in.NutanixCredentialConfig, v))
+		if err != nil {
+			return err
+		}
 	case openstackConfigDriver:
 		v, ok := d.Get("openstack_credential_config").([]interface{})
 		if !ok {
@@ -174,6 +183,11 @@ func expandCloudCredential(in *schema.ResourceData) *CloudCredential {
 	if v, ok := in.Get("linode_credential_config").([]interface{}); ok && len(v) > 0 {
 		obj.LinodeCredentialConfig = expandCloudCredentialLinode(v)
 		in.Set("driver", linodeConfigDriver)
+	}
+
+	if v, ok := in.Get("nutanix_credential_config").([]interface{}); ok && len(v) > 0 {
+		obj.NutanixCredentialConfig = expandCloudCredentialNutanix(v)
+		in.Set("driver", nutanixConfigDriver)
 	}
 
 	if v, ok := in.Get("openstack_credential_config").([]interface{}); ok && len(v) > 0 {

--- a/rancher2/structure_cloud_credential_nutanix.go
+++ b/rancher2/structure_cloud_credential_nutanix.go
@@ -1,0 +1,62 @@
+package rancher2
+
+// Flatteners
+
+func flattenCloudCredentialNutanix(in *nutanixCredentialConfig, p []interface{}) []interface{} {
+	var obj map[string]interface{}
+	if len(p) == 0 || p[0] == nil {
+		obj = make(map[string]interface{})
+	} else {
+		obj = p[0].(map[string]interface{})
+	}
+
+	if in == nil {
+		return []interface{}{}
+	}
+
+	if len(in.Endpoint) > 0 {
+		obj["endpoint"] = in.Endpoint
+	}
+
+	if len(in.Username) > 0 {
+		obj["username"] = in.Username
+	}
+
+	if len(in.Password) > 0 {
+		obj["password"] = in.Password
+	}
+
+	if len(in.Port) > 0 {
+		obj["port"] = in.Port
+	}
+
+	return []interface{}{obj}
+}
+
+// Expanders
+
+func expandCloudCredentialNutanix(p []interface{}) *nutanixCredentialConfig {
+	obj := &nutanixCredentialConfig{}
+	if len(p) == 0 || p[0] == nil {
+		return obj
+	}
+	in := p[0].(map[string]interface{})
+
+	if v, ok := in["endpoint"].(string); ok && len(v) > 0 {
+		obj.Endpoint = v
+	}
+
+	if v, ok := in["username"].(string); ok && len(v) > 0 {
+		obj.Username = v
+	}
+
+	if v, ok := in["password"].(string); ok && len(v) > 0 {
+		obj.Password = v
+	}
+
+	if v, ok := in["port"].(string); ok && len(v) > 0 {
+		obj.Port = v
+	}
+
+	return obj
+}

--- a/rancher2/structure_cloud_credential_nutanix_test.go
+++ b/rancher2/structure_cloud_credential_nutanix_test.go
@@ -1,0 +1,63 @@
+package rancher2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testCloudCredentialNutanixConf      *nutanixCredentialConfig
+	testCloudCredentialNutanixInterface []interface{}
+)
+
+func init() {
+	testCloudCredentialNutanixConf = &nutanixCredentialConfig{
+		Endpoint: "pc.example.com",
+		Username: "X-ntnx-api-key",
+		Password: "secret",
+		Port:     "9440",
+	}
+	testCloudCredentialNutanixInterface = []interface{}{
+		map[string]interface{}{
+			"endpoint": "pc.example.com",
+			"username": "X-ntnx-api-key",
+			"password": "secret",
+			"port":     "9440",
+		},
+	}
+}
+
+func TestFlattenCloudCredentialNutanix(t *testing.T) {
+	cases := []struct {
+		Input          *nutanixCredentialConfig
+		ExpectedOutput []interface{}
+	}{
+		{
+			testCloudCredentialNutanixConf,
+			testCloudCredentialNutanixInterface,
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenCloudCredentialNutanix(tc.Input, tc.ExpectedOutput)
+		assert.Equal(t, tc.ExpectedOutput, output, "Unexpected output from flattener.")
+	}
+}
+
+func TestExpandCloudCredentialNutanix(t *testing.T) {
+	cases := []struct {
+		Input          []interface{}
+		ExpectedOutput *nutanixCredentialConfig
+	}{
+		{
+			testCloudCredentialNutanixInterface,
+			testCloudCredentialNutanixConf,
+		},
+	}
+
+	for _, tc := range cases {
+		output := expandCloudCredentialNutanix(tc.Input)
+		assert.Equal(t, tc.ExpectedOutput, output, "Unexpected output from expander.")
+	}
+}

--- a/rancher2/structure_machine_config_v2.go
+++ b/rancher2/structure_machine_config_v2.go
@@ -27,6 +27,7 @@ type machineConfigV2 struct {
 	OpenstackConfig     *MachineConfigV2Openstack     `json:"openstackConfig,omitempty" yaml:"openstackConfig,omitempty"`
 	VmwarevsphereConfig *MachineConfigV2Vmwarevsphere `json:"vmwarevsphereConfig,omitempty" yaml:"vmwarevsphereConfig,omitempty"`
 	GoogleGCEConfig     *MachineConfigV2GoogleGCE     `json:"googleConfig,omitempty" yaml:"googleConfig,omitempty"`
+	NutanixConfig       *MachineConfigV2Nutanix       `json:"nutanixConfig,omitempty" yaml:"nutanixConfig,omitempty"`
 }
 
 type MachineConfigV2 struct {
@@ -55,6 +56,11 @@ func flattenMachineConfigV2(d *schema.ResourceData, in *MachineConfigV2) error {
 		}
 	case machineConfigV2DigitaloceanKind:
 		err := d.Set("digitalocean_config", flattenMachineConfigV2Digitalocean(in.DigitaloceanConfig))
+		if err != nil {
+			return err
+		}
+	case machineConfigV2NutanixKind:
+		err := d.Set("nutanix_config", flattenMachineConfigV2Nutanix(in.NutanixConfig))
 		if err != nil {
 			return err
 		}
@@ -151,6 +157,9 @@ func expandMachineConfigV2(in *schema.ResourceData) *MachineConfigV2 {
 	}
 	if v, ok := in.Get("google_config").([]interface{}); ok && len(v) > 0 {
 		obj.GoogleGCEConfig = expandMachineConfigV2GoogleGCE(v, obj)
+	}
+	if v, ok := in.Get("nutanix_config").([]interface{}); ok && len(v) > 0 {
+		obj.NutanixConfig = expandMachineConfigV2Nutanix(v, obj)
 	}
 
 	return obj

--- a/rancher2/structure_machine_config_v2_nutanix.go
+++ b/rancher2/structure_machine_config_v2_nutanix.go
@@ -1,0 +1,202 @@
+package rancher2
+
+import (
+	norman "github.com/rancher/norman/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	machineConfigV2NutanixKind       = "NutanixConfig"
+	machineConfigV2NutanixAPIVersion = "rke-machine-config.cattle.io/v1"
+	machineConfigV2NutanixAPIType    = "rke-machine-config.cattle.io.nutanixconfig"
+)
+
+type machineConfigV2Nutanix struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Endpoint          string   `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	Username          string   `json:"username,omitempty" yaml:"username,omitempty"`
+	Password          string   `json:"password,omitempty" yaml:"password,omitempty"`
+	Port              string   `json:"port,omitempty" yaml:"port,omitempty"`
+	Insecure          bool     `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	Cluster           string   `json:"cluster,omitempty" yaml:"cluster,omitempty"`
+	VMMem             string   `json:"vmMem,omitempty" yaml:"vmMem,omitempty"`
+	VMCPUs            string   `json:"vmCpus,omitempty" yaml:"vmCpus,omitempty"`
+	VMCores           string   `json:"vmCores,omitempty" yaml:"vmCores,omitempty"`
+	VMCPUPassthrough  bool     `json:"vmCpuPassthrough,omitempty" yaml:"vmCpuPassthrough,omitempty"`
+	VMNetwork         []string `json:"vmNetwork,omitempty" yaml:"vmNetwork,omitempty"`
+	VMImage           string   `json:"vmImage,omitempty" yaml:"vmImage,omitempty"`
+	VMImageSize       string   `json:"vmImageSize,omitempty" yaml:"vmImageSize,omitempty"`
+	VMCategories      []string `json:"vmCategories,omitempty" yaml:"vmCategories,omitempty"`
+	StorageContainer  string   `json:"storageContainer,omitempty" yaml:"storageContainer,omitempty"`
+	DiskSize          string   `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
+	CloudInit         string   `json:"cloudInit,omitempty" yaml:"cloudInit,omitempty"`
+	VMSerialPort      bool     `json:"vmSerialPort,omitempty" yaml:"vmSerialPort,omitempty"`
+	Project           string   `json:"project,omitempty" yaml:"project,omitempty"`
+	BootType          string   `json:"bootType,omitempty" yaml:"bootType,omitempty"`
+	Timeout           string   `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+	VMGPU             []string `json:"vmGpu,omitempty" yaml:"vmGpu,omitempty"`
+}
+
+type MachineConfigV2Nutanix struct {
+	norman.Resource
+	machineConfigV2Nutanix
+}
+
+func flattenMachineConfigV2Nutanix(in *MachineConfigV2Nutanix) []any {
+	if in == nil {
+		return nil
+	}
+
+	obj := make(map[string]any)
+
+	if len(in.Endpoint) > 0 {
+		obj["endpoint"] = in.Endpoint
+	}
+	if len(in.Username) > 0 {
+		obj["username"] = in.Username
+	}
+	if len(in.Password) > 0 {
+		obj["password"] = in.Password
+	}
+	if len(in.Port) > 0 {
+		obj["port"] = in.Port
+	}
+	obj["insecure"] = in.Insecure
+	if len(in.Cluster) > 0 {
+		obj["cluster"] = in.Cluster
+	}
+	if len(in.VMMem) > 0 {
+		obj["vm_mem"] = in.VMMem
+	}
+	if len(in.VMCPUs) > 0 {
+		obj["vm_cpus"] = in.VMCPUs
+	}
+	if len(in.VMCores) > 0 {
+		obj["vm_cores"] = in.VMCores
+	}
+	obj["vm_cpu_passthrough"] = in.VMCPUPassthrough
+	if len(in.VMNetwork) > 0 {
+		obj["vm_network"] = toArrayInterface(in.VMNetwork)
+	}
+	if len(in.VMImage) > 0 {
+		obj["vm_image"] = in.VMImage
+	}
+	if len(in.VMImageSize) > 0 {
+		obj["vm_image_size"] = in.VMImageSize
+	}
+	if len(in.VMCategories) > 0 {
+		obj["vm_categories"] = toArrayInterface(in.VMCategories)
+	}
+	if len(in.StorageContainer) > 0 {
+		obj["storage_container"] = in.StorageContainer
+	}
+	if len(in.DiskSize) > 0 {
+		obj["disk_size"] = in.DiskSize
+	}
+	if len(in.CloudInit) > 0 {
+		obj["cloud_init"] = in.CloudInit
+	}
+	obj["vm_serial_port"] = in.VMSerialPort
+	if len(in.Project) > 0 {
+		obj["project"] = in.Project
+	}
+	if len(in.BootType) > 0 {
+		obj["boot_type"] = in.BootType
+	}
+	if len(in.Timeout) > 0 {
+		obj["timeout"] = in.Timeout
+	}
+	if len(in.VMGPU) > 0 {
+		obj["vm_gpu"] = toArrayInterface(in.VMGPU)
+	}
+
+	return []any{obj}
+}
+
+func expandMachineConfigV2Nutanix(p []any, source *MachineConfigV2) *MachineConfigV2Nutanix {
+	if p == nil || len(p) == 0 || p[0] == nil {
+		return nil
+	}
+
+	obj := &MachineConfigV2Nutanix{}
+	if len(source.ID) > 0 {
+		obj.ID = source.ID
+	}
+
+	in := p[0].(map[string]any)
+
+	obj.TypeMeta.Kind = machineConfigV2NutanixKind
+	obj.TypeMeta.APIVersion = machineConfigV2NutanixAPIVersion
+	source.TypeMeta = obj.TypeMeta
+	obj.ObjectMeta = source.ObjectMeta
+
+	if v, ok := in["endpoint"].(string); ok && len(v) > 0 {
+		obj.Endpoint = v
+	}
+	if v, ok := in["username"].(string); ok && len(v) > 0 {
+		obj.Username = v
+	}
+	if v, ok := in["password"].(string); ok && len(v) > 0 {
+		obj.Password = v
+	}
+	if v, ok := in["port"].(string); ok && len(v) > 0 {
+		obj.Port = v
+	}
+	if v, ok := in["insecure"].(bool); ok {
+		obj.Insecure = v
+	}
+	if v, ok := in["cluster"].(string); ok && len(v) > 0 {
+		obj.Cluster = v
+	}
+	if v, ok := in["vm_mem"].(string); ok && len(v) > 0 {
+		obj.VMMem = v
+	}
+	if v, ok := in["vm_cpus"].(string); ok && len(v) > 0 {
+		obj.VMCPUs = v
+	}
+	if v, ok := in["vm_cores"].(string); ok && len(v) > 0 {
+		obj.VMCores = v
+	}
+	if v, ok := in["vm_cpu_passthrough"].(bool); ok {
+		obj.VMCPUPassthrough = v
+	}
+	if v, ok := in["vm_network"].([]any); ok && len(v) > 0 {
+		obj.VMNetwork = toArrayString(v)
+	}
+	if v, ok := in["vm_image"].(string); ok && len(v) > 0 {
+		obj.VMImage = v
+	}
+	if v, ok := in["vm_image_size"].(string); ok && len(v) > 0 {
+		obj.VMImageSize = v
+	}
+	if v, ok := in["vm_categories"].([]any); ok && len(v) > 0 {
+		obj.VMCategories = toArrayString(v)
+	}
+	if v, ok := in["storage_container"].(string); ok && len(v) > 0 {
+		obj.StorageContainer = v
+	}
+	if v, ok := in["disk_size"].(string); ok && len(v) > 0 {
+		obj.DiskSize = v
+	}
+	if v, ok := in["cloud_init"].(string); ok && len(v) > 0 {
+		obj.CloudInit = v
+	}
+	if v, ok := in["vm_serial_port"].(bool); ok {
+		obj.VMSerialPort = v
+	}
+	if v, ok := in["project"].(string); ok && len(v) > 0 {
+		obj.Project = v
+	}
+	if v, ok := in["boot_type"].(string); ok && len(v) > 0 {
+		obj.BootType = v
+	}
+	if v, ok := in["timeout"].(string); ok && len(v) > 0 {
+		obj.Timeout = v
+	}
+	if v, ok := in["vm_gpu"].([]any); ok && len(v) > 0 {
+		obj.VMGPU = toArrayString(v)
+	}
+
+	return obj
+}

--- a/rancher2/structure_machine_config_v2_nutanix_test.go
+++ b/rancher2/structure_machine_config_v2_nutanix_test.go
@@ -1,0 +1,114 @@
+package rancher2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	testMachineConfigV2NutanixConf = &MachineConfigV2Nutanix{
+		machineConfigV2Nutanix: machineConfigV2Nutanix{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       machineConfigV2NutanixKind,
+				APIVersion: machineConfigV2NutanixAPIVersion,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nc-test",
+				Namespace: "fleet-default",
+			},
+			Endpoint:         "pc.example.com",
+			Username:         "X-ntnx-api-key",
+			Password:         "secret",
+			Port:             "9440",
+			Insecure:         true,
+			Cluster:          "cluster-a",
+			VMMem:            "4096",
+			VMCPUs:           "4",
+			VMCores:          "2",
+			VMCPUPassthrough: true,
+			VMNetwork:        []string{"subnet-a", "subnet-b"},
+			VMImage:          "ubuntu-cloudinit",
+			VMImageSize:      "80",
+			VMCategories:     []string{"app:tf", "env:dev"},
+			StorageContainer: "container-uuid",
+			DiskSize:         "40",
+			CloudInit:        "#cloud-config",
+			VMSerialPort:     true,
+			Project:          "project-a",
+			BootType:         "uefi",
+			Timeout:          "600",
+			VMGPU:            []string{"gpu-a"},
+		},
+	}
+	testMachineConfigV2NutanixInterface = []any{
+		map[string]any{
+			"endpoint":           "pc.example.com",
+			"username":           "X-ntnx-api-key",
+			"password":           "secret",
+			"port":               "9440",
+			"insecure":           true,
+			"cluster":            "cluster-a",
+			"vm_mem":             "4096",
+			"vm_cpus":            "4",
+			"vm_cores":           "2",
+			"vm_cpu_passthrough": true,
+			"vm_network":         []any{"subnet-a", "subnet-b"},
+			"vm_image":           "ubuntu-cloudinit",
+			"vm_image_size":      "80",
+			"vm_categories":      []any{"app:tf", "env:dev"},
+			"storage_container":  "container-uuid",
+			"disk_size":          "40",
+			"cloud_init":         "#cloud-config",
+			"vm_serial_port":     true,
+			"project":            "project-a",
+			"boot_type":          "uefi",
+			"timeout":            "600",
+			"vm_gpu":             []any{"gpu-a"},
+		},
+	}
+)
+
+func TestFlattenMachineConfigV2Nutanix(t *testing.T) {
+	cases := []struct {
+		Input          *MachineConfigV2Nutanix
+		ExpectedOutput []any
+	}{
+		{
+			Input:          testMachineConfigV2NutanixConf,
+			ExpectedOutput: testMachineConfigV2NutanixInterface,
+		},
+	}
+
+	for _, tc := range cases {
+		output := flattenMachineConfigV2Nutanix(tc.Input)
+		assert.Equal(t, tc.ExpectedOutput, output, "Unexpected output from flattener.")
+	}
+}
+
+func TestExpandMachineConfigV2Nutanix(t *testing.T) {
+	cases := []struct {
+		Input          []any
+		Source         *MachineConfigV2
+		ExpectedOutput *MachineConfigV2Nutanix
+	}{
+		{
+			Input: testMachineConfigV2NutanixInterface,
+			Source: &MachineConfigV2{
+				machineConfigV2: machineConfigV2{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nc-test",
+						Namespace: "fleet-default",
+					},
+				},
+			},
+			ExpectedOutput: testMachineConfigV2NutanixConf,
+		},
+	}
+
+	for _, tc := range cases {
+		output := expandMachineConfigV2Nutanix(tc.Input, tc.Source)
+		assert.Equal(t, tc.ExpectedOutput.machineConfigV2Nutanix, output.machineConfigV2Nutanix, "Unexpected output from expander.")
+	}
+}


### PR DESCRIPTION
## Issue

  https://github.com/rancher/terraform-provider-rancher2/issues/2079

  ## Problem

  The provider did not support Nutanix in `rancher2_machine_config_v2`.

  When Terraform used a Nutanix machine config, the provider hit:
  `[ERROR] Unsupported driver on node template: NutanixConfig`

  This happened because Nutanix was missing in:

  - schema (`nutanix_config` block did not exist)
  - expand/flatten logic
  - create/read/update switch cases

  ## Solution

  Added Nutanix support in the same pattern used by other machine drivers:

  - Added `nutanix_config` schema block and conflict wiring in machine config v2.
  - Added Nutanix fields based on bundled Nutanix driver v3.8.0.
  - Added Nutanix structure type + constants + flatten/expand functions.
  - Wired Nutanix into machine config v2 create/read/update code paths.
  - Updated docs for `rancher2_machine_config_v2` with `nutanix_config` arguments.

  ## Testing

  Local check done:

  - `terraform plan` with `nutanix_config` works and no unsupported driver error appears.

  ## Engineering Testing

  ### Manual Testing

The plan flow was tested locally with development override and confirmed the new `nutanix_config` block is accepted.

  For full end-to-end validation (including cluster creation) test this PR locally with the steps below.
  
  ```bash
  1. Pull and checkout the PR branch

  git fetch upstream pull/2083/head:pr-2079-nutanix
  git checkout pr-2079-nutanix

  2. Build the provider

  make build

  3. Create a clean test directory

  mkdir -p /tmp/tf-rancher2-nutanix-test
  cd /tmp/tf-rancher2-nutanix-test

  4. Create a local Terraform CLI config (dev override)

  # file: /tmp/tf-rancher2-nutanix-test/.terraformrc
  provider_installation {
    dev_overrides {
      "rancher/rancher2" = "/ABSOLUTE/PATH/TO/terraform-provider-rancher2/bin"
    }
    direct {}
  }

  5. Export the CLI config path

  export TF_CLI_CONFIG_FILE=/tmp/tf-rancher2-nutanix-test/.terraformrc

  6. Create main.tf

  terraform {
    required_version = ">= 1.5.0"
    required_providers {
      rancher2 = {
        source = "rancher/rancher2"
      }
    }
  }

  provider "rancher2" {
    api_url   = var.rancher_api_url
    token_key = var.rancher_token_key
    insecure  = var.rancher_insecure
  }

  data "rancher2_node_driver" "nutanix" {
    name = "nutanix"
  }

  resource "rancher2_cloud_credential" "nutanix" {
    name = var.cloud_credential_name

    nutanix_credential_config {
      endpoint = var.nutanix_endpoint
      username = var.nutanix_username
      password = var.nutanix_password
      port     = var.nutanix_port
    }
  }

  resource "rancher2_machine_config_v2" "nutanix" {
    generate_name   = var.machine_config_generate_name
    fleet_namespace = var.fleet_namespace

    nutanix_config {
      cluster    = var.nutanix_cluster
      vm_network = var.nutanix_vm_network
      vm_image   = var.nutanix_vm_image

      insecure           = var.nutanix_insecure
      vm_mem             = var.nutanix_vm_mem
      vm_cpus            = var.nutanix_vm_cpus
      vm_cores           = var.nutanix_vm_cores
      boot_type          = var.nutanix_boot_type
      timeout            = var.nutanix_timeout
      vm_categories      = var.nutanix_vm_categories
      storage_container  = var.nutanix_storage_container
      disk_size          = var.nutanix_disk_size
      cloud_init         = var.nutanix_cloud_init
      vm_serial_port     = var.nutanix_vm_serial_port
      project            = var.nutanix_project
      vm_gpu             = var.nutanix_vm_gpu
    }

    depends_on = [data.rancher2_node_driver.nutanix]
  }

  7. Create cluster.tf

  resource "rancher2_cluster_v2" "nutanix" {
    name                  = var.cluster_name
    kubernetes_version    = var.kubernetes_version
    enable_network_policy = false

    rke_config {
      machine_pools {
        name                         = "pool1"
        cloud_credential_secret_name = rancher2_cloud_credential.nutanix.id
        control_plane_role           = true
        etcd_role                    = true
        worker_role                  = true
        quantity                     = 1
        drain_before_delete          = true

        machine_config {
          kind = rancher2_machine_config_v2.nutanix.kind
          name = rancher2_machine_config_v2.nutanix.name
        }
      }
    }
  }

  8. Create variables.tf

  variable "rancher_api_url" {
    type = string
  }

  variable "rancher_token_key" {
    type      = string
    sensitive = true
  }

  variable "rancher_insecure" {
    type = bool
  }

  variable "cloud_credential_name" {
    type = string
  }

  variable "fleet_namespace" {
    type    = string
    default = "fleet-default"
  }

  variable "machine_config_generate_name" {
    type = string
  }

  variable "cluster_name" {
    type = string
  }

  variable "kubernetes_version" {
    type = string
  }

  variable "nutanix_endpoint" {
    type = string
  }

  variable "nutanix_username" {
    type = string
  }

  variable "nutanix_password" {
    type      = string
    sensitive = true
  }

  variable "nutanix_cluster" {
    type = string
  }

  variable "nutanix_vm_network" {
    type = list(string)
  }

  variable "nutanix_vm_image" {
    type = string
  }

  variable "nutanix_port" {
    type    = string
    default = "9440"
  }

  variable "nutanix_insecure" {
    type    = bool
    default = false
  }

  variable "nutanix_vm_mem" {
    type    = string
    default = "2048"
  }

  variable "nutanix_vm_cpus" {
    type    = string
    default = "2"
  }

  variable "nutanix_vm_cores" {
    type    = string
    default = "1"
  }

  variable "nutanix_boot_type" {
    type    = string
    default = "legacy"
  }

  variable "nutanix_timeout" {
    type    = string
    default = "300"
  }

  variable "nutanix_vm_categories" {
    type    = list(string)
    default = []
  }

  variable "nutanix_storage_container" {
    type    = string
    default = ""
  }

  variable "nutanix_disk_size" {
    type    = string
    default = "0"
  }

  variable "nutanix_cloud_init" {
    type    = string
    default = ""
  }

  variable "nutanix_vm_serial_port" {
    type    = bool
    default = false
  }

  variable "nutanix_project" {
    type    = string
    default = ""
  }

  variable "nutanix_vm_gpu" {
    type    = list(string)
    default = []
  }

  9. Create nutanix.tfvars

  # Rancher
  rancher_api_url   = "https://<RANCHER_URL>"
  rancher_token_key = "<RANCHER_TOKEN>"
  rancher_insecure  = true

  # New Rancher cloud credential name (Terraform will create it)
  cloud_credential_name = "tf-nutanix-credential"

  # Machine config
  fleet_namespace              = "fleet-default"
  machine_config_generate_name = "nutanix-tf-"

  # Cluster
  cluster_name       = "tf-nutanix-e2e"
  kubernetes_version = "v1.30.6+rke2r1"

  # Nutanix
  nutanix_endpoint   = "<PRISM_ENDPOINT>"
  nutanix_username   = "X-ntnx-api-key"
  nutanix_password   = "<NUTANIX_API_KEY_OR_PASSWORD>"
  nutanix_cluster    = "<NUTANIX_CLUSTER_NAME>"
  nutanix_vm_network = ["<NETWORK_NAME_OR_UUID>"]
  nutanix_vm_image   = "<IMAGE_NAME>"

  10. Run test flow

  terraform init
  terraform validate
  terraform plan -var-file=nutanix.tfvars
  terraform apply -var-file=nutanix.tfvars
  terraform plan -var-file=nutanix.tfvars
  terraform destroy -var-file=nutanix.tfvars
  ```

  Expected result:

  - No Unsupported driver on node template error
  - Cloud credential + machine config + cluster are created
  - Second plan is no-op
 
  Optional update check:

  terraform apply -var-file=nutanix.tfvars -var='nutanix_vm_mem="4096"'
  terraform plan -var-file=nutanix.tfvars -var='nutanix_vm_mem="4096"'

  ### Automated Testing

  - Test types added/modified:
      - Unit

  Summary:

  - Added unit tests for Nutanix flatten/expand:
      - TestFlattenMachineConfigV2Nutanix
      - TestExpandMachineConfigV2Nutanix
  - Ran:
      - GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod GOFLAGS=-mod=mod go test ./rancher2
  - Result: pass

  ## QA Testing Considerations

  Please test:

  - Fresh create/update/delete of rancher2_machine_config_v2 with nutanix_config.
  - Cluster provisioning path (rancher2_cluster_v2 machine pool referencing Nutanix machine config).
  - Default username/password and service account values.