### PR TITLE
fix: clean up nix install script (#2230)

### DIFF
--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -120,13 +120,13 @@ jobs:
           cache: true
       - name: install-nix
         run: |
-          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
-          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
-          chmod +x install.sh
-          ./install.sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Run GoReleaser
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep TAG --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -113,13 +113,13 @@ jobs:
           cache: true
       - name: install-nix
         run: |
-          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
-          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
-          chmod +x install.sh
-          ./install.sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Run GoReleaser
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep TAG --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -26,10 +26,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Run make test
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |
@@ -43,10 +46,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: lint terraform
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |
@@ -62,10 +68,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: action lint
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: actionlint
@@ -79,10 +88,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: check
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |
@@ -100,10 +112,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: check
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |
@@ -118,10 +133,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: shell check
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |
@@ -138,10 +156,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Check commit message
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |
@@ -224,10 +245,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Check for secrets
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,10 +165,13 @@ jobs:
       - name: install-nix
         if: (steps.check-lock.outputs.status == 'clean' && steps.check-ip.outputs.status == 'clean') || strategy.job-index == 0
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: run-unit-tests
         id: run-unit-tests
         if: (steps.check-lock.outputs.status == 'clean' && steps.check-ip.outputs.status == 'clean') || strategy.job-index == 0
@@ -258,10 +261,13 @@ jobs:
           output-credentials: true
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: cleanup
         shell: '/home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep IDENTIFIER --keep GITHUB_TOKEN --keep GITHUB_OWNER --keep ZONE --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}'
         env:
@@ -398,13 +404,13 @@ jobs:
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - name: install-nix
         run: |
-          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
-          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
-          chmod +x install.sh
-          ./install.sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Run GoReleaser
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
@@ -482,13 +488,13 @@ jobs:
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - name: install-nix
         run: |
-          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
-          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
-          chmod +x install.sh
-          ./install.sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Run GoReleaser
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:


### PR DESCRIPTION
(cherry picked from commit e595d0f8faf4e1e5f6f3f8258c8907d9b643fe9f)
cherry picks #2230 
addresses #2233 for #2231
Description
The nix install script is overriding the base install.sh causing goreleaser to fail.
This changes the nix install script to nix_install.sh and removes it once nix is installed.

Testing
actionlint, this doesn't affect the product.

Not a breaking change.