### PR TITLE
Backport 2208 v15

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -43,10 +43,10 @@ if ! which "$0" | grep -q nix; then
   fi
 
   echo 'Installing Nix Profile...'
-  if ! nf profile install . --profile "$profile"; then
-    echo 'Failed to install new Nix profile! Reverting to previous profile...'
+  if ! nf profile add . --profile "$profile"; then
+    echo 'Failed to add new Nix profile! Reverting to previous profile...'
     git checkout flake.lock
-    nf profile install . --profile "$profile"
+    nf profile add . --profile "$profile"
   fi
 
   nf profile list --profile "$profile"

--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -13,16 +13,21 @@ on:
         description: 'The rc tag to create, e.g. v1.2.3-rc.1'
         required: true
 
-permissions:
-  contents: write
-  id-token: write
-  issues: write
-  pull-requests: write
-  actions: read
+env:
+  NIX_INSTALL_SHA: de490f61fcbaf9a5cabf2fa621ddb9ef93ad35d9a23a04e7d51b26e092b63691
+  NIX_INSTALL_VERSION: 2.34.4
+
+permissions: {}
 
 jobs:
   rc-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+      actions: read
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script/commits/main
         id: check-user-in-maintainers
@@ -113,15 +118,35 @@ jobs:
           go-version-file: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.mod
           cache-dependency-path: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.sum
           cache: true
+      - name: install-nix
+        run: |
+          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
+          chmod +x install.sh
+          ./install.sh
+          source /home/runner/.nix-profile/etc/profile.d/nix.sh
+          nix --version
+          which nix
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
-        with:
-          args: release --clean --skip=validate --config ../../.goreleaser_rc.yml
-          workdir: ${{ github.workspace }}/tags/${{ inputs.tag }}
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep TAG --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+          TAG: ${{ inputs.tag }}
+        run: |-
+          cd ${{ github.workspace }}/tags/$TAG
+          goreleaser release --clean --skip=validate --config ../../.goreleaser_rc.yml
+          if [[ ! -f dist/metadata.json ]] || [[ ! -s dist/metadata.json ]]; then
+            echo "Missing required file: dist/metadata.json"
+            exit 1
+          fi
+          if [[ ! -f dist/artifacts.json ]] || [[ ! -s dist/artifacts.json ]]; then
+            echo "Missing required file: dist/artifacts.json"
+            exit 1
+          fi
+          echo "metadata=$(tr -d '\n\r' < dist/metadata.json)" >> "${GITHUB_OUTPUT}"
+          echo "artifacts=$(tr -d '\n\r' < dist/artifacts.json)" >> "${GITHUB_OUTPUT}"
       - name: 'Find Issues and Create Comments'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script
         env:

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -10,18 +10,11 @@ on:
         description: 'The commit SHA to create the tag from, defaults to HEAD of the selected branch.'
         required: false
 
-<<<<<<< HEAD
-permissions:
-  contents: write
-  id-token: write
-  actions: read
-=======
 env:
   NIX_INSTALL_SHA: de490f61fcbaf9a5cabf2fa621ddb9ef93ad35d9a23a04e7d51b26e092b63691
   NIX_INSTALL_VERSION: 2.34.4
 
 permissions: {}
->>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))
 
 jobs:
   release:
@@ -118,13 +111,6 @@ jobs:
           go-version-file: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.mod
           cache-dependency-path: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.sum
           cache: true
-<<<<<<< HEAD
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
-        with:
-          args: release --clean --skip=validate --config ../../.goreleaser.yml
-          workdir: ${{ github.workspace }}/tags/${{ inputs.tag }}
-=======
       - name: install-nix
         run: |
           curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
@@ -136,13 +122,10 @@ jobs:
           which nix
       - name: Run GoReleaser
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep TAG --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
->>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-<<<<<<< HEAD
-=======
           TAG: ${{ inputs.tag }}
         run: |-
           cd ${{ github.workspace }}/tags/$TAG
@@ -157,4 +140,3 @@ jobs:
           fi
           echo "metadata=$(tr -d '\n\r' < dist/metadata.json)" >> "${GITHUB_OUTPUT}"
           echo "artifacts=$(tr -d '\n\r' < dist/artifacts.json)" >> "${GITHUB_OUTPUT}"
->>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -10,14 +10,26 @@ on:
         description: 'The commit SHA to create the tag from, defaults to HEAD of the selected branch.'
         required: false
 
+<<<<<<< HEAD
 permissions:
   contents: write
   id-token: write
   actions: read
+=======
+env:
+  NIX_INSTALL_SHA: de490f61fcbaf9a5cabf2fa621ddb9ef93ad35d9a23a04e7d51b26e092b63691
+  NIX_INSTALL_VERSION: 2.34.4
+
+permissions: {}
+>>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      actions: read
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script/commits/main
         id: check-user-in-maintainers
@@ -106,12 +118,43 @@ jobs:
           go-version-file: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.mod
           cache-dependency-path: ${{ github.workspace }}/tags/${{ inputs.tag }}/go.sum
           cache: true
+<<<<<<< HEAD
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
         with:
           args: release --clean --skip=validate --config ../../.goreleaser.yml
           workdir: ${{ github.workspace }}/tags/${{ inputs.tag }}
+=======
+      - name: install-nix
+        run: |
+          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
+          chmod +x install.sh
+          ./install.sh
+          source /home/runner/.nix-profile/etc/profile.d/nix.sh
+          nix --version
+          which nix
+      - name: Run GoReleaser
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep TAG --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
+>>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+<<<<<<< HEAD
+=======
+          TAG: ${{ inputs.tag }}
+        run: |-
+          cd ${{ github.workspace }}/tags/$TAG
+          goreleaser release --clean --skip=validate --config ../../.goreleaser.yml
+          if [[ ! -f dist/metadata.json ]] || [[ ! -s dist/metadata.json ]]; then
+            echo "Missing required file: dist/metadata.json"
+            exit 1
+          fi
+          if [[ ! -f dist/artifacts.json ]] || [[ ! -s dist/artifacts.json ]]; then
+            echo "Missing required file: dist/artifacts.json"
+            exit 1
+          fi
+          echo "metadata=$(tr -d '\n\r' < dist/metadata.json)" >> "${GITHUB_OUTPUT}"
+          echo "artifacts=$(tr -d '\n\r' < dist/artifacts.json)" >> "${GITHUB_OUTPUT}"
+>>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -408,14 +408,43 @@ jobs:
 
           echo "Importing gpg key"
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
+<<<<<<< HEAD
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
         with:
           args: release --clean --config .goreleaser_rc.yml
+=======
+      - name: install-nix
+        run: |
+          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
+          chmod +x install.sh
+          ./install.sh
+          source /home/runner/.nix-profile/etc/profile.d/nix.sh
+          nix --version
+          which nix
+      - name: Run GoReleaser
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
+>>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+<<<<<<< HEAD
+=======
+        run: |-
+          goreleaser release --clean --config .goreleaser_rc.yml
+          if [[ ! -f dist/metadata.json ]] || [[ ! -s dist/metadata.json ]]; then
+            echo "Missing required file: dist/metadata.json"
+            exit 1
+          fi
+          if [[ ! -f dist/artifacts.json ]] || [[ ! -s dist/artifacts.json ]]; then
+            echo "Missing required file: dist/artifacts.json"
+            exit 1
+          fi
+          echo "metadata=$(tr -d '\n\r' < dist/metadata.json)" >> "${GITHUB_OUTPUT}"
+          echo "artifacts=$(tr -d '\n\r' < dist/artifacts.json)" >> "${GITHUB_OUTPUT}"
+>>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))
       - name: 'Find Issues and Create Comments'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script
         env:
@@ -473,11 +502,40 @@ jobs:
 
           echo "Importing gpg key"
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
+<<<<<<< HEAD
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
         with:
           args: release --clean --config .goreleaser.yml
+=======
+      - name: install-nix
+        run: |
+          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
+          chmod +x install.sh
+          ./install.sh
+          source /home/runner/.nix-profile/etc/profile.d/nix.sh
+          nix --version
+          which nix
+      - name: Run GoReleaser
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
+>>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+<<<<<<< HEAD
+=======
+        run: |-
+          goreleaser release --clean --config .goreleaser.yml
+          if [[ ! -f dist/metadata.json ]] || [[ ! -s dist/metadata.json ]]; then
+            echo "Missing required file: dist/metadata.json"
+            exit 1
+          fi
+          if [[ ! -f dist/artifacts.json ]] || [[ ! -s dist/artifacts.json ]]; then
+            echo "Missing required file: dist/artifacts.json"
+            exit 1
+          fi
+          echo "metadata=$(tr -d '\n\r' < dist/metadata.json)" >> "${GITHUB_OUTPUT}"
+          echo "artifacts=$(tr -d '\n\r' < dist/artifacts.json)" >> "${GITHUB_OUTPUT}"
+>>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -408,12 +408,6 @@ jobs:
 
           echo "Importing gpg key"
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
-<<<<<<< HEAD
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
-        with:
-          args: release --clean --config .goreleaser_rc.yml
-=======
       - name: install-nix
         run: |
           curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
@@ -425,13 +419,10 @@ jobs:
           which nix
       - name: Run GoReleaser
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
->>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-<<<<<<< HEAD
-=======
         run: |-
           goreleaser release --clean --config .goreleaser_rc.yml
           if [[ ! -f dist/metadata.json ]] || [[ ! -s dist/metadata.json ]]; then
@@ -444,7 +435,6 @@ jobs:
           fi
           echo "metadata=$(tr -d '\n\r' < dist/metadata.json)" >> "${GITHUB_OUTPUT}"
           echo "artifacts=$(tr -d '\n\r' < dist/artifacts.json)" >> "${GITHUB_OUTPUT}"
->>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))
       - name: 'Find Issues and Create Comments'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0 https://github.com/actions/github-script
         env:
@@ -502,12 +492,6 @@ jobs:
 
           echo "Importing gpg key"
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
-<<<<<<< HEAD
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0 https://github.com/goreleaser/goreleaser-action
-        with:
-          args: release --clean --config .goreleaser.yml
-=======
       - name: install-nix
         run: |
           curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
@@ -519,13 +503,10 @@ jobs:
           which nix
       - name: Run GoReleaser
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
->>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-<<<<<<< HEAD
-=======
         run: |-
           goreleaser release --clean --config .goreleaser.yml
           if [[ ! -f dist/metadata.json ]] || [[ ! -s dist/metadata.json ]]; then
@@ -538,4 +519,3 @@ jobs:
           fi
           echo "metadata=$(tr -d '\n\r' < dist/metadata.json)" >> "${GITHUB_OUTPUT}"
           echo "artifacts=$(tr -d '\n\r' < dist/artifacts.json)" >> "${GITHUB_OUTPUT}"
->>>>>>> fe1ec8b4 (fix: resolve CI dependencies (#2208))

--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -19,6 +19,7 @@ pre-release
 prerelease
 rancher
 rc
+readme
 rke
 rke2
 sha

--- a/examples/use-cases/one/README.md
+++ b/examples/use-cases/one/README.md
@@ -7,21 +7,38 @@ This shows the most basic use case for the provider, is functions as a good star
 ## Dependencies
 
 The `flake.nix` file in the root of the module explains all of the dependencies for the development of the module, it also includes the dependencies to run it.
-You can see the list on lines 50-80, but a more specific list is below (with explanations).
+You can see the list on lines 143-174, but a more specific list is below (with explanations).
 
-- bash -> born again shell with linux core utils facilitates CLI actions
-- tfswitch -> handy for installing Terraform at specific verisons
-- git -> required by Terraform
-- curl -> required by Terraform as well as dependent modules (when downloading RKE2 for install)
-- openssh -> required by Terraform and used in dependent modules to connect to servers for initial configuration
-- openssl -> required by Terraform and used in dependent modules to verify TLS certificates
-- ssh-agent -> used for connecting to remote server for initial configuration, you need to have the key you send into the module loaded in your agent
+- actionlint -> used to lint workflows
+- aspellWithDicts -> used to validate commit messages
+- awscli2 -> used in some dependent modules in some use cases (dualstack)
+- bashInteractive -> born again shell with linux core utils facilitates CLI actions
+- cmctl -> helpful to troubleshoot Rancher install issues
+- curl -> required for Terraform
+- eslint -> lint node scripts in CI
 - gh -> the github cli tool, used to find releases when downloading RKE2 for install
-- jq -> json parsing tool, used in dependent modules to parse submodule outputs
-- kubectl -> used in local exec to patch kubernetes objects
-- awscli2 -> the aws cli tool, used in some dependent modules in some use cases (dualstack)
-- yq -> yaml parsing tool, used in dependent modules to parse kubectl outputs
-- go -> necessary to run tests
+- git -> required by Terraform
+- gitleaks -> used in CI to detect potential key leaks
+- gnupg -> helpful when generating a new gpg key for releases
+- go -> necessary for building and testing
+- golangci-lint -> lint go code
+- gotestfmt -> necessary for gotestsum
+- gotestsum -> test harness that allows for better parsing and testing of go tests
+- kubernetes-helm -> helpful when troubleshooting helm issues
+- jq -> used in dependent modules to parse submodule outputs
+- kubectl -> necessary when pulling kubeconfig
+- less -> helpful when needing to read files
+- nodejs_24 -> used by eslint to validate github scripts
+- openssh -> necessary to connect to servers
+- openssl -> helpful when generating certs
+- shellcheck -> used by ci to validate shell scripts
+- tflint -> used by ci to validate Terraform examples
+- vim -> helpful when editing files
+- which -> helpful when troubleshooting nix issues
+- yq -> used in dependent modules to parse kubectl outputs
+- terraform -> necessary to run tests
+- goreleaser -> necessary for releases
+- leftovers -> necessary for cleaning up broken tests
 
 ## Environment Variables
 

--- a/examples/use-cases/production/README.md
+++ b/examples/use-cases/production/README.md
@@ -8,21 +8,38 @@ The TLS certificate is externally generated and publicly verifiable (assuming yo
 ## Dependencies
 
 The `flake.nix` file in the root of the module explains all of the dependencies for the development of the module, it also includes the dependencies to run it.
-You can see the list on lines 50-80, but a more specific list is below (with explanations).
+You can see the list on lines 143-174, but a more specific list is below (with explanations).
 
-- bash -> born again shell with linux core utils facilitates CLI actions
-- tfswitch -> handy for installing Terraform at specific verisons
-- git -> required by Terraform
-- curl -> required by Terraform as well as dependent modules (when downloading RKE2 for install)
-- openssh -> required by Terraform and used in dependent modules to connect to servers for initial configuration
-- openssl -> required by Terraform and used in dependent modules to verify TLS certificates
-- ssh-agent -> used for connecting to remote server for initial configuration, you need to have the key you send into the module loaded in your agent
+- actionlint -> used to lint workflows
+- aspellWithDicts -> used to validate commit messages
+- awscli2 -> used in some dependent modules in some use cases (dualstack)
+- bashInteractive -> born again shell with linux core utils facilitates CLI actions
+- cmctl -> helpful to troubleshoot Rancher install issues
+- curl -> required for Terraform
+- eslint -> lint node scripts in CI
 - gh -> the github cli tool, used to find releases when downloading RKE2 for install
-- jq -> json parsing tool, used in dependent modules to parse submodule outputs
-- kubectl -> used in local exec to patch kubernetes objects
-- awscli2 -> the aws cli tool, used in some dependent modules in some use cases (dualstack)
-- yq -> yaml parsing tool, used in dependent modules to parse kubectl outputs
-- go -> necessary to run tests
+- git -> required by Terraform
+- gitleaks -> used in CI to detect potential key leaks
+- gnupg -> helpful when generating a new gpg key for releases
+- go -> necessary for building and testing
+- golangci-lint -> lint go code
+- gotestfmt -> necessary for gotestsum
+- gotestsum -> test harness that allows for better parsing and testing of go tests
+- kubernetes-helm -> helpful when troubleshooting helm issues
+- jq -> used in dependent modules to parse submodule outputs
+- kubectl -> necessary when pulling kubeconfig
+- less -> helpful when needing to read files
+- nodejs_24 -> used by eslint to validate github scripts
+- openssh -> necessary to connect to servers
+- openssl -> helpful when generating certs
+- shellcheck -> used by ci to validate shell scripts
+- tflint -> used by ci to validate Terraform examples
+- vim -> helpful when editing files
+- which -> helpful when troubleshooting nix issues
+- yq -> used in dependent modules to parse kubectl outputs
+- terraform -> necessary to run tests
+- goreleaser -> necessary for releases
+- leftovers -> necessary for cleaning up broken tests
 
 ## Environment Variables
 

--- a/examples/use-cases/three/README.md
+++ b/examples/use-cases/three/README.md
@@ -13,21 +13,38 @@ This module was developed working closely with specific customer feedback.
 ## Dependencies
 
 The `flake.nix` file in the root of the module explains all of the dependencies for the development of the module, it also includes the dependencies to run it.
-You can see the list on lines 50-80, but a more specific list is below (with explanations).
+You can see the list on lines 143-174, but a more specific list is below (with explanations).
 
-- bash -> born again shell with linux core utils facilitates CLI actions
-- tfswitch -> handy for installing Terraform at specific verisons
-- git -> required by Terraform
-- curl -> required by Terraform as well as dependent modules (when downloading RKE2 for install)
-- openssh -> required by Terraform and used in dependent modules to connect to servers for initial configuration
-- openssl -> required by Terraform and used in dependent modules to verify TLS certificates
-- ssh-agent -> used for connecting to remote server for initial configuration, you need to have the key you send into the module loaded in your agent
+- actionlint -> used to lint workflows
+- aspellWithDicts -> used to validate commit messages
+- awscli2 -> used in some dependent modules in some use cases (dualstack)
+- bashInteractive -> born again shell with linux core utils facilitates CLI actions
+- cmctl -> helpful to troubleshoot Rancher install issues
+- curl -> required for Terraform
+- eslint -> lint node scripts in CI
 - gh -> the github cli tool, used to find releases when downloading RKE2 for install
-- jq -> json parsing tool, used in dependent modules to parse submodule outputs
-- kubectl -> used in local exec to patch kubernetes objects
-- awscli2 -> the aws cli tool, used in some dependent modules in some use cases (dualstack)
-- yq -> yaml parsing tool, used in dependent modules to parse kubectl outputs
-- go -> necessary to run tests
+- git -> required by Terraform
+- gitleaks -> used in CI to detect potential key leaks
+- gnupg -> helpful when generating a new gpg key for releases
+- go -> necessary for building and testing
+- golangci-lint -> lint go code
+- gotestfmt -> necessary for gotestsum
+- gotestsum -> test harness that allows for better parsing and testing of go tests
+- kubernetes-helm -> helpful when troubleshooting helm issues
+- jq -> used in dependent modules to parse submodule outputs
+- kubectl -> necessary when pulling kubeconfig
+- less -> helpful when needing to read files
+- nodejs_24 -> used by eslint to validate github scripts
+- openssh -> necessary to connect to servers
+- openssl -> helpful when generating certs
+- shellcheck -> used by ci to validate shell scripts
+- tflint -> used by ci to validate Terraform examples
+- vim -> helpful when editing files
+- which -> helpful when troubleshooting nix issues
+- yq -> used in dependent modules to parse kubectl outputs
+- terraform -> necessary to run tests
+- goreleaser -> necessary for releases
+- leftovers -> necessary for cleaning up broken tests
 
 ## Environment Variables
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773597492,
-        "narHash": "sha256-hQ284SkIeNaeyud+LS0WVLX+WL2rxcVZLFEaK0e03zg=",
+        "lastModified": 1777826146,
+        "narHash": "sha256-wQ/iN5Zp5VIa3ebBibijPnLyKhor+xEbDy4d0goa9Zs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a07d4ce6bee67d7c838a8a5796e75dff9caa21ef",
+        "rev": "73c703c22422b8951895a960959dbbaca7296492",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachSystem [ "x86_64-darwin" "aarch64-darwin" "x86_64-linux" ]
+    flake-utils.lib.eachSystem [ "aarch64-darwin" "x86_64-linux" "aarch64-linux" ]
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
@@ -16,10 +16,6 @@
             "selected" = "v0.70.0";
           };
           leftovers-prep = {
-            "x86_64-darwin" = {
-              "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-darwin-amd64";
-              "sha" = "sha256-HV12kHqB14lGDm1rh9nD1n7Jvw0rCnxmjC9gusw7jfo=";
-            };
             "aarch64-darwin" = {
               "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-darwin-arm64";
               "sha" = "sha256-Tw7G538RYZrwIauN7kI68u6aKS4d/0Efh+dirL/kzoM=";
@@ -27,6 +23,11 @@
             "x86_64-linux" = {
               "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-linux-amd64";
               "sha" = "sha256-D2OPjLlV5xR3f+dVHu0ld6bQajD5Rv9GLCMCk9hXlu8=";
+            };
+            # linux container running on darwin, actual arm linux isn't in the artifacts
+            "aarch64-linux" = {
+              "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-darwin-arm64";
+              "sha" = "sha256-Tw7G538RYZrwIauN7kI68u6aKS4d/0Efh+dirL/kzoM=";
             };
           };
           leftovers = pkgs.stdenv.mkDerivation {
@@ -42,18 +43,109 @@
               chmod +x $out/bin/leftovers
             '';
           };
+
+          terraform-version = {
+            "selected" = "1.5.7";
+          };
+          terraform-prep = {
+            "aarch64-darwin" = {
+              "url" = "https://releases.hashicorp.com/terraform/${terraform-version.selected}/terraform_${terraform-version.selected}_darwin_arm64.zip";
+              "sha" = "sha256-23wz6xpEa3OkQ+LFW1MoRfe3DNVhAL7EyW8Vz6tfUMs=";
+              "checksum" = "db7c33eb1a446b73a443e2c55b532845f7b70cd56100bec4c96f15cfab5f50cb";
+            };
+            "x86_64-linux" = {
+              "url" = "https://releases.hashicorp.com/terraform/${terraform-version.selected}/terraform_${terraform-version.selected}_linux_amd64.zip";
+              "sha" = "sha256-wO17wy7lKuJVr5mCyMiKekxhBIXPHVX+6wN+q3X6CCw=";
+              "checksum" = "c0ed7bc32ee52ae255af9982c8c88a7a4c610485cf1d55feeb037eab75fa082c";
+            };
+            # linux container running on darwin or arm linux
+            "aarch64-linux" = {
+              "url" = "https://releases.hashicorp.com/terraform/${terraform-version.selected}/terraform_${terraform-version.selected}_linux_arm64.zip";
+              "sha" = "sha256-9LStfGtgiJYKZn40SVyuSQ+wcpR6n/Jmv1kp9TM1ZeQ=";
+              "checksum" = "f4b4ad7c6b6088960a667e34495cae490fb072947a9ff266bf5929f5333565e4";
+            };
+          };
+          terraform = pkgs.stdenv.mkDerivation {
+            name = "terraform-${terraform-version.selected}";
+            src = pkgs.fetchurl {
+              url = terraform-prep."${system}".url;
+              sha256 = terraform-prep."${system}".sha;
+            };
+            checksum = terraform-prep."${system}".checksum;
+            nativeBuildInputs = [ pkgs.unzip ];
+            phases = [ "installPhase" ];
+            installPhase = ''
+              echo "Verifying checksum..."
+              SUM="$(sha256sum $src | awk '{print $1}')"
+              if [ "$SUM" = "$checksum" ]; then 
+                echo "Valid!";
+              else 
+                echo "Invalid!";
+                echo "expected: $checksum, got: $SUM"
+                echo "check your flake.nix file"
+                exit 1;
+              fi
+
+              install -d $out/bin
+              unzip -o $src -d $out/bin
+              chmod +x $out/bin/terraform
+            '';
+          };
+          goreleaser-version = {
+            "selected" = "2.15.4";
+          };
+          goreleaser-prep = {
+            "aarch64-darwin" = { # local workstation
+              "url" = "https://github.com/goreleaser/goreleaser/releases/download/v${goreleaser-version.selected}/goreleaser_Darwin_arm64.tar.gz";
+              "sha" = "sha256-2c0JeNZGhutU5T6fCLQA7cix+QNPmPykPsej9kEycIE=";
+              "checksum" = "d9cd0978d64686eb54e53e9f08b400edc8b1f9034f98fca43ec7a3f641327081";
+            };
+            "x86_64-linux" = { # github ubuntu latest runner
+              "url" = "https://github.com/goreleaser/goreleaser/releases/download/v${goreleaser-version.selected}/goreleaser_Linux_x86_64.tar.gz";
+              "sha" = "sha256-quAMcaSm1V4IzOknOhUWvc4zweB8/7flAvpv7EN33t4=";
+              "checksum" = "aae00c71a4a6d55e08cce9273a1516bdce33c1e07cffb7e502fa6fec4377dede";
+            };
+            "aarch64-linux" = { # linux container running on darwin
+              "url" = "https://github.com/goreleaser/goreleaser/releases/download/v${goreleaser-version.selected}/goreleaser_Linux_arm64.tar.gz";
+              "sha" = "sha256-3gHKFJdXHps0hBPNLn90vkm41XaWrjhvfu3QYXZUSog=";
+              "checksum" = "de01ca1497571e9b348413cd2e7f74be49b8d57696ae386f7eedd06176544a88";
+            };
+          };
+          goreleaser = pkgs.stdenv.mkDerivation {
+            name = "goreleaser-${goreleaser-version.selected}";
+            src = pkgs.fetchurl {
+              url = goreleaser-prep."${system}".url;
+              sha256 = goreleaser-prep."${system}".sha;
+            };
+            checksum = goreleaser-prep."${system}".checksum;
+            phases = [ "installPhase" ];
+            installPhase = ''
+              echo "Verifying checksum..."
+              SUM="$(sha256sum $src | awk '{print $1}')"
+              if [ "$SUM" = "$checksum" ]; then 
+                echo "Valid!";
+              else 
+                echo "Invalid!";
+                echo "expected: $checksum, got: $SUM"
+                echo "check your flake.nix file"
+                exit 1;
+              fi
+              install -d $out/bin
+              tar -xf $src goreleaser
+              install -m 755 goreleaser $out/bin/goreleaser
+            '';
+          };
           aspellWithDicts = pkgs.aspellWithDicts (d: [d.en d.en-computers]);
 
           devShellPackage = pkgs.symlinkJoin {
             name = "dev-shell-package";
-            paths = with pkgs; [
+            paths = (with pkgs; [
               actionlint
-              age
               aspellWithDicts
               awscli2
               bashInteractive
+              cmctl
               curl
-              dig
               eslint
               gh
               git
@@ -61,27 +153,25 @@
               gnupg
               go
               golangci-lint
-              goreleaser
               gotestfmt
               gotestsum
+              kubernetes-helm
               jq
               kubectl
-              kubernetes-helm
-              leftovers
               less
-              nodejs_22
+              nodejs_24
               openssh
               openssl
               shellcheck
               tflint
-              tfsec
-              tfswitch
-              trivy
-              updatecli
               vim
               which
               yq
-            ];
+            ] ++ [ # manually downloaded packages here
+              terraform
+              goreleaser
+              leftovers
+            ]);
           };
         in
         {
@@ -91,10 +181,6 @@
             buildInputs = [ devShellPackage ];
             shellHook = ''
               while read word; do echo -e "*$word\n#" | aspell -a --dont-validate-words >/dev/null; done < aspell_custom.txt
-              homebin=$HOME/bin;
-              install -d $homebin;
-              tfswitch -b $homebin/terraform 1.5.7 &>/dev/null;
-              export PATH="$homebin:$PATH";
               export PS1="nix:# ";
             '';
           };


### PR DESCRIPTION
Description
This change adds GoReleaser to the Nix environment and manually downloads Terraform.
TFSwitch is having trouble due to a change in the Gpg key that Hashicorp uses to sign Terraform releases, so we are eliminating tfswitch and downloading it manually. There isn't a build for Terraform v1.5.7 in nix-pkgs so we are downloading it from Hashicorp and validating the checksum. Nix also automatically validates the download with its own sha.
Using the same process for GoReleaser since the latest version isn't in nix-pkgs.

Testing
Manually tested locally, this doesn't effect the product just how it is built and released.

Not a breaking change.