### PR TITLE
feat: add http put response hop limit to amazonec2 machine config

### DIFF
--- a/rancher2/schema_machine_config_v2_amazonec2.go
+++ b/rancher2/schema_machine_config_v2_amazonec2.go
@@ -79,6 +79,12 @@ func machineConfigV2Amazonec2Fields() map[string]*schema.Schema {
 			Optional:    true,
 			Description: "The state of token usage for your instance metadata requests",
 		},
+		"http_put_response_hop_limit": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "2",
+			Description: "The desired HTTP PUT response hop limit for instance metadata requests",
+		},
 		"iam_instance_profile": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/rancher2/structure_machine_config_v2_amazonec2.go
+++ b/rancher2/structure_machine_config_v2_amazonec2.go
@@ -1,6 +1,7 @@
 package rancher2
 
 import (
+
 	norman "github.com/rancher/norman/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,6 +26,7 @@ type machineConfigV2Amazonec2 struct {
 	Endpoint                string   `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 	HTTPEndpoint            string   `json:"httpEndpoint,omitempty" yaml:"httpEndpoint,omitempty"`
 	HTTPTokens              string   `json:"httpTokens,omitempty" yaml:"httpTokens,omitempty"`
+	HTTPPutResponseHopLimit string   `json:"httpPutResponseHopLimit,omitempty" yaml:"httpPutResponseHopLimit,omitempty"`
 	IamInstanceProfile      string   `json:"iamInstanceProfile,omitempty" yaml:"iamInstanceProfile,omitempty"`
 	InsecureTransport       bool     `json:"insecureTransport,omitempty" yaml:"insecureTransport,omitempty"`
 	InstanceType            string   `json:"instanceType,omitempty" yaml:"instanceType,omitempty"`
@@ -108,6 +110,9 @@ func flattenMachineConfigV2Amazonec2(in *MachineConfigV2Amazonec2) []interface{}
 	}
 	if len(in.HTTPTokens) > 0 {
 		obj["http_tokens"] = in.HTTPTokens
+	}
+	if len(in.HTTPPutResponseHopLimit) > 0 {
+		obj["http_put_response_hop_limit"] = in.HTTPPutResponseHopLimit
 	}
 
 	if len(in.IamInstanceProfile) > 0 {
@@ -253,6 +258,9 @@ func expandMachineConfigV2Amazonec2(p []interface{}, source *MachineConfigV2) *M
 	}
 	if v, ok := in["http_tokens"].(string); ok && len(v) > 0 {
 		obj.HTTPTokens = v
+	}
+	if v, ok := in["http_put_response_hop_limit"].(string); ok && len(v) > 0 {
+		obj.HTTPPutResponseHopLimit = v
 	}
 
 	if v, ok := in["iam_instance_profile"].(string); ok && len(v) > 0 {


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->

Addresses [#56145](https://github.com/rancher/rancher/issues/56145)
https://github.com/rancher/terraform-provider-rancher2/issues/2327
## Description

Adds support for the `http_put_response_hop_limit` field to the Amazon EC2 machine configuration, including schema, expand, and flatten handling.

## Testing

Verified the provider builds successfully.

Not a breaking change.
