### PR TITLE
feat: Machine Config for Harvester: CPU Pinning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ tf-*
 */*.tfvars
 */*.pem
 *.tgz
-main.tf
 terraform-provider-rancher2
 node_modules
 .vscode

--- a/docs/resources/machine_config_v2.md
+++ b/docs/resources/machine_config_v2.md
@@ -50,7 +50,13 @@ resource "rancher2_machine_config_v2" "foo-harvester-v2" {
   generate_name = "foo-harvester-v2"
   harvester_config {
     vm_namespace = "default"
-    cpu_count = "2"
+
+    cpu {
+      count = 2
+      pinning = true
+      isolate_emulator_thread = true
+    }
+
     memory_size = "4"
     disk_info = <<EOF
     {

--- a/examples/resources/rancher2_machine_config_v2/main.tf
+++ b/examples/resources/rancher2_machine_config_v2/main.tf
@@ -1,0 +1,65 @@
+terraform {
+  required_version = "~> v1.14.8"
+
+  required_providers {
+    rancher2 = {
+      source  = "terraform.local/local/rancher2"
+      version = "0.0.0-dev"
+    }
+  }
+}
+
+provider "rancher2" {
+  api_url    = "https://rancher.192.168.0.131.sslip.io"
+  insecure   = true
+  access_key = "token-hf7vc"
+  secret_key = "mmf52l956zjbbkrhncmc4q8fvnrlbdhfftrrjdlnqwmkz5b7lrlst7"
+}
+
+resource "rancher2_machine_config_v2" "foo-harvester-v2" {
+  generate_name = "foo-harvester-v2"
+
+  harvester_config {
+    vm_namespace = "default"
+
+    cpu {
+      count                   = 2
+      pinning                 = true
+      isolate_emulator_thread = true
+    }
+
+    memory_size = "4"
+
+    disk_info = <<EOF
+    {
+        "disks": [{
+            "imageName": "harvester-public/image-57hzg",
+            "size": 40,
+            "bootOrder": 1
+        }]
+    }
+    EOF
+
+    network_info = <<EOF
+    {
+        "interfaces": [{
+            "networkName": "harvester-public/vlan1"
+        }]
+    }
+    EOF
+
+    ssh_user = "ubuntu"
+
+    user_data = <<EOF
+    package_update: true
+    packages:
+      - qemu-guest-agent
+      - iptables
+    runcmd:
+      - - systemctl
+        - enable
+        - '--now'
+        - qemu-guest-agent.service
+    EOF
+  }
+}

--- a/rancher2/schema_machine_config_v2_harvester.go
+++ b/rancher2/schema_machine_config_v2_harvester.go
@@ -6,6 +6,30 @@ import (
 
 //Schemas
 
+func machineConfigV2HarvesterCPUFields() map[string]*schema.Schema {
+	s := map[string]*schema.Schema{
+		"count": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "2",
+			Description: "vCPU count",
+		},
+		"pinning": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "pin vCPUs to physical cores",
+		},
+		"isolate_emulator_thread": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "isolate emulator thread from VM vCPUs on separate CPU core",
+		},
+	}
+	return s
+}
+
 func machineConfigV2HarvesterFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"vm_namespace": {
@@ -18,11 +42,14 @@ func machineConfigV2HarvesterFields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "VM affinity, base64 is supported",
 		},
-		"cpu_count": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Default:     "2",
-			Description: "CPU count",
+		"cpu": {
+			Type:        schema.TypeList,
+			MaxItems:    1,
+			Required:    true,
+			Description: "CPU settings",
+			Elem: &schema.Resource{
+				Schema: machineConfigV2HarvesterCPUFields(),
+			},
 		},
 		"memory_size": {
 			Type:        schema.TypeString,

--- a/rancher2/structure_machine_config_v2_harvester.go
+++ b/rancher2/structure_machine_config_v2_harvester.go
@@ -14,25 +14,31 @@ const (
 
 //Types
 
+type MachineConfigV2HarvesterCPU struct {
+	Count                 int  `json:"count,omitempty", yaml:count,omitempty"`
+	Pinning               bool `json:"pinning,omitempty", yaml:pinning,omitempty"`
+	IsolateEmulatorThread bool `json:"isolateEmulatorThread,omitempty", yaml:isolateEmulatorThread,omitempty"`
+}
+
 type machineConfigV2Harvester struct {
 	metav1.TypeMeta    `json:",inline"`
 	metav1.ObjectMeta  `json:"metadata,omitempty"`
-	VMNamespace        string `json:"vmNamespace,omitempty" yaml:"vmNamespace,omitempty"`
-	VMAffinity         string `json:"vmAffinity,omitempty" yaml:"vmAffinity,omitempty"`
-	CPUCount           string `json:"cpuCount,omitempty" yaml:"cpuCount,omitempty"`
-	MemorySize         string `json:"memorySize,omitempty" yaml:"memorySize,omitempty"`
-	ReservedMemorySize string `json:"reservedMemorySize,omitempty" yaml:"reservedMemorySize,omitempty"`
-	DiskSize           string `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
-	DiskBus            string `json:"diskBus,omitempty" yaml:"diskBus,omitempty"`
-	ImageName          string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
-	DiskInfo           string `json:"diskInfo,omitempty" yaml:"diskInfo,omitempty"`
-	SSHUser            string `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
-	SSHPassword        string `json:"sshPassword,omitempty" yaml:"sshPassword,omitempty"`
-	NetworkName        string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
-	NetworkModel       string `json:"networkModel,omitempty" yaml:"networkModel,omitempty"`
-	NetworkInfo        string `json:"networkInfo,omitempty" yaml:"networkInfo,omitempty"`
-	UserData           string `json:"userData,omitempty" yaml:"userData,omitempty"`
-	NetworkData        string `json:"networkData,omitempty" yaml:"networkData,omitempty"`
+	VMNamespace        string                       `json:"vmNamespace,omitempty" yaml:"vmNamespace,omitempty"`
+	VMAffinity         string                       `json:"vmAffinity,omitempty" yaml:"vmAffinity,omitempty"`
+	CPU                *MachineConfigV2HarvesterCPU `json:"cpu,omitempty" yaml:"cpu,omitempty"`
+	MemorySize         string                       `json:"memorySize,omitempty" yaml:"memorySize,omitempty"`
+	ReservedMemorySize string                       `json:"reservedMemorySize,omitempty" yaml:"reservedMemorySize,omitempty"`
+	DiskSize           string                       `json:"diskSize,omitempty" yaml:"diskSize,omitempty"`
+	DiskBus            string                       `json:"diskBus,omitempty" yaml:"diskBus,omitempty"`
+	ImageName          string                       `json:"imageName,omitempty" yaml:"imageName,omitempty"`
+	DiskInfo           string                       `json:"diskInfo,omitempty" yaml:"diskInfo,omitempty"`
+	SSHUser            string                       `json:"sshUser,omitempty" yaml:"sshUser,omitempty"`
+	SSHPassword        string                       `json:"sshPassword,omitempty" yaml:"sshPassword,omitempty"`
+	NetworkName        string                       `json:"networkName,omitempty" yaml:"networkName,omitempty"`
+	NetworkModel       string                       `json:"networkModel,omitempty" yaml:"networkModel,omitempty"`
+	NetworkInfo        string                       `json:"networkInfo,omitempty" yaml:"networkInfo,omitempty"`
+	UserData           string                       `json:"userData,omitempty" yaml:"userData,omitempty"`
+	NetworkData        string                       `json:"networkData,omitempty" yaml:"networkData,omitempty"`
 }
 
 type MachineConfigV2Harvester struct {
@@ -41,6 +47,24 @@ type MachineConfigV2Harvester struct {
 }
 
 // Flatteners
+
+func flattenMachineConfigV2HarvesterCPU(in *MachineConfigV2HarvesterCPU) []interface{} {
+	if in == nil {
+		return nil
+	}
+
+	obj := make(map[string]interface{})
+
+	if in.Count > 0 {
+		obj["count"] = in.Count
+	} else {
+		obj["count"] = 2
+	}
+	obj["pinning"] = in.Pinning
+	obj["isolateEmulatorThread"] = in.IsolateEmulatorThread
+
+	return []interface{}{obj}
+}
 
 func flattenMachineConfigV2Harvester(in *MachineConfigV2Harvester) []interface{} {
 	if in == nil {
@@ -57,8 +81,8 @@ func flattenMachineConfigV2Harvester(in *MachineConfigV2Harvester) []interface{}
 		obj["vm_affinity"] = in.VMAffinity
 	}
 
-	if len(in.CPUCount) > 0 {
-		obj["cpu_count"] = in.CPUCount
+	if in.CPU != nil {
+		obj["cpu"] = flattenMachineConfigV2HarvesterCPU(in.CPU)
 	}
 
 	if len(in.MemorySize) > 0 {
@@ -118,6 +142,29 @@ func flattenMachineConfigV2Harvester(in *MachineConfigV2Harvester) []interface{}
 
 // Expanders
 
+func expandMachineConfigV2HarvesterCPU(p []interface{}) *MachineConfigV2HarvesterCPU {
+	if p == nil || len(p) != 1 || p[0] == nil {
+		return nil
+	}
+	in := p[0].(map[string]interface{})
+
+	obj := MachineConfigV2HarvesterCPU{}
+
+	if v, ok := in["count"].(int); ok {
+		obj.Count = v
+	}
+
+	if v, ok := in["pinning"].(bool); ok {
+		obj.Pinning = v
+	}
+
+	if v, ok := in["isolateEmulatorThread"].(bool); ok {
+		obj.IsolateEmulatorThread = v
+	}
+
+	return &obj
+}
+
 func expandMachineConfigV2Harvester(p []interface{}, source *MachineConfigV2) *MachineConfigV2Harvester {
 	if p == nil || len(p) == 0 || p[0] == nil {
 		return nil
@@ -142,8 +189,8 @@ func expandMachineConfigV2Harvester(p []interface{}, source *MachineConfigV2) *M
 		obj.VMAffinity = v
 	}
 
-	if v, ok := in["cpu_count"].(string); ok && len(v) > 0 {
-		obj.CPUCount = v
+	if v, ok := in["cpu"].([]interface{}); ok && len(v) > 0 {
+		obj.CPU = expandMachineConfigV2HarvesterCPU(v)
 	}
 
 	if v, ok := in["memory_size"].(string); ok && len(v) > 0 {

--- a/rancher2/structure_machine_config_v2_harvester_test.go
+++ b/rancher2/structure_machine_config_v2_harvester_test.go
@@ -1,0 +1,77 @@
+package rancher2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenMachineConfigV2HarvesterCPU(t *testing.T) {
+	testcases := []struct {
+		Input       *MachineConfigV2HarvesterCPU
+		Expectation []any
+	}{
+		{
+			// All default values
+			Input: &MachineConfigV2HarvesterCPU{},
+			Expectation: []any{map[string]interface{}{
+				"count":                 2,
+				"pinning":               false,
+				"isolateEmulatorThread": false,
+			}},
+		},
+		{
+			Input: &MachineConfigV2HarvesterCPU{
+				Count:                 3,
+				Pinning:               true,
+				IsolateEmulatorThread: true,
+			},
+			Expectation: []any{map[string]interface{}{
+				"count":                 3,
+				"pinning":               true,
+				"isolateEmulatorThread": true,
+			}},
+		},
+	}
+
+	for _, tc := range testcases {
+		output := flattenMachineConfigV2HarvesterCPU(tc.Input)
+		assert.Equal(t, tc.Expectation, output, "unexpected output from flattenMachineConfigV2HarvesterCPU")
+	}
+}
+
+func TestExpandMachineConfigV2HarvesterCPU(t *testing.T) {
+	testcases := []struct {
+		Input       []any
+		Expectation *MachineConfigV2HarvesterCPU
+	}{
+		{
+			// All default values
+			Input: []any{map[string]interface{}{
+				"count":                 2,
+				"pinning":               false,
+				"isolateEmulatorThread": false,
+			}},
+			Expectation: &MachineConfigV2HarvesterCPU{
+				Count: 2,
+			},
+		},
+		{
+			Input: []any{map[string]interface{}{
+				"count":                 3,
+				"pinning":               true,
+				"isolateEmulatorThread": true,
+			}},
+			Expectation: &MachineConfigV2HarvesterCPU{
+				Count:                 3,
+				Pinning:               true,
+				IsolateEmulatorThread: true,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		output := expandMachineConfigV2HarvesterCPU(tc.Input)
+		assert.Equal(t, tc.Expectation, output, "unexpected output from flattenMachineConfigV2HarvesterCPU")
+	}
+}


### PR DESCRIPTION

## Addresses

- harvester/harvester#6551
- rancher/rancher#50147

## Description

Add advanced CPU settings to the Rancher Machine Config for Harvester. By moving all CPU settings to a dedicated structure, advanced features like CPU pinning can be added to the machine config without making it too complicated.

## Testing

<details><summary>Created a machine config from the following Terraform script</summary>

```
terraform {
  required_providers {
    rancher2 = {
      source = "terraform.local/local/rancher2"
      version = "0.0.0-dev"
    }
  }
}

provider "rancher2" {
  api_url = "https://rancher.192.168.0.131.sslip.io"
  insecure = true
  access_key = "token-hf7vc"
  secret_key = "mmf52l956zjbbkrhncmc4q8fvnrlbdhfftrrjdlnqwmkz5b7lrlst7"
}

# Create a new rancher2 machine config v2 using harvester node_driver
resource "rancher2_machine_config_v2" "foo-harvester-v2" {
  generate_name = "foo-harvester-v2"
  harvester_config {
    vm_namespace = "default"
    cpu {
      count = 2
      pinning = true
      isolate_emulator_thread = true
    }
    memory_size = "4"
    disk_info = <<EOF
    {
        "disks": [{
            "imageName": "default/image-rfmgm",
            "size": 40,
            "bootOrder": 1
        }]
    }
    EOF
    network_info = <<EOF
    {
        "interfaces": [{
            "networkName": "default/testnet"
        }]
    }
    EOF
    ssh_user = "ubuntu"
    user_data = <<EOF
    password: foobar
    chpasswd:
      expire: false
    package_update: true
    packages:
      - qemu-guest-agent
      - iptables
    runcmd:
      - - systemctl
        - enable
        - '--now'
        - qemu-guest-agent.service
    EOF
  }
}

```

</details>

<details><summary>This results in the following machine config resource</summary>

```
> k -n fleet-default get harvesterconfigs.rke-machine-config.cattle.io nc-foo-harvester-v2-9p5bh -o yaml
apiVersion: rke-machine-config.cattle.io/v1
cloudConfig: ""
clusterId: ""
clusterName: ""
clusterType: ""
cpuCount: "2"
cpuModel: ""
cpuPinning: false
diskBus: ""
diskInfo: |2
      {
          "disks": [{
              "imageName": "default/image-rfmgm",
              "size": 40,
              "bootOrder": 1
          }]
      }
diskSize: "0"
enableEfi: false
enableSecureBoot: false
enableTpm: false
imageName: ""
isolateEmulatorThread: false
keyPairName: ""
kind: HarvesterConfig
kubeconfigContent: ""
memorySize: "4"
metadata:
  annotations:
    field.cattle.io/creatorId: user-8pdth
    ownerBindingsCreated: "true"
  creationTimestamp: "2026-05-29T11:16:40Z"
  generateName: nc-foo-harvester-v2-
  generation: 1
  name: nc-foo-harvester-v2-9p5bh
  namespace: fleet-default
  ownerReferences:
  - apiVersion: provisioning.cattle.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: Cluster
    name: foo-harvester-v2
    uid: 94c8c047-a8db-450c-9dab-df268499ec4f
  resourceVersion: "15364"
  uid: 2647ec9f-cfd6-41b6-8aea-01d8845de057
networkData: ""
networkInfo: |2
      {
          "interfaces": [{
              "networkName": "default/testnet"
          }]
      }
networkModel: ""
networkName: ""
networkType: ""
reservedMemorySize: "-1"
sshPassword: ""
sshPort: "22"
sshPrivateKeyPath: ""
sshUser: ubuntu
userData: |2
      password: foobar
      chpasswd:
        expire: false
      package_update: true
      packages:
        - qemu-guest-agent
        - iptables
      runcmd:
        - - systemctl
          - enable
          - '--now'
          - qemu-guest-agent.service
vgpuInfo: ""
vmAffinity: ""
vmNamespace: default
```
<img width="3827" height="1979" alt="Screenshot at 2026-05-29 14-57-53" src="https://github.com/user-attachments/assets/10c78e0d-31a0-4fb6-a7d1-8ab194e7ca11" />

Note the fields `cpuCount`, `cpuPinning` and `isolateEmulatorThread`

</details>

## Other

<details><summary>Does this change alter an interface that users of the provider will need to adjust to?</summary>

Yes. The `harvester_config` interface of the `rancher2_machine_config_v2` resource will be modified from:
```
resource "rancher2_machine_config_v2" "foo-harvester-v2" {
  harvester_config {
    cpu_count = "2"
  }
}
```
to:
```
resource "rancher2_machine_config_v2" "foo-harvester-v2" {
  harvester_config {
    cpu {
      count = 2
      pinning = false
      isolate_emulator_thread = false
    }
  }
}
```

</details>

<details><summary>Will there be any existing configurations broken by this change?</summary>

Yes, existing configurations will need to be updated.
However this change opens the door to more advanced CPU topology configurations, like detailing sockets, threads and core-count separately. This more advanced CPU topology is a prerequisite for enabling vertical scaling features like CPU hotplug.

</details>