### PR TITLE
fix: manual release workflows broken by containerization

### DIFF
--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -17,8 +17,10 @@ permissions: {}
 jobs:
   rc-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
+    environment: release
     permissions:
       contents: write
       id-token: write
@@ -82,17 +84,16 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag }}
-          path: ${{ github.workspace }}/tags/${{ inputs.tag }}
+          path: tags/${{ inputs.tag }}
       - name: Prepare Registry Manifest
         id: prepare-registry-manifest
         env:
-          WORKSPACE: ${{ github.workspace }}
           TAG: ${{ inputs.tag }}
         run: |
           # remove any tags that are not the one specified (to avoid goreleaser confusion)
           DIR="$(pwd)"
-          cd "$WORKSPACE/tags/$TAG"
-          tags_to_delete=$(git tag | grep -v -e "^$TAG$")
+          cd "$GITHUB_WORKSPACE/tags/$TAG"
+          tags_to_delete=$(git tag | grep -v -x -F -e "$TAG" || true)
           if [ -n "$tags_to_delete" ]; then
             echo "$tags_to_delete" | xargs git tag -d
           fi
@@ -145,6 +146,10 @@ jobs:
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
           TAG: ${{ inputs.tag }}
+        # Expansion is deliberately deferred to the inner Nix shell: GITHUB_WORKSPACE and
+        # TAG are on the --keep allowlist in nix-run.sh, which starts that shell with
+        # --ignore-environment. Deferring also keeps the step injection-safe, because the
+        # inner shell expands $TAG rather than re-parsing it as source.
         run: .github/workflows/scripts/nix-run.sh bash -c "cd \"\$GITHUB_WORKSPACE/tags/\$TAG\" && goreleaser release --clean --skip=validate --config ../../.goreleaser_rc.yml"
       - name: 'Find Issues and Create Comments'
         id: find-issues-create-comments

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -14,8 +14,10 @@ permissions: {}
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
       image: ghcr.io/rancher/ci-image/nix:20260603-18
+    environment: release
     permissions:
       contents: write
       id-token: write
@@ -75,17 +77,16 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.tag }}
-          path: ${{ github.workspace }}/tags/${{ inputs.tag }}
+          path: tags/${{ inputs.tag }}
       - name: Prepare Registry Manifest
         id: prepare-registry-manifest
         env:
-          WORKSPACE: ${{ github.workspace }}
           TAG: ${{ inputs.tag }}
         run: |
           # remove any tags that are not the one specified (to avoid goreleaser confusion)
           DIR="$(pwd)"
-          cd "$WORKSPACE/tags/$TAG"
-          tags_to_delete=$(git tag | grep -v -e "^$TAG$")
+          cd "$GITHUB_WORKSPACE/tags/$TAG"
+          tags_to_delete=$(git tag | grep -v -x -F -e "$TAG" || true)
           if [ -n "$tags_to_delete" ]; then
             echo "$tags_to_delete" | xargs git tag -d
           fi
@@ -138,4 +139,8 @@ jobs:
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
           TAG: ${{ inputs.tag }}
+        # Expansion is deliberately deferred to the inner Nix shell: GITHUB_WORKSPACE and
+        # TAG are on the --keep allowlist in nix-run.sh, which starts that shell with
+        # --ignore-environment. Deferring also keeps the step injection-safe, because the
+        # inner shell expands $TAG rather than re-parsing it as source.
         run: .github/workflows/scripts/nix-run.sh bash -c "cd \"\$GITHUB_WORKSPACE/tags/\$TAG\" && goreleaser release --clean --skip=validate --config ../../.goreleaser.yml"

--- a/.github/workflows/scripts/nix-run.sh
+++ b/.github/workflows/scripts/nix-run.sh
@@ -49,6 +49,7 @@ sudo -E -u suse /home/suse/.nix-profile/bin/nix develop \
   --keep SSH_AUTH_SOCK \
   --keep GITHUB_TOKEN \
   --keep GITHUB_OWNER \
+  --keep GITHUB_WORKSPACE \
   --keep AWS_ACCESS_KEY_ID \
   --keep AWS_SECRET_ACCESS_KEY \
   --keep AWS_SESSION_TOKEN \
@@ -59,6 +60,7 @@ sudo -E -u suse /home/suse/.nix-profile/bin/nix develop \
   --keep ZONE \
   --keep ACME_SERVER_URL \
   --keep PR_NUMBER \
+  --keep TAG \
   --keep GPG_PASSPHRASE \
   --keep GPG_KEY_ID \
   --keep GPG_KEY \


### PR DESCRIPTION
## Problem

The `Manually Create RC Release` workflow fails at the `Prepare Registry Manifest` step ([run 31718150932](https://github.com/rancher/terraform-provider-rancher2/actions/runs/31718150932), exit 1). Commit 2baf25d9 moved the manual release jobs into the `ghcr.io/rancher/ci-image/nix` container but left the path handling unchanged, so the step `cd`s to a host path that does not exist inside the container.

This currently blocks all RC releases. The failed run pushed tag `v15.0.0-rc.13` with no release attached; it is being left in place as a dangling tag.

## Fixes

Applied to both `manual-rc-release.yml` and `manual-release.yml`, which carried the defects verbatim:

1. **Container path breakage (root cause).** `${{ github.workspace }}` is evaluated on the *host* (`/home/runner/work/<repo>/<repo>`), which is unreachable from inside the container (`/__w/<repo>/<repo>`). `actions/checkout` translates host paths internally, but plain `run:` steps do not. The checkout `path:` is now the container-agnostic relative form, and the step uses `$GITHUB_WORKSPACE` (the in-container env var) instead of a `WORKSPACE` env entry.

2. **Latent `set -e` abort.** `tags_to_delete=$(git tag | grep -v ...)` inherits the substitution's exit status, so an empty `grep` result kills the step under the container's default `sh -e` shell. This survived historically by coincidence: for `v13.2.0-rc.1` the checkout tag glob `refs/tags/<tag>*` also matched `rc.10`, `rc.11`, … leaving residue for `grep -v` to print. A tag with no numeric siblings (e.g. `v15.0.0-rc.13`) returns empty and aborts. Now suffixed with `|| true`, with the empty case already handled by the following `if [ -n ... ]` guard.

3. **Empty expansion across the Nix boundary.** `nix-run.sh` starts the shell with `nix develop --ignore-environment` and an explicit `--keep` allowlist. Neither `GITHUB_WORKSPACE` nor `TAG` was on it, so the deferred `\$GITHUB_WORKSPACE/tags/\$TAG` expanded to empty inside the Nix shell and the step would `cd /tags/` — failing immediately once fix 1 unblocked it. Both variables are now on the allowlist, fixing this at its root rather than at each call site.

## Also included

- `timeout-minutes: 30` on both jobs, per `.agent/rules/workflows.instructions.md` §2, matching the equivalent GoReleaser jobs in `release.yml`.
- `environment: release` on both jobs, matching `release.yml`. Note: this environment does not yet exist in repository settings, so GitHub will auto-create it with no protection rules — it is a hook that still needs required reviewers configured to provide real protection. The same gap already applies to `release.yml`.
- The tag-pruning filter is now `grep -v -x -F -e "$TAG"`. The previous `grep -v -e "^$TAG$"` treated the tag as a basic regular expression, so `.` matched any character; releasing `v15.0.0-rc.14` would wrongly preserve a sibling tag `v15x0.0-rc.14`.

## Verification

- `actionlint` passes on both workflows; `shellcheck` passes on `nix-run.sh`.
- The corrected `Prepare Registry Manifest` body was run under `sh -e` against a scratch repo containing exactly one tag, confirming it no longer aborts.
- The `Run GoReleaser` invocation was emulated end-to-end through `nix-run.sh`'s `printf %q` serialisation under a cleared environment, confirming three behaviours: a benign tag reaches the correct directory; a tag containing shell metacharacters is treated as a literal path component and is never re-parsed as code; and removing the variables from the allowlist fails loudly with exit 1 rather than silently releasing from the wrong tree.

## Follow-up (deliberately out of scope)

- Extract the multi-line `Prepare Registry Manifest` body into `.github/workflows/scripts/` (`shellcheck` reports SC2164 on its two `cd` calls when run standalone — not a live bug, since the step runs under `sh -e`).
- The `|| true` above also masks a genuine `git tag` failure.
- Dead `DIR="$(pwd)"` / `cd "$DIR"` round-trip.
- Configure protection rules on the `release` environment.