### PR TITLE
feat: add refresh_interval support to catalog_v2

### DIFF
--- a/docs/data-sources/catalog_v2.md
+++ b/docs/data-sources/catalog_v2.md
@@ -29,6 +29,7 @@ data "rancher2_catalog_v2" "foo" {
 * `git_branch` - (Computed) Git Repository branch containing Helm chart definitions. Default `master` (string)
 * `git_repo` - (Computed) The url of the catalog v2 repo (string)
 * `insecure` - (Computed) Use insecure HTTPS to download the repo's index. Default: `false` (bool)
+* `refresh_interval` - (Computed) Interval in seconds at which the Helm repository should be refreshed (int)
 * `secret_name` - (Computed) K8s secret name to be used to connect to the repo (string)
 * `secret_namespace` - (Computed) K8s secret namespace (string)
 * `service_account` - (Computed) K8s service account used to deploy charts instead of the end users credentials (string)

--- a/docs/guides/apps_marketplace.md
+++ b/docs/guides/apps_marketplace.md
@@ -29,6 +29,7 @@ This resource has the following arguments definition:
 * `git_branch` - (Optional) Git Repository branch containing Helm chart definitions. Default `master` (string)
 * `git_repo` - (Optional) The url of the catalog v2 repo (string)
 * `insecure` - (Optional) Use insecure HTTPS to download the repo's index. Default: `false` (bool)
+* `refresh_interval` - (Optional/Computed) Interval in seconds at which the Helm repository should be refreshed (int)
 * `secret_name` - (Optional) K8s secret name to be used to connect to the repo (string)
 * `secret_namespace` - (Optional) K8s secret namespace (string)
 * `service_account` - (Optional) K8s service account used to deploy charts instead of the end users credentials (string)

--- a/docs/resources/catalog_v2.md
+++ b/docs/resources/catalog_v2.md
@@ -35,6 +35,7 @@ The following arguments are supported:
 * `git_branch` - (Optional/Computed) Git Repository branch containing Helm chart definitions. Default `master` (string)
 * `git_repo` - (Optional) The url of the catalog v2 repo. Conflicts with `url` (string)
 * `insecure` - (Optional) Use insecure HTTPS to download the repo's index. Default: `false` (bool)
+* `refresh_interval` - (Optional/Computed) Interval in seconds at which the Helm repository should be refreshed (int)
 * `secret_name` - (Optional) K8s secret name to be used to connect to the repo (string)
 * `secret_namespace` - (Optional) K8s secret namespace (string)
 * `service_account` - (Optional) K8s service account used to deploy charts instead of the end users credentials (string)

--- a/rancher2/data_source_rancher2_catalog_v2.go
+++ b/rancher2/data_source_rancher2_catalog_v2.go
@@ -67,6 +67,11 @@ func dataSourceRancher2CatalogV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"refresh_interval": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Interval in seconds at which the Helm repository should be refreshed",
+			},
 			"secret_name": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/rancher2/schema_catalog_v2.go
+++ b/rancher2/schema_catalog_v2.go
@@ -99,6 +99,12 @@ func catalogV2Fields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"refresh_interval": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+			Description: "Interval in seconds at which the Helm repository should be refreshed",
+		},
 		"secret_name": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/rancher2/structure_catalog_v2.go
+++ b/rancher2/structure_catalog_v2.go
@@ -49,6 +49,7 @@ func flattenCatalogV2(d *schema.ResourceData, in *ClusterRepo) error {
 	}
 
 	d.Set("insecure_plain_http", in.Spec.InsecurePlainHTTP)
+	d.Set("refresh_interval", in.Spec.RefreshInterval)
 
 	d.Set("service_account", in.Spec.ServiceAccount)
 	d.Set("service_account_namespace", in.Spec.ServiceAccountNamespace)
@@ -154,6 +155,9 @@ func expandCatalogV2(in *schema.ResourceData) (*ClusterRepo, error) {
 	}
 	if v, ok := in.Get("url").(string); ok {
 		obj.Spec.URL = v
+	}
+	if v, ok := in.Get("refresh_interval").(int); ok && v > 0 {
+		obj.Spec.RefreshInterval = v
 	}
 
 	return obj, nil

--- a/rancher2/structure_catalog_v2_test.go
+++ b/rancher2/structure_catalog_v2_test.go
@@ -46,6 +46,7 @@ func init() {
 	testCatalogV2Conf.Spec.ServiceAccount = "service_account"
 	testCatalogV2Conf.Spec.ServiceAccountNamespace = "service_account_namespace"
 	testCatalogV2Conf.Spec.URL = "url"
+	testCatalogV2Conf.Spec.RefreshInterval = 300
 
 	testCatalogV2Interface = map[string]interface{}{
 		"name":                            "name",
@@ -63,6 +64,7 @@ func init() {
 		"service_account":                 "service_account",
 		"service_account_namespace":       "service_account_namespace",
 		"url":                             "url",
+		"refresh_interval":                300,
 		"annotations": map[string]interface{}{
 			"value1": "one",
 			"value2": "two",


### PR DESCRIPTION
Addresses rancher/rancher#54331

## Description

The ClusterRepo CRD in Rancher supports a refreshInterval field to control how often Helm repositories are refreshed. This field was missing from the Terraform provider.

Changes:
- Add refresh_interval to resource and data source schemas
- Update flatteners and expanders to support refresh_interval
- Add test coverage
- Update documentation

## Testing

Configuration:
```
# Test 1: Catalog with custom refresh_interval (git repo)
resource "rancher2_catalog_v2" "test_custom_interval_git" {
  cluster_id = "local"
  name       = "test-refresh-git"

  git_repo   = "https://github.com/rancher/charts"
  git_branch = "dev-v2.9"

  refresh_interval = 600

  annotations = {
    "test" = "refresh_interval_feature"
  }
}

# Test 2: Catalog without refresh_interval
resource "rancher2_catalog_v2" "test_default_interval" {
  cluster_id = "local"
  name       = "test-refresh-default"

  git_repo   = "https://github.com/rancher/charts"
  git_branch = "release-v2.9"
}

# Data source to read back the catalog and verify refresh_interval
data "rancher2_catalog_v2" "verify_custom" {
  depends_on = [rancher2_catalog_v2.test_custom_interval_git]

  cluster_id = "local"
  name       = "test-refresh-git"
}

# Outputs to verify the values
output "custom_interval_git_value" {
  description = "Refresh interval for git catalog (should be 600)"
  value       = rancher2_catalog_v2.test_custom_interval_git.refresh_interval
}

output "data_source_verified_value" {
  description = "Refresh interval read from data source (should be 600)"
  value       = data.rancher2_catalog_v2.verify_custom.refresh_interval
}
```

Output:
```
rancher2_catalog_v2.test_custom_interval_git: Creating...
rancher2_catalog_v2.test_default_interval: Creating...
rancher2_catalog_v2.test_default_interval: Still creating... [10s elapsed]
rancher2_catalog_v2.test_custom_interval_git: Still creating... [10s elapsed]
rancher2_catalog_v2.test_default_interval: Creation complete after 10s [id=local.test-refresh-default]
rancher2_catalog_v2.test_custom_interval_git: Still creating... [20s elapsed]
rancher2_catalog_v2.test_custom_interval_git: Creation complete after 20s [id=local.test-refresh-git]
data.rancher2_catalog_v2.verify_custom: Reading...
data.rancher2_catalog_v2.verify_custom: Read complete after 0s [id=local.test-refresh-git]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

custom_interval_git_value = 600
data_source_verified_value = 600
```

Not a breaking change since the field is optional.
