### PR TITLE
Add support for host devices and vgpus

### DIFF
--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -229,6 +229,8 @@ The following attributes are exported:
 * `user_data` - (Optional) UserData content of cloud-init, base64 is supported. If the image does not contain the qemu-guest-agent package, you must install and start qemu-guest-agent using userdata (string)
 * `network_data` - (Optional) NetworkData content of cloud-init, base64 is supported (string)
 * `vm_affinity` - (Optional) Virtual machine affinity, only base64 format is supported. For Rancher v2.6.7 and above (string)
+* `vgpu_info` - (Optional) A list of vGPU devices to attach to the VM. Each element contains `name` and `device_name`. (list)
+* `host_device_info` - (Optional) A list of Host Devices (e.g PCI passthrough) to attach to the VM. Each element contains `name` and `device_name`. (list)
 
 ### `linode_config`
 

--- a/rancher2/schema_machine_config_v2_harvester.go
+++ b/rancher2/schema_machine_config_v2_harvester.go
@@ -127,7 +127,38 @@ func machineConfigV2HarvesterFields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "NetworkData content of cloud-init, base64 is supported",
 		},
+		"vgpu_info": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "A list of vGPU devices to attach to the VM",
+			Elem: &schema.Resource{
+				Schema: harvesterDeviceFields(),
+			},
+		},
+		"host_device_info": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "A list of Host Devices (e.g. PCI passthrough) to attach to the VM",
+			Elem: &schema.Resource{
+				Schema: harvesterDeviceFields(),
+			},
+		},
 	}
 
 	return s
+}
+
+func harvesterDeviceFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The name of the device",
+		},
+		"device_name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The device name (e.g. nvidia.com/GH100_H200_SXM_141GB)",
+		},
+	}
 }

--- a/rancher2/structure_machine_config_v2_harvester.go
+++ b/rancher2/structure_machine_config_v2_harvester.go
@@ -1,6 +1,8 @@
 package rancher2
 
 import (
+	"encoding/json"
+
 	norman "github.com/rancher/norman/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -33,6 +35,8 @@ type machineConfigV2Harvester struct {
 	NetworkInfo        string `json:"networkInfo,omitempty" yaml:"networkInfo,omitempty"`
 	UserData           string `json:"userData,omitempty" yaml:"userData,omitempty"`
 	NetworkData        string `json:"networkData,omitempty" yaml:"networkData,omitempty"`
+	VGPUInfo           string `json:"vgpuInfo,omitempty" yaml:"vgpuInfo,omitempty"`
+	HostDeviceInfo     string `json:"hostDeviceInfo,omitempty" yaml:"hostDeviceInfo,omitempty"`
 }
 
 type MachineConfigV2Harvester struct {
@@ -111,6 +115,40 @@ func flattenMachineConfigV2Harvester(in *MachineConfigV2Harvester) []interface{}
 
 	if len(in.NetworkData) > 0 {
 		obj["network_data"] = in.NetworkData
+	}
+
+	if len(in.VGPUInfo) > 0 {
+		var vgpuMap map[string][]map[string]string
+		err := json.Unmarshal([]byte(in.VGPUInfo), &vgpuMap)
+		if err == nil {
+			if gpuDevices, ok := vgpuMap["gpuDevices"]; ok {
+				var devices []any
+				for _, d := range gpuDevices {
+					devices = append(devices, map[string]any{
+						"name":        d["name"],
+						"device_name": d["deviceName"],
+					})
+				}
+				obj["vgpu_info"] = devices
+			}
+		}
+	}
+
+	if len(in.HostDeviceInfo) > 0 {
+		var hostMap map[string][]map[string]string
+		err := json.Unmarshal([]byte(in.HostDeviceInfo), &hostMap)
+		if err == nil {
+			if hostDevices, ok := hostMap["hostDevices"]; ok {
+				var devices []any
+				for _, d := range hostDevices {
+					devices = append(devices, map[string]any{
+						"name":        d["name"],
+						"device_name": d["deviceName"],
+					})
+				}
+				obj["host_device_info"] = devices
+			}
+		}
 	}
 
 	return []interface{}{obj}
@@ -196,6 +234,42 @@ func expandMachineConfigV2Harvester(p []interface{}, source *MachineConfigV2) *M
 
 	if v, ok := in["network_data"].(string); ok && len(v) > 0 {
 		obj.NetworkData = v
+	}
+
+	if v, ok := in["vgpu_info"].([]any); ok && len(v) > 0 {
+		gpuDevices := []map[string]string{}
+		for _, raw := range v {
+			d := raw.(map[string]any)
+			gpuDevices = append(gpuDevices, map[string]string{
+				"name":       d["name"].(string),
+				"deviceName": d["device_name"].(string),
+			})
+		}
+		vgpuMap := map[string][]map[string]string{
+			"gpuDevices": gpuDevices,
+		}
+		vgpuJSON, err := json.Marshal(vgpuMap)
+		if err == nil {
+			obj.VGPUInfo = string(vgpuJSON)
+		}
+	}
+
+	if v, ok := in["host_device_info"].([]any); ok && len(v) > 0 {
+		hostDevices := []map[string]string{}
+		for _, raw := range v {
+			d := raw.(map[string]any)
+			hostDevices = append(hostDevices, map[string]string{
+				"name":       d["name"].(string),
+				"deviceName": d["device_name"].(string),
+			})
+		}
+		hostMap := map[string][]map[string]string{
+			"hostDevices": hostDevices,
+		}
+		hostJSON, err := json.Marshal(hostMap)
+		if err == nil {
+			obj.HostDeviceInfo = string(hostJSON)
+		}
 	}
 
 	return obj


### PR DESCRIPTION
Addresses #1030 

vGPUs parameter is not supported in the Harvester config for the Machine Config resource.

## Description

Adds support for the vGPU and HostDevices parameter.

## Testing

Specify a vgpu_info parameter and check that it is populated in the HarvesterConfig.

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
