### PR TITLE
feat: add s3 retention config for etcd snapshots

### DIFF
--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -13,6 +13,7 @@ destructuring
 eks
 eslint
 esm
+etcd
 git
 github
 gke

--- a/custom_words.txt
+++ b/custom_words.txt
@@ -13,6 +13,7 @@ destructuring
 eks
 eslint
 esm
+etcd
 git
 github
 gke

--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -1273,6 +1273,7 @@ This argument is available in Rancher v2.7.2 and later.
 * `endpoint_ca` - (Optional, string) ETCD snapshot S3 endpoint CA.
 * `folder` - (Optional, string) ETCD snapshot S3 folder.
 * `region` - (Optional, string) ETCD snapshot S3 region.
+* `retention` - (Optional, int) Number of snapshots in S3 to retain. If not set, the `snapshot_retention` value is used.
 * `skip_ssl_verify` - (Optional, bool, default: false) Disable ETCD skip ssl verify.
 
 ##### `rotate_certificates`

--- a/rancher2/schema_cluster_v2_rke_config_etcd.go
+++ b/rancher2/schema_cluster_v2_rke_config_etcd.go
@@ -38,6 +38,11 @@ func clusterV2RKEConfigETCDSnapshotS3Fields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "ETCD snapshot S3 region",
 		},
+		"retention": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Number of snapshots in S3 to retain",
+		},
 		"skip_ssl_verify": {
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -65,7 +70,7 @@ func clusterV2RKEConfigETCDFields() map[string]*schema.Schema {
 		"snapshot_retention": {
 			Type:        schema.TypeInt,
 			Optional:    true,
-			Description: "ETCD snapshot retention",
+			Description: "Number of snapshots to retain",
 		},
 		"s3_config": {
 			Type:        schema.TypeList,

--- a/rancher2/structure_cluster_v2_rke_config_etcd.go
+++ b/rancher2/structure_cluster_v2_rke_config_etcd.go
@@ -31,6 +31,9 @@ func flattenClusterV2RKEConfigETCDSnapshotS3(in *rkev1.ETCDSnapshotS3) []interfa
 	if len(in.Region) > 0 {
 		obj["region"] = in.Region
 	}
+	if in.Retention > 0 {
+		obj["retention"] = in.Retention
+	}
 	obj["skip_ssl_verify"] = in.SkipSSLVerify
 
 	return []interface{}{obj}
@@ -86,6 +89,9 @@ func expandClusterV2RKEConfigETCDSnapshotS3(p []interface{}) *rkev1.ETCDSnapshot
 	}
 	if v, ok := in["region"].(string); ok && len(v) > 0 {
 		obj.Region = v
+	}
+	if v, ok := in["retention"].(int); ok && v > 0 {
+		obj.Retention = v
 	}
 	obj.SkipSSLVerify = in["skip_ssl_verify"].(bool)
 

--- a/rancher2/structure_cluster_v2_rke_config_etcd_test.go
+++ b/rancher2/structure_cluster_v2_rke_config_etcd_test.go
@@ -24,6 +24,7 @@ func init() {
 		EndpointCA:          "endpoint_ca",
 		Folder:              "folder",
 		Region:              "region",
+		Retention:           5,
 		SkipSSLVerify:       true,
 	}
 
@@ -35,6 +36,7 @@ func init() {
 			"endpoint_ca":           "endpoint_ca",
 			"folder":                "folder",
 			"region":                "region",
+			"retention":             5,
 			"skip_ssl_verify":       true,
 		},
 	}


### PR DESCRIPTION
Rancher now supports a separate retention count for S3-stored etcd snapshots, independent of the local snapshot_retention value.

<!--- If there is no user issue related to this then you should remove the next line --->
- Addresses #2126
<!--- Add labels (eg. release/v15) for each release branch to target --->
<!--- Please don't manually add "internal" labels, those are for automation only --->

## Description
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->


## Testing
My current cluster is configured with the following etcd configuration in rancher2_cluster_v2.rke_config.etcd
```terraform
    etcd {
      snapshot_retention = 2
      ...
      s3_config {
        ...
      }
    }
```

Updating the provider doesn't make any changes to the existing cluster configuration.

Next updating the provider and setting retention = 3 results in the following changes
```
  # module.downstream_cluster[0].module.cluster.rancher2_cluster_v2.main will be updated in-place
  ~ resource "rancher2_cluster_v2" "main" {
        id                           = "..."
        name                         = "..."
        # (10 unchanged attributes hidden)

      ~ rke_config {
            # (3 unchanged attributes hidden)

          ~ etcd {
                # (3 unchanged attributes hidden)

              ~ s3_config {
                  ~ retention             = 0 -> 3
                    # (7 unchanged attributes hidden)
                }
            }

            # (10 unchanged blocks hidden)
        }

        # (1 unchanged block hidden)
    }
```


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? -->
<!--- If so, change the following line with an explanation. --->
Not a breaking change.
