### PR TITLE
Fix ci

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -43,10 +43,10 @@ if ! which "$0" | grep -q nix; then
   fi
 
   echo 'Installing Nix Profile...'
-  if ! nf profile install . --profile "$profile"; then
-    echo 'Failed to install new Nix profile! Reverting to previous profile...'
+  if ! nf profile add . --profile "$profile"; then
+    echo 'Failed to add new Nix profile! Reverting to previous profile...'
     git checkout flake.lock
-    nf profile install . --profile "$profile"
+    nf profile add . --profile "$profile"
   fi
 
   nf profile list --profile "$profile"

--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -110,46 +110,21 @@ jobs:
           go-version-file: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.mod
           cache-dependency-path: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.sum
           cache: true
-      - name: Setup goreleaser
-        shell: bash
-        run: |-
-          OS="Linux"
-          if [[ ${RUNNER_OS} != "Linux" ]]; then
-          	echo "Unsupported OS: ${RUNNER_OS}"
-          	exit 1
-          fi
-
-          # renovate-local: goreleaser-x86_64
-          GORELEASER_VERSION="v2.15.2"
-          # renovate-local: goreleaser-x86_64=v2.15.2
-          GORELEASER_CHECKSUM_x86_64="0ebdbf0353aba566b969dde746cc4e4806f96c27aa2f3971b229a9df7611fedc"
-
-          ARCH=$(uname -m)
-          CHECKSUM="${GORELEASER_CHECKSUM_x86_64}"
-          if [[ "${ARCH}" != "x86_64" ]]; then
-          	echo "Unsupported architecture: ${ARCH}"
-          	exit 1
-          fi
-
-          FILE="goreleaser_${OS}_${ARCH}.tar.gz"
-
-          echo "Installing ${FILE}"
-          curl -LO "https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/${FILE}"
-          echo "${CHECKSUM} ${FILE}" | sha256sum -c
-          tar -xf "${FILE}" goreleaser
-
-          if sudo -n true &> /dev/null; then
-          	sudo install -m 755 goreleaser /usr/local/bin/goreleaser
-          else
-          	install -m 755 goreleaser /usr/local/bin/goreleaser
-          fi
-          rm -f "${FILE}" goreleaser
+      - name: install-nix
+        run: |
+          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
+          chmod +x install.sh
+          ./install.sh
+          source /home/runner/.nix-profile/etc/profile.d/nix.sh
+          nix --version
+          which nix
       - name: Run GoReleaser
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-        shell: bash
         run: |-
           goreleaser release --clean --skip=validate --config ../../.goreleaser_rc.yml
           if [[ ! -f dist/metadata.json ]] || [[ ! -s dist/metadata.json ]]; then

--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -11,15 +11,22 @@ on:
       tag:
         description: 'The rc tag to create, e.g. v1.2.3-rc.1'
         required: true
-permissions:
-  contents: write
-  id-token: write
-  issues: write
-  pull-requests: write
-  actions: read
+
+env:
+  NIX_INSTALL_SHA: de490f61fcbaf9a5cabf2fa621ddb9ef93ad35d9a23a04e7d51b26e092b63691
+  NIX_INSTALL_VERSION: 2.34.4
+
+permissions: {}
+
 jobs:
   rc-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+      actions: read
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script/commits/main
         id: check-user-in-maintainers
@@ -120,12 +127,14 @@ jobs:
           nix --version
           which nix
       - name: Run GoReleaser
-        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep TAG --keep GPG_KEY_ID --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GPG_PASSPHRASE --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+          TAG: ${{ inputs.tag }}
         run: |-
+          cd ${{ github.workspace }}/tags/$TAG
           goreleaser release --clean --skip=validate --config ../../.goreleaser_rc.yml
           if [[ ! -f dist/metadata.json ]] || [[ ! -s dist/metadata.json ]]; then
             echo "Missing required file: dist/metadata.json"

--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -127,7 +127,7 @@ jobs:
           nix --version
           which nix
       - name: Run GoReleaser
-        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep TAG --keep GPG_KEY_ID --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GPG_PASSPHRASE --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep TAG --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -103,46 +103,21 @@ jobs:
           go-version-file: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.mod
           cache-dependency-path: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.sum
           cache: true
-      - name: Setup goreleaser
-        shell: bash
-        run: |-
-          OS="Linux"
-          if [[ ${RUNNER_OS} != "Linux" ]]; then
-          	echo "Unsupported OS: ${RUNNER_OS}"
-          	exit 1
-          fi
-
-          # renovate-local: goreleaser-x86_64
-          GORELEASER_VERSION="v2.15.2"
-          # renovate-local: goreleaser-x86_64=v2.15.2
-          GORELEASER_CHECKSUM_x86_64="0ebdbf0353aba566b969dde746cc4e4806f96c27aa2f3971b229a9df7611fedc"
-
-          ARCH=$(uname -m)
-          CHECKSUM="${GORELEASER_CHECKSUM_x86_64}"
-          if [[ "${ARCH}" != "x86_64" ]]; then
-          	echo "Unsupported architecture: ${ARCH}"
-          	exit 1
-          fi
-
-          FILE="goreleaser_${OS}_${ARCH}.tar.gz"
-
-          echo "Installing ${FILE}"
-          curl -LO "https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/${FILE}"
-          echo "${CHECKSUM} ${FILE}" | sha256sum -c
-          tar -xf "${FILE}" goreleaser
-
-          if sudo -n true &> /dev/null; then
-          	sudo install -m 755 goreleaser /usr/local/bin/goreleaser
-          else
-          	install -m 755 goreleaser /usr/local/bin/goreleaser
-          fi
-          rm -f "${FILE}" goreleaser
+      - name: install-nix
+        run: |
+          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
+          chmod +x install.sh
+          ./install.sh
+          source /home/runner/.nix-profile/etc/profile.d/nix.sh
+          nix --version
+          which nix
       - name: Run GoReleaser
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-        shell: bash
         run: |-
           goreleaser release --clean --skip=validate --config ../../.goreleaser.yml
           if [[ ! -f dist/metadata.json ]] || [[ ! -s dist/metadata.json ]]; then

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -8,13 +8,20 @@ on:
       sha:
         description: 'The commit SHA to create the tag from, defaults to HEAD of the selected branch.'
         required: false
-permissions:
-  contents: write
-  id-token: write
-  actions: read
+
+env:
+  NIX_INSTALL_SHA: de490f61fcbaf9a5cabf2fa621ddb9ef93ad35d9a23a04e7d51b26e092b63691
+  NIX_INSTALL_VERSION: 2.34.4
+
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      actions: read
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script/commits/main
         id: check-user-in-maintainers
@@ -113,12 +120,14 @@ jobs:
           nix --version
           which nix
       - name: Run GoReleaser
-        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep TAG --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+          TAG: ${{ inputs.tag }}
         run: |-
+          cd ${{ github.workspace }}/tags/$TAG
           goreleaser release --clean --skip=validate --config ../../.goreleaser.yml
           if [[ ! -f dist/metadata.json ]] || [[ ! -s dist/metadata.json ]]; then
             echo "Missing required file: dist/metadata.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -495,7 +495,7 @@ jobs:
           nix --version
           which nix
       - name: Run GoReleaser
-        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,46 +399,21 @@ jobs:
 
           echo "Importing gpg key"
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
-      - name: Setup goreleaser
-        shell: bash
-        run: |-
-          OS="Linux"
-          if [[ ${RUNNER_OS} != "Linux" ]]; then
-          	echo "Unsupported OS: ${RUNNER_OS}"
-          	exit 1
-          fi
-
-          # renovate-local: goreleaser-x86_64
-          GORELEASER_VERSION="v2.15.2"
-          # renovate-local: goreleaser-x86_64=v2.15.2
-          GORELEASER_CHECKSUM_x86_64="0ebdbf0353aba566b969dde746cc4e4806f96c27aa2f3971b229a9df7611fedc"
-
-          ARCH=$(uname -m)
-          CHECKSUM="${GORELEASER_CHECKSUM_x86_64}"
-          if [[ "${ARCH}" != "x86_64" ]]; then
-          	echo "Unsupported architecture: ${ARCH}"
-          	exit 1
-          fi
-
-          FILE="goreleaser_${OS}_${ARCH}.tar.gz"
-
-          echo "Installing ${FILE}"
-          curl -LO "https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/${FILE}"
-          echo "${CHECKSUM} ${FILE}" | sha256sum -c
-          tar -xf "${FILE}" goreleaser
-
-          if sudo -n true &> /dev/null; then
-          	sudo install -m 755 goreleaser /usr/local/bin/goreleaser
-          else
-          	install -m 755 goreleaser /usr/local/bin/goreleaser
-          fi
-          rm -f "${FILE}" goreleaser
+      - name: install-nix
+        run: |
+          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
+          chmod +x install.sh
+          ./install.sh
+          source /home/runner/.nix-profile/etc/profile.d/nix.sh
+          nix --version
+          which nix
       - name: Run GoReleaser
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-        shell: bash
         run: |-
           goreleaser release --clean --config .goreleaser_rc.yml
           if [[ ! -f dist/metadata.json ]] || [[ ! -s dist/metadata.json ]]; then
@@ -507,46 +482,21 @@ jobs:
 
           echo "Importing gpg key"
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
-      - name: Setup goreleaser
-        shell: bash
-        run: |-
-          OS="Linux"
-          if [[ ${RUNNER_OS} != "Linux" ]]; then
-          	echo "Unsupported OS: ${RUNNER_OS}"
-          	exit 1
-          fi
-
-          # renovate-local: goreleaser-x86_64
-          GORELEASER_VERSION="v2.15.2"
-          # renovate-local: goreleaser-x86_64=v2.15.2
-          GORELEASER_CHECKSUM_x86_64="0ebdbf0353aba566b969dde746cc4e4806f96c27aa2f3971b229a9df7611fedc"
-
-          ARCH=$(uname -m)
-          CHECKSUM="${GORELEASER_CHECKSUM_x86_64}"
-          if [[ "${ARCH}" != "x86_64" ]]; then
-          	echo "Unsupported architecture: ${ARCH}"
-          	exit 1
-          fi
-
-          FILE="goreleaser_${OS}_${ARCH}.tar.gz"
-
-          echo "Installing ${FILE}"
-          curl -LO "https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/${FILE}"
-          echo "${CHECKSUM} ${FILE}" | sha256sum -c
-          tar -xf "${FILE}" goreleaser
-
-          if sudo -n true &> /dev/null; then
-          	sudo install -m 755 goreleaser /usr/local/bin/goreleaser
-          else
-          	install -m 755 goreleaser /usr/local/bin/goreleaser
-          fi
-          rm -f "${FILE}" goreleaser
+      - name: install-nix
+        run: |
+          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
+          chmod +x install.sh
+          ./install.sh
+          source /home/runner/.nix-profile/etc/profile.d/nix.sh
+          nix --version
+          which nix
       - name: Run GoReleaser
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-        shell: bash
         run: |-
           goreleaser release --clean --config .goreleaser.yml
           if [[ ! -f dist/metadata.json ]] || [[ ! -s dist/metadata.json ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - release/v*
+
 env:
   AWS_REGION: us-west-2
   AWS_ROLE: arn:aws:iam::270074865685:role/terraform-module-ci-test
@@ -10,12 +11,14 @@ env:
   ALL_TESTS_JSON: '["TestOneBasic","TestThreeBasic","TestProductionBasic"]'
   NIX_INSTALL_SHA: de490f61fcbaf9a5cabf2fa621ddb9ef93ad35d9a23a04e7d51b26e092b63691
   NIX_INSTALL_VERSION: 2.34.4
+
 permissions:
   contents: write
   id-token: write
   issues: write
   pull-requests: write
   actions: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -409,7 +412,7 @@ jobs:
           nix --version
           which nix
       - name: Run GoReleaser
-        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}

--- a/README.md
+++ b/README.md
@@ -1,110 +1,145 @@
-<p align="center">
-  <img alt="GoReleaser Logo" src="https://avatars2.githubusercontent.com/u/24697112?v=3&s=200" height="200" />
-  <h3 align="center">GoReleaser</h3>
-  <p align="center">Release engineering, simplified.</p>
-  <p align="center">
-    <img height="30" src="https://cdn.simpleicons.org/go/555555/ffffff" alt="Go" />
-    <img height="30" src="https://cdn.simpleicons.org/rust/555555/ffffff" alt="Rust" />
-    <img height="30" src="https://cdn.simpleicons.org/zig/555555/ffffff" alt="Zig" />
-    <img height="30" src="https://cdn.simpleicons.org/typescript/555555/ffffff" alt="TypeScript" />
-    <img height="30" src="https://cdn.simpleicons.org/python/555555/ffffff" alt="Python" />
-  </p>
-</p>
+Terraform Provider for Rancher v2
+==================================
 
----
+[![Go Report Card](https://goreportcard.com/badge/github.com/terraform-providers/terraform-provider-rancher2)](https://goreportcard.com/report/github.com/terraform-providers/terraform-provider-rancher2)
 
-We handle the complexities of releasing so you can focus in building what really
-matters: **your software**.
+Requirements
+------------
 
-![](https://goreleaser.com/static/goreleaser.svg)
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.5.0
+- [Go](https://golang.org/doc/install) 1.23 to build the provider plugin
 
----
+Building The Provider
+---------------------
 
-## Get GoReleaser
+Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-rancher2`
 
-- [On your machine](https://goreleaser.com/install/);
-- [On CI/CD systems](https://goreleaser.com/ci/).
+```sh
+$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
+$ git clone git@github.com:terraform-providers/terraform-provider-rancher2
+```
 
-## Documentation
+Enter the provider directory and build the provider
 
-Documentation is hosted live at https://goreleaser.com
+```sh
+$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-rancher2
+$ make build
+```
 
-## Community
+Using the Provider
+----------------------
 
-You have questions, need support and or just want to talk about GoReleaser?
+If you're building the provider, follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it. Documentation about the provider specific configuration options can be found on the [provider's website](https://www.terraform.io/docs/providers/rancher2/index.html).
 
-Here are ways to get in touch with the GoReleaser community:
+Developing the Provider
+---------------------------
 
-[![Join Discord](https://img.shields.io/badge/Discuss_on_Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/RGEBtg8vQ6)
-[![Follow on 𝕏](https://img.shields.io/badge/Follow_on_𝕏-000000?style=for-the-badge&logo=x&logoColor=white)](https://twitter.com/goreleaser)
-[![Follow Telegram Channel](https://img.shields.io/badge/Follow_on_Telegram-26A5E4?style=for-the-badge&logo=telegram&logoColor=%23FFFFFF)](https://t.me/goreleasernews)
-[![GitHub Discussions](https://img.shields.io/badge/Discuss_on_GITHUB-181717?style=for-the-badge&logo=github&logoColor=white)](https://github.com/goreleaser/goreleaser/discussions)
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.20+ is *required*). A Nix flake is also available in the repo which is used to generate an environment for build and test.
 
-You can find the links above and all others [here](https://goreleaser.com/links/).
+To compile the provider, run `make build`. This will build the provider and put the provider binary in a bin directory where the repo was cloned.
 
-### Code of Conduct
+```sh
+$ make build
+...
+$ $GOPATH/bin/terraform-provider-rancher2
+...
+```
 
-This project adheres to the Contributor Covenant [code of conduct](https://github.com/goreleaser/.github/blob/main/CODE_OF_CONDUCT.md).
-By participating, you are expected to uphold this code.
-We appreciate your contribution.
-Please refer to our [contributing guidelines](CONTRIBUTING.md) for further information.
+There are a few full implementation examples in the "examples" directory, these are run by the CI using the "run_tests.sh" script.
+The run_tests script will build and run the examples to test.
+WARNING! These are real implementations, you will need AWS credentials in your environment and there will be a cost associated.
+The following example runs a single implementation, the most basic one:
 
-## Badges
+```sh
+./run_tests.sh -t TestOneBasic
+```
 
-[![Release](https://img.shields.io/github/release/goreleaser/goreleaser.svg?style=for-the-badge)](https://github.com/goreleaser/goreleaser/releases/latest)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=for-the-badge)](/LICENSE.md)
-[![Build status](https://img.shields.io/github/actions/workflow/status/goreleaser/goreleaser/build.yml?style=for-the-badge&branch=main)](https://github.com/goreleaser/goreleaser/actions?workflow=build)
-[![Codecov branch](https://img.shields.io/codecov/c/github/goreleaser/goreleaser/main.svg?style=for-the-badge)](https://codecov.io/gh/goreleaser/goreleaser)
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/goreleaser&style=for-the-badge)](https://artifacthub.io/packages/search?repo=goreleaser)
-[![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg?style=for-the-badge)](http://godoc.org/github.com/goreleaser/goreleaser)
-[![Powered By: GoReleaser](https://img.shields.io/badge/powered%20by-goreleaser-green.svg?style=for-the-badge)](https://github.com/goreleaser)
-[![Backers on Open Collective](https://opencollective.com/goreleaser/backers/badge.svg?style=for-the-badge)](https://opencollective.com/goreleaser/backers/)
-[![Sponsors on Open Collective](https://opencollective.com/goreleaser/sponsors/badge.svg?style=for-the-badge)](https://opencollective.com/goreleaser/sponsors/)
-[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge)](https://conventionalcommits.org)
-[![CII Best Practices](https://img.shields.io/cii/summary/5420?label=openssf%20best%20practices&style=for-the-badge)](https://bestpractices.coreinfrastructure.org/projects/5420)
-[![GoReportCard](https://goreportcard.com/badge/github.com/goreleaser/goreleaser?style=for-the-badge)](https://goreportcard.com/report/github.com/goreleaser/goreleaser)
+See [development process](docs/development-process.md) for more details.
 
-## Contributing
+Testing the Provider
+---------------------------
 
-This project exists thanks to all the people who contribute.
-[Contribution guide](CONTRIBUTING.md).
+To run unit tests run `make test`, the unit tests are currently non-functional.
 
-## Sponsoring
+```sh
+$ make test
+```
 
-Does you or your company use GoReleaser?
+To run acceptance tests, use the `run_tests.sh` script.
+WARNING! These are real implementations, you will need AWS credentials in your environment and there will be a cost associated.
+The following example runs a every acceptance test, one at a time.
 
-You can help keep the project bug-free and feature rich by sponsoring the
-project and its maintainers.
+```sh
+./run_tests.sh -s
+```
 
-You can sponsor GoReleaser via:
+See [test process](docs/test-process.md) for details on release testing (_Terraform Maintainers Only_).
 
-- **[GitHub Sponsors](https://github.com/sponsors/caarlos0)**
-- **[OpenCollective](https://opencollective.com/goreleaser)**
+Branching the Provider
+---------------------------
 
-A big **thank you** to all current, past, and future sponsors!
+This provider is branched in correlation with minor versions of Rancher:
+* the `release/v7` branch with v7.0.0+ is aligned with Rancher 2.11
+* the `release/v8` branch with v8.0.0+ is aligned with Rancher 2.12
+* the `release/v13` branch with v13.0.0+ is aligned with Rancher 2.13
 
----
+We no longer release from the main branch, this allows us to test integration early and often.
 
-<!-- sponsors:begin -->
-<!-- this list is auto-generated by https://github.com/goreleaser/sponsors -->
-<div align="center">
-  <h2>Our Sponsors</h2>
-  <h3>Diamond</h3>
-  <a href="https://serpapi.com/?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://github.com/serpapi.png" alt="SerpApi" width="128" height="128"/></a>
-  <h3>Gold</h3>
-  <a href="https://opensource.mercedes-benz.com/?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://avatars.githubusercontent.com/u/34240465?s=96&v=4" alt="Mercedes-Benz Group" width="96" height="96"/></a>
-  <a href="https://nitric.io?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://avatars.githubusercontent.com/u/72055470?s=96&v=4" alt="nitric" width="96" height="96"/></a>
-  <h3>Silver</h3>
-  <a href="https://depot.dev?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=opencollective" target="_blank" rel="noopener sponsored" ><img src="https://images.opencollective.com/depot/39125a1/logo.png?height=80" alt="Depot" width="80" height="80"/></a>
-  <a href="https://www.n-ix.com/?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=opencollective" target="_blank" rel="noopener sponsored" ><img src="https://images.opencollective.com/n-ix-ltd/575a7a5/logo.png?height=80" alt="N-iX Ltd" width="80" height="80"/></a>
-  <h3>Bronze</h3>
-  <a href="https://www.conet.de?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://avatars.githubusercontent.com/u/35725664?s=64&v=4" alt="conet cloud" width="64" height="64"/></a>
-  <a href="https://encore.dev?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://avatars.githubusercontent.com/u/50438175?s=64&v=4" alt="Encore" width="64" height="64"/></a>
-  <a href="https://www.comet.com/site/?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://avatars.githubusercontent.com/u/31487821?s=64&v=4" alt="Comet" width="64" height="64"/></a>
-  <a href="https://about.gitea.com/?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=opencollective" target="_blank" rel="noopener sponsored" ><img src="https://images.opencollective.com/gitea/bf35c2f/logo.png?height=64" alt="Gitea" width="64" height="64"/></a>
-  <a href="https://www.interviewpal.com?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://avatars.githubusercontent.com/u/268665632?s=64&v=4" alt="InterviewPal.com" width="64" height="64"/></a>
-  <h3>And many more!</h3>
-  <p>See the full list <a href="https://goreleaser.com/sponsors" target="_blank" rel="noopener sponsored">here</a>.</p>
-</div>
+The lifecycle of each major provider version is aligned with the lifecycle of each Rancher minor version.
+For example, provider versions 4.x are aligned with Rancher 2.8.x will only be actively maintained until the EOM for Rancher 2.8.x and supported until EOL for Rancher 2.8.x.
 
-<!-- sponsors:end -->
+See the [Rancher support matrix](https://www.suse.com/lifecycle/#rancher) for details.
+
+Aligning major provider releases with minor Rancher releases means:
+
+* We can follow semver
+* We can cut patch/minor versions on an as-needed basis to fix bugs or add new resources
+* We have 'out of band' flexibility and are only tied to releasing a new version of the provider when we get a new 2.x Rancher minor version.
+
+See the [compatibility matrix](docs/compatibility-matrix.md) for details.
+
+Releasing the Provider
+---------------------------
+
+As of v2.0.0 and v3.0.0, the provider is tied to Rancher minor releases but can be released 'out of band' within that minor version.
+As of v13.0.0, the provider's major number aligns with Rancher's minor number.
+For example, v13.0.0 will be released 1-2 weeks after Rancher 2.13.x and fixes and features in the v13.0.0 release will be supported for clusters provisioned via Terraform on Rancher 2.13.x.
+A critical bug fix can be released immediately as a patch release. For instance, as v13.0.1
+
+
+To release the provider:
+
+Version 13+
+
+* Make sure that all backport issues are approved by QA teams and closed, they should be assigned to the related milestone.
+* Find the release PR generated by release-please.
+* Make sure the e2e tests pass, the link should be in the PR.
+* Approve the PR and merge the changelog.
+
+Version 7 & 8
+
+* Make sure that all backport issues are approved by QA teams and closed, they should be assigned to the related milestone.
+* Run e2e tests manually and verify that they work properly.
+* Use the `Manually Create RC Release` workflow to manually trigger the release process.
+
+Making sure the release automation works:
+
+1. Create a PR with the proper release branches specified by the labels, add the labels before creating the PR.
+2. When a PR is created a tracking issue will be generated automatically for it, if the PR has the proper labels they will be automatically added to the tracking issue.
+3. If the PR was created without the proper labels, add them to the tracking issue.
+4. Adding the labels to the tracking issue will generate "backport" issues used to track the PR's release.
+5. The labels should be added before the PR is merged to main.
+6. If the labels and issues are generated properly, when the PR merges to main, backport PRs will be generated automatically.
+7. If the backport PRs weren't generated, you can generate them manually using the `Manually Cherry-Pick to Release Branches` workflow.
+8. When the backport PRs merge into their respective release branch an RC release should be generated automatically.
+9. If an RC wasn't generated you can create one manually using the `Manually Create RC Release` workflow.
+10. When a release is generated all open backport PRs should get a comment with a link to the new release.
+11. For version 13+ there should be a "release PR" generated by release-please, review and merge this to finalize the release.
+12. The release workflow will generate a release when the "release PR" merges.
+
+Updating Release Version
+
+* Each new release version will require a change to the release-please config's "release-as:" attribute.
+* Make sure to update the 'release-please-config.json' file at the root of the repository when adding a new version.
+* Once release/v14 is created this will mean that PRs will need to be made directly to the release/v13 branch to update the version there.
+* Main should have the version from the last created release branch.

--- a/README.md
+++ b/README.md
@@ -1,145 +1,110 @@
-Terraform Provider for Rancher v2
-==================================
+<p align="center">
+  <img alt="GoReleaser Logo" src="https://avatars2.githubusercontent.com/u/24697112?v=3&s=200" height="200" />
+  <h3 align="center">GoReleaser</h3>
+  <p align="center">Release engineering, simplified.</p>
+  <p align="center">
+    <img height="30" src="https://cdn.simpleicons.org/go/555555/ffffff" alt="Go" />
+    <img height="30" src="https://cdn.simpleicons.org/rust/555555/ffffff" alt="Rust" />
+    <img height="30" src="https://cdn.simpleicons.org/zig/555555/ffffff" alt="Zig" />
+    <img height="30" src="https://cdn.simpleicons.org/typescript/555555/ffffff" alt="TypeScript" />
+    <img height="30" src="https://cdn.simpleicons.org/python/555555/ffffff" alt="Python" />
+  </p>
+</p>
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/terraform-providers/terraform-provider-rancher2)](https://goreportcard.com/report/github.com/terraform-providers/terraform-provider-rancher2)
+---
 
-Requirements
-------------
+We handle the complexities of releasing so you can focus in building what really
+matters: **your software**.
 
-- [Terraform](https://www.terraform.io/downloads.html) >= 1.5.0
-- [Go](https://golang.org/doc/install) 1.23 to build the provider plugin
+![](https://goreleaser.com/static/goreleaser.svg)
 
-Building The Provider
----------------------
+---
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-rancher2`
+## Get GoReleaser
 
-```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-rancher2
-```
+- [On your machine](https://goreleaser.com/install/);
+- [On CI/CD systems](https://goreleaser.com/ci/).
 
-Enter the provider directory and build the provider
+## Documentation
 
-```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-rancher2
-$ make build
-```
+Documentation is hosted live at https://goreleaser.com
 
-Using the Provider
-----------------------
+## Community
 
-If you're building the provider, follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it. Documentation about the provider specific configuration options can be found on the [provider's website](https://www.terraform.io/docs/providers/rancher2/index.html).
+You have questions, need support and or just want to talk about GoReleaser?
 
-Developing the Provider
----------------------------
+Here are ways to get in touch with the GoReleaser community:
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.20+ is *required*). A Nix flake is also available in the repo which is used to generate an environment for build and test.
+[![Join Discord](https://img.shields.io/badge/Discuss_on_Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/RGEBtg8vQ6)
+[![Follow on 𝕏](https://img.shields.io/badge/Follow_on_𝕏-000000?style=for-the-badge&logo=x&logoColor=white)](https://twitter.com/goreleaser)
+[![Follow Telegram Channel](https://img.shields.io/badge/Follow_on_Telegram-26A5E4?style=for-the-badge&logo=telegram&logoColor=%23FFFFFF)](https://t.me/goreleasernews)
+[![GitHub Discussions](https://img.shields.io/badge/Discuss_on_GITHUB-181717?style=for-the-badge&logo=github&logoColor=white)](https://github.com/goreleaser/goreleaser/discussions)
 
-To compile the provider, run `make build`. This will build the provider and put the provider binary in a bin directory where the repo was cloned.
+You can find the links above and all others [here](https://goreleaser.com/links/).
 
-```sh
-$ make build
-...
-$ $GOPATH/bin/terraform-provider-rancher2
-...
-```
+### Code of Conduct
 
-There are a few full implementation examples in the "examples" directory, these are run by the CI using the "run_tests.sh" script.
-The run_tests script will build and run the examples to test.
-WARNING! These are real implementations, you will need AWS credentials in your environment and there will be a cost associated.
-The following example runs a single implementation, the most basic one:
+This project adheres to the Contributor Covenant [code of conduct](https://github.com/goreleaser/.github/blob/main/CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code.
+We appreciate your contribution.
+Please refer to our [contributing guidelines](CONTRIBUTING.md) for further information.
 
-```sh
-./run_tests.sh -t TestOneBasic
-```
+## Badges
 
-See [development process](docs/development-process.md) for more details.
+[![Release](https://img.shields.io/github/release/goreleaser/goreleaser.svg?style=for-the-badge)](https://github.com/goreleaser/goreleaser/releases/latest)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=for-the-badge)](/LICENSE.md)
+[![Build status](https://img.shields.io/github/actions/workflow/status/goreleaser/goreleaser/build.yml?style=for-the-badge&branch=main)](https://github.com/goreleaser/goreleaser/actions?workflow=build)
+[![Codecov branch](https://img.shields.io/codecov/c/github/goreleaser/goreleaser/main.svg?style=for-the-badge)](https://codecov.io/gh/goreleaser/goreleaser)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/goreleaser&style=for-the-badge)](https://artifacthub.io/packages/search?repo=goreleaser)
+[![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg?style=for-the-badge)](http://godoc.org/github.com/goreleaser/goreleaser)
+[![Powered By: GoReleaser](https://img.shields.io/badge/powered%20by-goreleaser-green.svg?style=for-the-badge)](https://github.com/goreleaser)
+[![Backers on Open Collective](https://opencollective.com/goreleaser/backers/badge.svg?style=for-the-badge)](https://opencollective.com/goreleaser/backers/)
+[![Sponsors on Open Collective](https://opencollective.com/goreleaser/sponsors/badge.svg?style=for-the-badge)](https://opencollective.com/goreleaser/sponsors/)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge)](https://conventionalcommits.org)
+[![CII Best Practices](https://img.shields.io/cii/summary/5420?label=openssf%20best%20practices&style=for-the-badge)](https://bestpractices.coreinfrastructure.org/projects/5420)
+[![GoReportCard](https://goreportcard.com/badge/github.com/goreleaser/goreleaser?style=for-the-badge)](https://goreportcard.com/report/github.com/goreleaser/goreleaser)
 
-Testing the Provider
----------------------------
+## Contributing
 
-To run unit tests run `make test`, the unit tests are currently non-functional.
+This project exists thanks to all the people who contribute.
+[Contribution guide](CONTRIBUTING.md).
 
-```sh
-$ make test
-```
+## Sponsoring
 
-To run acceptance tests, use the `run_tests.sh` script.
-WARNING! These are real implementations, you will need AWS credentials in your environment and there will be a cost associated.
-The following example runs a every acceptance test, one at a time.
+Does you or your company use GoReleaser?
 
-```sh
-./run_tests.sh -s
-```
+You can help keep the project bug-free and feature rich by sponsoring the
+project and its maintainers.
 
-See [test process](docs/test-process.md) for details on release testing (_Terraform Maintainers Only_).
+You can sponsor GoReleaser via:
 
-Branching the Provider
----------------------------
+- **[GitHub Sponsors](https://github.com/sponsors/caarlos0)**
+- **[OpenCollective](https://opencollective.com/goreleaser)**
 
-This provider is branched in correlation with minor versions of Rancher:
-* the `release/v7` branch with v7.0.0+ is aligned with Rancher 2.11
-* the `release/v8` branch with v8.0.0+ is aligned with Rancher 2.12
-* the `release/v13` branch with v13.0.0+ is aligned with Rancher 2.13
+A big **thank you** to all current, past, and future sponsors!
 
-We no longer release from the main branch, this allows us to test integration early and often.
+---
 
-The lifecycle of each major provider version is aligned with the lifecycle of each Rancher minor version.
-For example, provider versions 4.x are aligned with Rancher 2.8.x will only be actively maintained until the EOM for Rancher 2.8.x and supported until EOL for Rancher 2.8.x.
+<!-- sponsors:begin -->
+<!-- this list is auto-generated by https://github.com/goreleaser/sponsors -->
+<div align="center">
+  <h2>Our Sponsors</h2>
+  <h3>Diamond</h3>
+  <a href="https://serpapi.com/?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://github.com/serpapi.png" alt="SerpApi" width="128" height="128"/></a>
+  <h3>Gold</h3>
+  <a href="https://opensource.mercedes-benz.com/?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://avatars.githubusercontent.com/u/34240465?s=96&v=4" alt="Mercedes-Benz Group" width="96" height="96"/></a>
+  <a href="https://nitric.io?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://avatars.githubusercontent.com/u/72055470?s=96&v=4" alt="nitric" width="96" height="96"/></a>
+  <h3>Silver</h3>
+  <a href="https://depot.dev?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=opencollective" target="_blank" rel="noopener sponsored" ><img src="https://images.opencollective.com/depot/39125a1/logo.png?height=80" alt="Depot" width="80" height="80"/></a>
+  <a href="https://www.n-ix.com/?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=opencollective" target="_blank" rel="noopener sponsored" ><img src="https://images.opencollective.com/n-ix-ltd/575a7a5/logo.png?height=80" alt="N-iX Ltd" width="80" height="80"/></a>
+  <h3>Bronze</h3>
+  <a href="https://www.conet.de?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://avatars.githubusercontent.com/u/35725664?s=64&v=4" alt="conet cloud" width="64" height="64"/></a>
+  <a href="https://encore.dev?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://avatars.githubusercontent.com/u/50438175?s=64&v=4" alt="Encore" width="64" height="64"/></a>
+  <a href="https://www.comet.com/site/?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://avatars.githubusercontent.com/u/31487821?s=64&v=4" alt="Comet" width="64" height="64"/></a>
+  <a href="https://about.gitea.com/?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=opencollective" target="_blank" rel="noopener sponsored" ><img src="https://images.opencollective.com/gitea/bf35c2f/logo.png?height=64" alt="Gitea" width="64" height="64"/></a>
+  <a href="https://www.interviewpal.com?utm_source=goreleaser&utm_medium=sponsor&utm_campaign=homepage&utm_content=github" target="_blank" rel="noopener sponsored" ><img src="https://avatars.githubusercontent.com/u/268665632?s=64&v=4" alt="InterviewPal.com" width="64" height="64"/></a>
+  <h3>And many more!</h3>
+  <p>See the full list <a href="https://goreleaser.com/sponsors" target="_blank" rel="noopener sponsored">here</a>.</p>
+</div>
 
-See the [Rancher support matrix](https://www.suse.com/lifecycle/#rancher) for details.
-
-Aligning major provider releases with minor Rancher releases means:
-
-* We can follow semver
-* We can cut patch/minor versions on an as-needed basis to fix bugs or add new resources
-* We have 'out of band' flexibility and are only tied to releasing a new version of the provider when we get a new 2.x Rancher minor version.
-
-See the [compatibility matrix](docs/compatibility-matrix.md) for details.
-
-Releasing the Provider
----------------------------
-
-As of v2.0.0 and v3.0.0, the provider is tied to Rancher minor releases but can be released 'out of band' within that minor version.
-As of v13.0.0, the provider's major number aligns with Rancher's minor number.
-For example, v13.0.0 will be released 1-2 weeks after Rancher 2.13.x and fixes and features in the v13.0.0 release will be supported for clusters provisioned via Terraform on Rancher 2.13.x.
-A critical bug fix can be released immediately as a patch release. For instance, as v13.0.1
-
-
-To release the provider:
-
-Version 13+
-
-* Make sure that all backport issues are approved by QA teams and closed, they should be assigned to the related milestone.
-* Find the release PR generated by release-please.
-* Make sure the e2e tests pass, the link should be in the PR.
-* Approve the PR and merge the changelog.
-
-Version 7 & 8
-
-* Make sure that all backport issues are approved by QA teams and closed, they should be assigned to the related milestone.
-* Run e2e tests manually and verify that they work properly.
-* Use the `Manually Create RC Release` workflow to manually trigger the release process.
-
-Making sure the release automation works:
-
-1. Create a PR with the proper release branches specified by the labels, add the labels before creating the PR.
-2. When a PR is created a tracking issue will be generated automatically for it, if the PR has the proper labels they will be automatically added to the tracking issue.
-3. If the PR was created without the proper labels, add them to the tracking issue.
-4. Adding the labels to the tracking issue will generate "backport" issues used to track the PR's release.
-5. The labels should be added before the PR is merged to main.
-6. If the labels and issues are generated properly, when the PR merges to main, backport PRs will be generated automatically.
-7. If the backport PRs weren't generated, you can generate them manually using the `Manually Cherry-Pick to Release Branches` workflow.
-8. When the backport PRs merge into their respective release branch an RC release should be generated automatically.
-9. If an RC wasn't generated you can create one manually using the `Manually Create RC Release` workflow.
-10. When a release is generated all open backport PRs should get a comment with a link to the new release.
-11. For version 13+ there should be a "release PR" generated by release-please, review and merge this to finalize the release.
-12. The release workflow will generate a release when the "release PR" merges.
-
-Updating Release Version
-
-* Each new release version will require a change to the release-please config's "release-as:" attribute.
-* Make sure to update the 'release-please-config.json' file at the root of the repository when adding a new version.
-* Once release/v14 is created this will mean that PRs will need to be made directly to the release/v13 branch to update the version there.
-* Main should have the version from the last created release branch.
+<!-- sponsors:end -->

--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -19,6 +19,7 @@ pre-release
 prerelease
 rancher
 rc
+readme
 rke
 rke2
 sha

--- a/examples/use-cases/one/README.md
+++ b/examples/use-cases/one/README.md
@@ -7,21 +7,38 @@ This shows the most basic use case for the provider, is functions as a good star
 ## Dependencies
 
 The `flake.nix` file in the root of the module explains all of the dependencies for the development of the module, it also includes the dependencies to run it.
-You can see the list on lines 50-80, but a more specific list is below (with explanations).
+You can see the list on lines 143-174, but a more specific list is below (with explanations).
 
-- bash -> born again shell with linux core utils facilitates CLI actions
-- tfswitch -> handy for installing Terraform at specific verisons
-- git -> required by Terraform
-- curl -> required by Terraform as well as dependent modules (when downloading RKE2 for install)
-- openssh -> required by Terraform and used in dependent modules to connect to servers for initial configuration
-- openssl -> required by Terraform and used in dependent modules to verify TLS certificates
-- ssh-agent -> used for connecting to remote server for initial configuration, you need to have the key you send into the module loaded in your agent
+- actionlint -> used to lint workflows
+- aspellWithDicts -> used to validate commit messages
+- awscli2 -> used in some dependent modules in some use cases (dualstack)
+- bashInteractive -> born again shell with linux core utils facilitates CLI actions
+- cmctl -> helpful to troubleshoot Rancher install issues
+- curl -> required for Terraform
+- eslint -> lint node scripts in CI
 - gh -> the github cli tool, used to find releases when downloading RKE2 for install
-- jq -> json parsing tool, used in dependent modules to parse submodule outputs
-- kubectl -> used in local exec to patch kubernetes objects
-- awscli2 -> the aws cli tool, used in some dependent modules in some use cases (dualstack)
-- yq -> yaml parsing tool, used in dependent modules to parse kubectl outputs
-- go -> necessary to run tests
+- git -> required by Terraform
+- gitleaks -> used in CI to detect potential key leaks
+- gnupg -> helpful when generating a new gpg key for releases
+- go -> necessary for building and testing
+- golangci-lint -> lint go code
+- gotestfmt -> necessary for gotestsum
+- gotestsum -> test harness that allows for better parsing and testing of go tests
+- kubernetes-helm -> helpful when troubleshooting helm issues
+- jq -> used in dependent modules to parse submodule outputs
+- kubectl -> necessary when pulling kubeconfig
+- less -> helpful when needing to read files
+- nodejs_24 -> used by eslint to validate github scripts
+- openssh -> necessary to connect to servers
+- openssl -> helpful when generating certs
+- shellcheck -> used by ci to validate shell scripts
+- tflint -> used by ci to validate Terraform examples
+- vim -> helpful when editing files
+- which -> helpful when troubleshooting nix issues
+- yq -> used in dependent modules to parse kubectl outputs
+- terraform -> necesary to run tests
+- goreleaser -> necessary for releases
+- leftovers -> necessary for cleaning up broken tests
 
 ## Environment Variables
 

--- a/examples/use-cases/one/README.md
+++ b/examples/use-cases/one/README.md
@@ -36,7 +36,7 @@ You can see the list on lines 143-174, but a more specific list is below (with e
 - vim -> helpful when editing files
 - which -> helpful when troubleshooting nix issues
 - yq -> used in dependent modules to parse kubectl outputs
-- terraform -> necesary to run tests
+- terraform -> necessary to run tests
 - goreleaser -> necessary for releases
 - leftovers -> necessary for cleaning up broken tests
 

--- a/examples/use-cases/production/README.md
+++ b/examples/use-cases/production/README.md
@@ -8,21 +8,38 @@ The TLS certificate is externally generated and publicly verifiable (assuming yo
 ## Dependencies
 
 The `flake.nix` file in the root of the module explains all of the dependencies for the development of the module, it also includes the dependencies to run it.
-You can see the list on lines 50-80, but a more specific list is below (with explanations).
+You can see the list on lines 143-174, but a more specific list is below (with explanations).
 
-- bash -> born again shell with linux core utils facilitates CLI actions
-- tfswitch -> handy for installing Terraform at specific verisons
-- git -> required by Terraform
-- curl -> required by Terraform as well as dependent modules (when downloading RKE2 for install)
-- openssh -> required by Terraform and used in dependent modules to connect to servers for initial configuration
-- openssl -> required by Terraform and used in dependent modules to verify TLS certificates
-- ssh-agent -> used for connecting to remote server for initial configuration, you need to have the key you send into the module loaded in your agent
+- actionlint -> used to lint workflows
+- aspellWithDicts -> used to validate commit messages
+- awscli2 -> used in some dependent modules in some use cases (dualstack)
+- bashInteractive -> born again shell with linux core utils facilitates CLI actions
+- cmctl -> helpful to troubleshoot Rancher install issues
+- curl -> required for Terraform
+- eslint -> lint node scripts in CI
 - gh -> the github cli tool, used to find releases when downloading RKE2 for install
-- jq -> json parsing tool, used in dependent modules to parse submodule outputs
-- kubectl -> used in local exec to patch kubernetes objects
-- awscli2 -> the aws cli tool, used in some dependent modules in some use cases (dualstack)
-- yq -> yaml parsing tool, used in dependent modules to parse kubectl outputs
-- go -> necessary to run tests
+- git -> required by Terraform
+- gitleaks -> used in CI to detect potential key leaks
+- gnupg -> helpful when generating a new gpg key for releases
+- go -> necessary for building and testing
+- golangci-lint -> lint go code
+- gotestfmt -> necessary for gotestsum
+- gotestsum -> test harness that allows for better parsing and testing of go tests
+- kubernetes-helm -> helpful when troubleshooting helm issues
+- jq -> used in dependent modules to parse submodule outputs
+- kubectl -> necessary when pulling kubeconfig
+- less -> helpful when needing to read files
+- nodejs_24 -> used by eslint to validate github scripts
+- openssh -> necessary to connect to servers
+- openssl -> helpful when generating certs
+- shellcheck -> used by ci to validate shell scripts
+- tflint -> used by ci to validate Terraform examples
+- vim -> helpful when editing files
+- which -> helpful when troubleshooting nix issues
+- yq -> used in dependent modules to parse kubectl outputs
+- terraform -> necesary to run tests
+- goreleaser -> necessary for releases
+- leftovers -> necessary for cleaning up broken tests
 
 ## Environment Variables
 

--- a/examples/use-cases/production/README.md
+++ b/examples/use-cases/production/README.md
@@ -37,7 +37,7 @@ You can see the list on lines 143-174, but a more specific list is below (with e
 - vim -> helpful when editing files
 - which -> helpful when troubleshooting nix issues
 - yq -> used in dependent modules to parse kubectl outputs
-- terraform -> necesary to run tests
+- terraform -> necessary to run tests
 - goreleaser -> necessary for releases
 - leftovers -> necessary for cleaning up broken tests
 

--- a/examples/use-cases/three/README.md
+++ b/examples/use-cases/three/README.md
@@ -42,7 +42,7 @@ You can see the list on lines 143-174, but a more specific list is below (with e
 - vim -> helpful when editing files
 - which -> helpful when troubleshooting nix issues
 - yq -> used in dependent modules to parse kubectl outputs
-- terraform -> necesary to run tests
+- terraform -> necessary to run tests
 - goreleaser -> necessary for releases
 - leftovers -> necessary for cleaning up broken tests
 

--- a/examples/use-cases/three/README.md
+++ b/examples/use-cases/three/README.md
@@ -13,21 +13,38 @@ This module was developed working closely with specific customer feedback.
 ## Dependencies
 
 The `flake.nix` file in the root of the module explains all of the dependencies for the development of the module, it also includes the dependencies to run it.
-You can see the list on lines 50-80, but a more specific list is below (with explanations).
+You can see the list on lines 143-174, but a more specific list is below (with explanations).
 
-- bash -> born again shell with linux core utils facilitates CLI actions
-- tfswitch -> handy for installing Terraform at specific verisons
-- git -> required by Terraform
-- curl -> required by Terraform as well as dependent modules (when downloading RKE2 for install)
-- openssh -> required by Terraform and used in dependent modules to connect to servers for initial configuration
-- openssl -> required by Terraform and used in dependent modules to verify TLS certificates
-- ssh-agent -> used for connecting to remote server for initial configuration, you need to have the key you send into the module loaded in your agent
+- actionlint -> used to lint workflows
+- aspellWithDicts -> used to validate commit messages
+- awscli2 -> used in some dependent modules in some use cases (dualstack)
+- bashInteractive -> born again shell with linux core utils facilitates CLI actions
+- cmctl -> helpful to troubleshoot Rancher install issues
+- curl -> required for Terraform
+- eslint -> lint node scripts in CI
 - gh -> the github cli tool, used to find releases when downloading RKE2 for install
-- jq -> json parsing tool, used in dependent modules to parse submodule outputs
-- kubectl -> used in local exec to patch kubernetes objects
-- awscli2 -> the aws cli tool, used in some dependent modules in some use cases (dualstack)
-- yq -> yaml parsing tool, used in dependent modules to parse kubectl outputs
-- go -> necessary to run tests
+- git -> required by Terraform
+- gitleaks -> used in CI to detect potential key leaks
+- gnupg -> helpful when generating a new gpg key for releases
+- go -> necessary for building and testing
+- golangci-lint -> lint go code
+- gotestfmt -> necessary for gotestsum
+- gotestsum -> test harness that allows for better parsing and testing of go tests
+- kubernetes-helm -> helpful when troubleshooting helm issues
+- jq -> used in dependent modules to parse submodule outputs
+- kubectl -> necessary when pulling kubeconfig
+- less -> helpful when needing to read files
+- nodejs_24 -> used by eslint to validate github scripts
+- openssh -> necessary to connect to servers
+- openssl -> helpful when generating certs
+- shellcheck -> used by ci to validate shell scripts
+- tflint -> used by ci to validate Terraform examples
+- vim -> helpful when editing files
+- which -> helpful when troubleshooting nix issues
+- yq -> used in dependent modules to parse kubectl outputs
+- terraform -> necesary to run tests
+- goreleaser -> necessary for releases
+- leftovers -> necessary for cleaning up broken tests
 
 ## Environment Variables
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773597492,
-        "narHash": "sha256-hQ284SkIeNaeyud+LS0WVLX+WL2rxcVZLFEaK0e03zg=",
+        "lastModified": 1777826146,
+        "narHash": "sha256-wQ/iN5Zp5VIa3ebBibijPnLyKhor+xEbDy4d0goa9Zs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a07d4ce6bee67d7c838a8a5796e75dff9caa21ef",
+        "rev": "73c703c22422b8951895a960959dbbaca7296492",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
             nativeBuildInputs = [ pkgs.unzip ];
             phases = [ "installPhase" ];
             installPhase = ''
-              echo "Verifying age checksum..."
+              echo "Verifying checksum..."
               SUM="$(sha256sum $src | awk '{print $1}')"
               if [ "$SUM" = "$checksum" ]; then 
                 echo "Valid!";
@@ -118,10 +118,9 @@
               sha256 = goreleaser-prep."${system}".sha;
             };
             checksum = goreleaser-prep."${system}".checksum;
-            nativeBuildInputs = [ pkgs.unzip ];
             phases = [ "installPhase" ];
             installPhase = ''
-              echo "Verifying age checksum..."
+              echo "Verifying checksum..."
               SUM="$(sha256sum $src | awk '{print $1}')"
               if [ "$SUM" = "$checksum" ]; then 
                 echo "Valid!";

--- a/flake.nix
+++ b/flake.nix
@@ -141,13 +141,11 @@
             name = "dev-shell-package";
             paths = (with pkgs; [
               actionlint
-              age
               aspellWithDicts
               awscli2
               bashInteractive
               cmctl
               curl
-              dig
               eslint
               gh
               git
@@ -166,9 +164,6 @@
               openssl
               shellcheck
               tflint
-              tfsec
-              trivy
-              updatecli
               vim
               which
               yq

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
               "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-linux-amd64";
               "sha" = "sha256-D2OPjLlV5xR3f+dVHu0ld6bQajD5Rv9GLCMCk9hXlu8=";
             };
-            # linux container running on darwin, actual arm linux isnt in the artifacts
+            # linux container running on darwin, actual arm linux isn't in the artifacts
             "aarch64-linux" = {
               "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-darwin-arm64";
               "sha" = "sha256-Tw7G538RYZrwIauN7kI68u6aKS4d/0Efh+dirL/kzoM=";

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachSystem [ "x86_64-darwin" "aarch64-darwin" "x86_64-linux" ]
+    flake-utils.lib.eachSystem [ "aarch64-darwin" "x86_64-linux" "aarch64-linux" ]
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
@@ -16,10 +16,6 @@
             "selected" = "v0.70.0";
           };
           leftovers-prep = {
-            "x86_64-darwin" = {
-              "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-darwin-amd64";
-              "sha" = "sha256-HV12kHqB14lGDm1rh9nD1n7Jvw0rCnxmjC9gusw7jfo=";
-            };
             "aarch64-darwin" = {
               "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-darwin-arm64";
               "sha" = "sha256-Tw7G538RYZrwIauN7kI68u6aKS4d/0Efh+dirL/kzoM=";
@@ -27,6 +23,11 @@
             "x86_64-linux" = {
               "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-linux-amd64";
               "sha" = "sha256-D2OPjLlV5xR3f+dVHu0ld6bQajD5Rv9GLCMCk9hXlu8=";
+            };
+            # linux container running on darwin, actual arm linux isnt in the artifacts
+            "aarch64-linux" = {
+              "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-darwin-arm64";
+              "sha" = "sha256-Tw7G538RYZrwIauN7kI68u6aKS4d/0Efh+dirL/kzoM=";
             };
           };
           leftovers = pkgs.stdenv.mkDerivation {
@@ -42,6 +43,99 @@
               chmod +x $out/bin/leftovers
             '';
           };
+
+          terraform-version = {
+            "selected" = "1.5.7";
+          };
+          terraform-prep = {
+            "aarch64-darwin" = {
+              "url" = "https://releases.hashicorp.com/terraform/${terraform-version.selected}/terraform_${terraform-version.selected}_darwin_arm64.zip";
+              "sha" = "sha256-23wz6xpEa3OkQ+LFW1MoRfe3DNVhAL7EyW8Vz6tfUMs=";
+              "checksum" = "db7c33eb1a446b73a443e2c55b532845f7b70cd56100bec4c96f15cfab5f50cb";
+            };
+            "x86_64-linux" = {
+              "url" = "https://releases.hashicorp.com/terraform/${terraform-version.selected}/terraform_${terraform-version.selected}_linux_amd64.zip";
+              "sha" = "sha256-wO17wy7lKuJVr5mCyMiKekxhBIXPHVX+6wN+q3X6CCw=";
+              "checksum" = "c0ed7bc32ee52ae255af9982c8c88a7a4c610485cf1d55feeb037eab75fa082c";
+            };
+            # linux container running on darwin or arm linux
+            "aarch64-linux" = {
+              "url" = "https://releases.hashicorp.com/terraform/${terraform-version.selected}/terraform_${terraform-version.selected}_linux_arm64.zip";
+              "sha" = "sha256-9LStfGtgiJYKZn40SVyuSQ+wcpR6n/Jmv1kp9TM1ZeQ=";
+              "checksum" = "f4b4ad7c6b6088960a667e34495cae490fb072947a9ff266bf5929f5333565e4";
+            };
+          };
+          terraform = pkgs.stdenv.mkDerivation {
+            name = "terraform-${terraform-version.selected}";
+            src = pkgs.fetchurl {
+              url = terraform-prep."${system}".url;
+              sha256 = terraform-prep."${system}".sha;
+            };
+            checksum = terraform-prep."${system}".checksum;
+            nativeBuildInputs = [ pkgs.unzip ];
+            phases = [ "installPhase" ];
+            installPhase = ''
+              echo "Verifying age checksum..."
+              SUM="$(sha256sum $src | awk '{print $1}')"
+              if [ "$SUM" = "$checksum" ]; then 
+                echo "Valid!";
+              else 
+                echo "Invalid!";
+                echo "expected: $checksum, got: $SUM"
+                echo "check your flake.nix file"
+                exit 1;
+              fi
+
+              install -d $out/bin
+              unzip -o $src -d $out/bin
+              chmod +x $out/bin/terraform
+            '';
+          };
+          goreleaser-version = {
+            "selected" = "2.15.4";
+          };
+          goreleaser-prep = {
+            "aarch64-darwin" = { # local workstation
+              "url" = "https://github.com/goreleaser/goreleaser/releases/download/v${goreleaser-version.selected}/goreleaser_Darwin_arm64.tar.gz";
+              "sha" = "sha256-2c0JeNZGhutU5T6fCLQA7cix+QNPmPykPsej9kEycIE=";
+              "checksum" = "d9cd0978d64686eb54e53e9f08b400edc8b1f9034f98fca43ec7a3f641327081";
+            };
+            "x86_64-linux" = { # github ubuntu latest runner
+              "url" = "https://github.com/goreleaser/goreleaser/releases/download/v${goreleaser-version.selected}/goreleaser_Linux_x86_64.tar.gz";
+              "sha" = "sha256-quAMcaSm1V4IzOknOhUWvc4zweB8/7flAvpv7EN33t4=";
+              "checksum" = "aae00c71a4a6d55e08cce9273a1516bdce33c1e07cffb7e502fa6fec4377dede";
+            };
+            "aarch64-linux" = { # linux container running on darwin
+              "url" = "https://github.com/goreleaser/goreleaser/releases/download/v${goreleaser-version.selected}/goreleaser_Linux_arm64.tar.gz";
+              "sha" = "sha256-3gHKFJdXHps0hBPNLn90vkm41XaWrjhvfu3QYXZUSog=";
+              "checksum" = "de01ca1497571e9b348413cd2e7f74be49b8d57696ae386f7eedd06176544a88";
+            };
+          };
+          goreleaser = pkgs.stdenv.mkDerivation {
+            name = "goreleaser-${goreleaser-version.selected}";
+            src = pkgs.fetchurl {
+              url = goreleaser-prep."${system}".url;
+              sha256 = goreleaser-prep."${system}".sha;
+            };
+            checksum = goreleaser-prep."${system}".checksum;
+            nativeBuildInputs = [ pkgs.unzip ];
+            phases = [ "installPhase" ];
+            installPhase = ''
+              echo "Verifying age checksum..."
+              SUM="$(sha256sum $src | awk '{print $1}')"
+              if [ "$SUM" = "$checksum" ]; then 
+                echo "Valid!";
+              else 
+                echo "Invalid!";
+                echo "expected: $checksum, got: $SUM"
+                echo "check your flake.nix file"
+                exit 1;
+              fi
+              install -d $out/bin
+              tar -xf $src goreleaser
+              install -m 755 goreleaser $out/bin/goreleaser
+            '';
+          };
           aspellWithDicts = pkgs.aspellWithDicts (d: [d.en d.en-computers]);
 
           devShellPackage = pkgs.symlinkJoin {
@@ -52,6 +146,7 @@
               aspellWithDicts
               awscli2
               bashInteractive
+              cmctl
               curl
               dig
               eslint
@@ -61,21 +156,20 @@
               gnupg
               go
               golangci-lint
-              goreleaser
               gotestfmt
               gotestsum
+              goreleaser
+              kubernetes-helm
               jq
               kubectl
-              kubernetes-helm
               leftovers
               less
-              nodejs_22
               openssh
               openssl
               shellcheck
+              terraform
               tflint
               tfsec
-              tfswitch
               trivy
               updatecli
               vim
@@ -91,10 +185,6 @@
             buildInputs = [ devShellPackage ];
             shellHook = ''
               while read word; do echo -e "*$word\n#" | aspell -a --dont-validate-words >/dev/null; done < aspell_custom.txt
-              homebin=$HOME/bin;
-              install -d $homebin;
-              tfswitch -b $homebin/terraform 1.5.7 &>/dev/null;
-              export PATH="$homebin:$PATH";
               export PS1="nix:# ";
             '';
           };

--- a/flake.nix
+++ b/flake.nix
@@ -139,7 +139,7 @@
 
           devShellPackage = pkgs.symlinkJoin {
             name = "dev-shell-package";
-            paths = with pkgs; [
+            paths = (with pkgs; [
               actionlint
               age
               aspellWithDicts
@@ -157,17 +157,14 @@
               golangci-lint
               gotestfmt
               gotestsum
-              goreleaser
               kubernetes-helm
               jq
               kubectl
-              leftovers
               less
               nodejs_24
               openssh
               openssl
               shellcheck
-              terraform
               tflint
               tfsec
               trivy
@@ -175,7 +172,11 @@
               vim
               which
               yq
-            ];
+            ] ++ [ # manually downloaded packages here
+              terraform
+              goreleaser
+              leftovers
+            ]);
           };
         in
         {

--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,7 @@
               kubectl
               leftovers
               less
+              nodejs_24
               openssh
               openssl
               shellcheck


### PR DESCRIPTION
<!--- Add labels (eg. release/v14) for each release branch to target --->
<!--- Please don't manually add "internal" labels, those are for automation only --->

## Description
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
This change adds GoReleaser to the Nix environment and manually downloads Terraform.
TFSwitch is having trouble due to a change in the Gpg key that Hashicorp uses to sign Terraform releases, so we are eliminating tfswitch and downloading it manually. There isn't a build for Terraform v1.5.7 in nix-pkgs so we are downloading it from Hashicorp and validating the checksum. Nix also automatically validates the download with its own sha.
Using the same process for GoReleaser since the latest version isn't in nix-pkgs. 

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->
Manually tested locally, this doesn't effect the product just how it is built and released.
<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
