### PR TITLE
fix: clean up nix install script (#2230)

### DIFF
--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -120,13 +120,13 @@ jobs:
           cache: true
       - name: install-nix
         run: |
-          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
-          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
-          chmod +x install.sh
-          ./install.sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Run GoReleaser
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep TAG --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -113,13 +113,13 @@ jobs:
           cache: true
       - name: install-nix
         run: |
-          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
-          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
-          chmod +x install.sh
-          ./install.sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Run GoReleaser
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep TAG --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,7 +19,25 @@ jobs:
           VERSION: ${{ github.ref_name }}
         run: |
           make build
-
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout
+        with:
+          fetch-depth: 0
+      - name: install-nix
+        run: |
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
+          source /home/runner/.nix-profile/etc/profile.d/nix.sh
+          nix --version
+          rm -f ./nix_install.sh
+      - name: Run make test
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
+        run: |
+          make test
   terraform:
     name: 'Terraform'
     runs-on: ubuntu-latest
@@ -29,10 +47,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: lint terraform
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |
@@ -48,10 +69,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: action lint
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: actionlint
@@ -65,10 +89,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: check
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |
@@ -86,10 +113,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: check
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |
@@ -104,10 +134,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: shell check
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |
@@ -124,10 +157,13 @@ jobs:
           fetch-depth: 0 # fetch all history so that we can validate the commit messages
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Check commit message
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |
@@ -209,10 +245,13 @@ jobs:
           fetch-depth: 0
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Check for secrets
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,10 +165,13 @@ jobs:
       - name: install-nix
         if: (steps.check-lock.outputs.status == 'clean' && steps.check-ip.outputs.status == 'clean') || strategy.job-index == 0
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: run-unit-tests
         id: run-unit-tests
         if: (steps.check-lock.outputs.status == 'clean' && steps.check-ip.outputs.status == 'clean') || strategy.job-index == 0
@@ -258,10 +261,13 @@ jobs:
           output-credentials: true
       - name: install-nix
         run: |
-          curl -L https://nixos.org/nix/install | sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: cleanup
         shell: '/home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep IDENTIFIER --keep GITHUB_TOKEN --keep GITHUB_OWNER --keep ZONE --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}'
         env:
@@ -394,13 +400,13 @@ jobs:
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - name: install-nix
         run: |
-          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
-          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
-          chmod +x install.sh
-          ./install.sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Run GoReleaser
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:
@@ -480,13 +486,13 @@ jobs:
           echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - name: install-nix
         run: |
-          curl -L -o install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
-          echo "${NIX_INSTALL_SHA} install.sh" | sha256sum -c -
-          chmod +x install.sh
-          ./install.sh
+          curl -L -o nix_install.sh "https://releases.nixos.org/nix/nix-${NIX_INSTALL_VERSION}/install"
+          echo "${NIX_INSTALL_SHA} nix_install.sh" | sha256sum -c -
+          chmod +x nix_install.sh
+          ./nix_install.sh
           source /home/runner/.nix-profile/etc/profile.d/nix.sh
           nix --version
-          which nix
+          rm -f ./nix_install.sh
       - name: Run GoReleaser
         shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GPG_KEY_ID --keep GPG_PASSPHRASE --keep GITHUB_TOKEN --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
         env:


### PR DESCRIPTION
cherry picks #2230
adresses #2234 for #2231
(cherry picked from commit https://github.com/rancher/terraform-provider-rancher2/commit/e595d0f8faf4e1e5f6f3f8258c8907d9b643fe9f)
Description
The nix install script is overriding the base install.sh causing goreleaser to fail.
This changes the nix install script to nix_install.sh and removes it once nix is installed.

Testing
actionlint, this doesn't affect the product.

Not a breaking change.