### PR TITLE
fix: Stop data sources from generating kubeconfig tokens on every plan

### DIFF
--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -8,6 +8,7 @@ azure
 backport
 cognito
 config
+datasource
 destructuring
 eks
 eslint

--- a/rancher2/data_source_rancher2_cluster.go
+++ b/rancher2/data_source_rancher2_cluster.go
@@ -37,8 +37,8 @@ func dataSourceRancher2Cluster() *schema.Resource {
 			"generate_kube_config": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
-				Description: "Generate a kubeconfig for the cluster. Warning: this creates a new API token on each plan/apply.",
+				Default:     true,
+				Description: "Generate a kubeconfig for the cluster. Set to false to avoid creating a new API token on each plan/apply. Default will change to false in a future version.",
 			},
 			"ca_cert": {
 				Type:      schema.TypeString,
@@ -241,7 +241,9 @@ func dataSourceRancher2ClusterRead(d *schema.ResourceData, meta interface{}) err
 		}
 
 		var kubeConfig *managementClient.GenerateKubeConfigOutput
-		if d.Get("generate_kube_config").(bool) {
+		generateKubeConfig := d.Get("generate_kube_config").(bool)
+		if generateKubeConfig {
+			log.Printf("[WARN] Generating kubeconfig for cluster %s creates a new API token. Set generate_kube_config = false if you don't need kube_config. The default will change to false in a future version.", cluster.ID)
 			kubeConfig, err = getClusterKubeconfig(meta.(*Config), cluster.ID, d.Get("kube_config").(string))
 			if err != nil && !IsForbidden(err) {
 				return resource.NonRetryableError(err)

--- a/rancher2/data_source_rancher2_cluster.go
+++ b/rancher2/data_source_rancher2_cluster.go
@@ -2,8 +2,11 @@ package rancher2
 
 import (
 	"fmt"
+	"log"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	managementClient "github.com/rancher/rancher/pkg/client/generated/management/v3"
 )
 
 func dataSourceRancher2Cluster() *schema.Resource {
@@ -30,6 +33,12 @@ func dataSourceRancher2Cluster() *schema.Resource {
 			"kube_config": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"generate_kube_config": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Generate a kubeconfig for the cluster. Warning: this creates a new API token on each plan/apply.",
 			},
 			"ca_cert": {
 				Type:      schema.TypeString,
@@ -209,5 +218,49 @@ func dataSourceRancher2ClusterRead(d *schema.ResourceData, meta interface{}) err
 
 	d.SetId(clusters.Data[0].ID)
 
-	return resourceRancher2ClusterRead(d, meta)
+	return resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+		cluster := &Cluster{}
+		err = client.APIBaseClient.ByID(managementClient.ClusterType, d.Id(), cluster)
+		if err != nil {
+			if IsNotFound(err) || IsForbidden(err) {
+				log.Printf("[INFO] Cluster ID %s not found.", d.Id())
+				d.SetId("")
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+
+		clusterRegistrationToken, err := findClusterRegistrationToken(client, cluster.ID)
+		if err != nil && !IsForbidden(err) {
+			return resource.NonRetryableError(err)
+		}
+
+		defaultProjectID, systemProjectID, err := meta.(*Config).GetClusterSpecialProjectsID(cluster.ID)
+		if err != nil && !IsForbidden(err) {
+			return resource.NonRetryableError(err)
+		}
+
+		var kubeConfig *managementClient.GenerateKubeConfigOutput
+		if d.Get("generate_kube_config").(bool) {
+			kubeConfig, err = getClusterKubeconfig(meta.(*Config), cluster.ID, d.Get("kube_config").(string))
+			if err != nil && !IsForbidden(err) {
+				return resource.NonRetryableError(err)
+			}
+		}
+		if kubeConfig == nil {
+			kubeConfig = &managementClient.GenerateKubeConfigOutput{}
+		}
+
+		if err = flattenCluster(
+			d,
+			cluster,
+			clusterRegistrationToken,
+			kubeConfig,
+			defaultProjectID,
+			systemProjectID); err != nil {
+			return resource.NonRetryableError(err)
+		}
+
+		return nil
+	})
 }

--- a/rancher2/data_source_rancher2_cluster_v2.go
+++ b/rancher2/data_source_rancher2_cluster_v2.go
@@ -80,8 +80,8 @@ func dataSourceRancher2ClusterV2() *schema.Resource {
 			"generate_kube_config": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
-				Description: "Generate a kubeconfig for the cluster. Warning: this creates a new API token on each plan/apply.",
+				Default:     true,
+				Description: "Generate a kubeconfig for the cluster. Set to false to avoid creating a new API token on each plan/apply. Default will change to false in a future version.",
 			},
 			"cluster_v1_id": {
 				Type:     schema.TypeString,
@@ -120,7 +120,11 @@ func dataSourceRancher2ClusterV2Read(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	d.Set("cluster_v1_id", cluster.Status.ClusterName)
-	err = setClusterV2LegacyData(d, meta.(*Config), d.Get("generate_kube_config").(bool))
+	generateKubeConfig := d.Get("generate_kube_config").(bool)
+	if generateKubeConfig {
+		log.Printf("[WARN] Generating kubeconfig for cluster %s creates a new API token. Set generate_kube_config = false if you don't need kube_config. The default will change to false in a future version.", d.Id())
+	}
+	err = setClusterV2LegacyData(d, meta.(*Config), generateKubeConfig)
 	if err != nil {
 		return err
 	}

--- a/rancher2/data_source_rancher2_cluster_v2.go
+++ b/rancher2/data_source_rancher2_cluster_v2.go
@@ -1,6 +1,8 @@
 package rancher2
 
 import (
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -75,6 +77,12 @@ func dataSourceRancher2ClusterV2() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"generate_kube_config": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Generate a kubeconfig for the cluster. Warning: this creates a new API token on each plan/apply.",
+			},
 			"cluster_v1_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -100,5 +108,21 @@ func dataSourceRancher2ClusterV2Read(d *schema.ResourceData, meta interface{}) e
 	namespace := d.Get("fleet_namespace").(string)
 	d.SetId(namespace + clusterV2ClusterIDsep + name)
 
-	return resourceRancher2ClusterV2Read(d, meta)
+	log.Printf("[INFO] Refreshing Cluster V2 %s", d.Id())
+
+	cluster, err := getClusterV2ByID(meta.(*Config), d.Id())
+	if err != nil {
+		if IsNotFound(err) || IsForbidden(err) || IsNotAccessibleByID(err) {
+			log.Printf("[INFO] Cluster V2 %s not found", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+	d.Set("cluster_v1_id", cluster.Status.ClusterName)
+	err = setClusterV2LegacyData(d, meta.(*Config), d.Get("generate_kube_config").(bool))
+	if err != nil {
+		return err
+	}
+	return flattenClusterV2(d, cluster)
 }

--- a/rancher2/resource_rancher2_cluster_v2.go
+++ b/rancher2/resource_rancher2_cluster_v2.go
@@ -146,7 +146,7 @@ func resourceRancher2ClusterV2Read(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	d.Set("cluster_v1_id", cluster.Status.ClusterName)
-	err = setClusterV2LegacyData(d, meta.(*Config))
+	err = setClusterV2LegacyData(d, meta.(*Config), true)
 	if err != nil {
 		return err
 	}
@@ -376,7 +376,7 @@ func waitForClusterV2State(c *Config, id, state string, interval time.Duration) 
 	}
 }
 
-func setClusterV2LegacyData(d *schema.ResourceData, c *Config) error {
+func setClusterV2LegacyData(d *schema.ResourceData, c *Config, generateKubeConfig bool) error {
 	format := "Setting cluster V2 legacy data: %w"
 
 	if c == nil {
@@ -412,11 +412,13 @@ func setClusterV2LegacyData(d *schema.ResourceData, c *Config) error {
 		return fmt.Errorf(format, err)
 	}
 
-	kubeConfig, err := getClusterKubeconfig(c, cluster.ID, d.Get("kube_config").(string))
-	if err != nil {
-		return fmt.Errorf(format, err)
+	if generateKubeConfig {
+		kubeConfig, err := getClusterKubeconfig(c, cluster.ID, d.Get("kube_config").(string))
+		if err != nil {
+			return fmt.Errorf(format, err)
+		}
+		d.Set("kube_config", kubeConfig.Config)
 	}
-	d.Set("kube_config", kubeConfig.Config)
 
 	return nil
 }


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->
Addresses #1229

<!--- Add labels (eg. release/v14) for each release branch to target --->
<!--- Please don't manually add "internal" labels, those are for automation only --->

## Description

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->

Cluster data sources called the Rancher generateKubeconfig API on every plan and apply, creating a new API token each time. Over time this leads to accumulation of large numbers of orphaned tokens.

Data sources now skip kubeconfig generation by default, **which is a breaking change**. Users who need the kubeconfig output can opt in by setting generate_kube_config = true on the data source.

The alternative is to make it opt-out in which case the side-effect remains the default behavior.


## Testing

<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
This is a breaking change.

`kube_config` on cluster data sources (`rancher2_cluster`, `rancher2_cluster_v2`) is now empty by default.
Previously, every plan/apply generated a new API token. Users who need `kube_config` from a data source must set `generate_kube_config = true`.
