### PR TITLE
fix: import gpg signing key inside the nix shell that runs goreleaser

### DIFF
--- a/.github/workflows/manual-rc-release.yml
+++ b/.github/workflows/manual-rc-release.yml
@@ -119,38 +119,22 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/signing/gpg passphrase | GPG_PASSPHRASE ;
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKeyId | GPG_KEY_ID ;
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
-      - name: import_gpg_key
-        id: import-gpg-key
-        env:
-          GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
-          GPG_KEY: ${{ env.GPG_KEY }}
-        run: |
-          cleanup() {
-            # clear history just in case
-            history -c
-          }
-          trap cleanup EXIT TERM
-
-          # sanitize variables
-          if [ -z "${GPG_PASSPHRASE}" ]; then echo "gpg passphrase empty"; exit 1; fi
-          if [ -z "${GPG_KEY_ID}" ]; then echo "key id empty"; exit 1; fi
-          if [ -z "${GPG_KEY}" ]; then echo "key contents empty"; exit 1; fi
-
-          echo "Importing gpg key"
-          echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - name: Run GoReleaser
         id: run-goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+          GPG_KEY: ${{ env.GPG_KEY }}
           TAG: ${{ inputs.tag }}
-        # Expansion is deliberately deferred to the inner Nix shell: GITHUB_WORKSPACE and
-        # TAG are on the --keep allowlist in nix-run.sh, which starts that shell with
-        # --ignore-environment. Deferring also keeps the step injection-safe, because the
-        # inner shell expands $TAG rather than re-parsing it as source.
-        run: .github/workflows/scripts/nix-run.sh bash -c "cd \"\$GITHUB_WORKSPACE/tags/\$TAG\" && goreleaser release --clean --skip=validate --config ../../.goreleaser_rc.yml"
+          # Relative to the repository root, which is where nix-run.sh starts. Avoids
+          # having to name the workspace, whose path differs inside the container.
+          WORKING_DIR: tags/${{ inputs.tag }}
+          GORELEASER_CONFIG: ../../.goreleaser_rc.yml
+          SKIP_VALIDATE: 'true'
+        # The key must be imported by the same 'suse' user that nix-run.sh drops to,
+        # so goreleaser.sh does the import itself rather than a separate step as root.
+        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/goreleaser.sh
       - name: 'Find Issues and Create Comments'
         id: find-issues-create-comments
         # https://github.com/actions/github-script/releases

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -112,35 +112,19 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/signing/gpg passphrase | GPG_PASSPHRASE ;
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKeyId | GPG_KEY_ID ;
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
-      - name: import_gpg_key
-        id: import-gpg-key
-        env:
-          GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
-          GPG_KEY: ${{ env.GPG_KEY }}
-        run: |
-          cleanup() {
-            # clear history just in case
-            history -c
-          }
-          trap cleanup EXIT TERM
-
-          # sanitize variables
-          if [ -z "${GPG_PASSPHRASE}" ]; then echo "gpg passphrase empty"; exit 1; fi
-          if [ -z "${GPG_KEY_ID}" ]; then echo "key id empty"; exit 1; fi
-          if [ -z "${GPG_KEY}" ]; then echo "key contents empty"; exit 1; fi
-
-          echo "Importing gpg key"
-          echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - name: Run GoReleaser
         id: run-goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+          GPG_KEY: ${{ env.GPG_KEY }}
           TAG: ${{ inputs.tag }}
-        # Expansion is deliberately deferred to the inner Nix shell: GITHUB_WORKSPACE and
-        # TAG are on the --keep allowlist in nix-run.sh, which starts that shell with
-        # --ignore-environment. Deferring also keeps the step injection-safe, because the
-        # inner shell expands $TAG rather than re-parsing it as source.
-        run: .github/workflows/scripts/nix-run.sh bash -c "cd \"\$GITHUB_WORKSPACE/tags/\$TAG\" && goreleaser release --clean --skip=validate --config ../../.goreleaser.yml"
+          # Relative to the repository root, which is where nix-run.sh starts. Avoids
+          # having to name the workspace, whose path differs inside the container.
+          WORKING_DIR: tags/${{ inputs.tag }}
+          GORELEASER_CONFIG: ../../.goreleaser.yml
+          SKIP_VALIDATE: 'true'
+        # The key must be imported by the same 'suse' user that nix-run.sh drops to,
+        # so goreleaser.sh does the import itself rather than a separate step as root.
+        run: .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/goreleaser.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,30 +467,18 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/signing/gpg passphrase | GPG_PASSPHRASE ;
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKeyId | GPG_KEY_ID ;
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
-      - name: import_gpg_key
-        id: import-gpg-key
-        env:
-          GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
-          GPG_KEY: ${{ env.GPG_KEY }}
-        run: |
-          cleanup() {
-            history -c
-          }
-          trap cleanup EXIT TERM
-          if [ -z "${GPG_PASSPHRASE}" ]; then echo "gpg passphrase empty"; exit 1; fi
-          if [ -z "${GPG_KEY_ID}" ]; then echo "key id empty"; exit 1; fi
-          if [ -z "${GPG_KEY}" ]; then echo "key contents empty"; exit 1; fi
-          echo "Importing gpg key"
-          echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - name: Run GoReleaser
         id: run-goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+          GPG_KEY: ${{ env.GPG_KEY }}
+          GORELEASER_CONFIG: .goreleaser_rc.yml
+        # The key must be imported by the same 'suse' user that nix-run.sh drops to,
+        # so goreleaser.sh does the import itself rather than a separate step as root.
         run: |-
-          .github/workflows/scripts/nix-run.sh goreleaser release --clean --config .goreleaser_rc.yml
+          .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/goreleaser.sh
       - name: 'Find Issues and Create Comments'
         id: find-issues-create-comments
         # https://github.com/actions/github-script/releases
@@ -545,30 +533,18 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/signing/gpg passphrase | GPG_PASSPHRASE ;
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKeyId | GPG_KEY_ID ;
             secret/data/github/repo/${{ github.repository }}/signing/gpg privateKey | GPG_KEY
-      - name: import_gpg_key
-        id: import-gpg-key
-        env:
-          GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
-          GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
-          GPG_KEY: ${{ env.GPG_KEY }}
-        run: |
-          cleanup() {
-            history -c
-          }
-          trap cleanup EXIT TERM
-          if [ -z "${GPG_PASSPHRASE}" ]; then echo "gpg passphrase empty"; exit 1; fi
-          if [ -z "${GPG_KEY_ID}" ]; then echo "key id empty"; exit 1; fi
-          if [ -z "${GPG_KEY}" ]; then echo "key contents empty"; exit 1; fi
-          echo "Importing gpg key"
-          echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Failed to import GPG key"; exit 1; }
       - name: Run GoReleaser
         id: run-goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY_ID: ${{ env.GPG_KEY_ID }}
           GPG_PASSPHRASE: ${{ env.GPG_PASSPHRASE }}
+          GPG_KEY: ${{ env.GPG_KEY }}
+          GORELEASER_CONFIG: .goreleaser.yml
+        # The key must be imported by the same 'suse' user that nix-run.sh drops to,
+        # so goreleaser.sh does the import itself rather than a separate step as root.
         run: |-
-          .github/workflows/scripts/nix-run.sh goreleaser release --clean --config .goreleaser.yml
+          .github/workflows/scripts/nix-run.sh bash .github/workflows/scripts/goreleaser.sh
       - name: Publish Release
         id: publish-release
         # https://github.com/actions/github-script/releases

--- a/.github/workflows/scripts/goreleaser.sh
+++ b/.github/workflows/scripts/goreleaser.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Imports the release signing key and runs GoReleaser.
+#
+# This MUST run inside nix-run.sh. nix-run.sh drops privileges to the 'suse' user,
+# so a GPG key imported by an earlier workflow step (which runs as root) lands in
+# root's keyring and is invisible here. Importing in the same shell that invokes
+# goreleaser is what keeps the key and the signer in the same GnuPG home.
+#
+# Environment (all must be on the --keep allowlist in nix-run.sh):
+#   GPG_KEY          - ASCII-armored private key                    (required)
+#   GPG_KEY_ID       - key id, used by goreleaser as --local-user   (required)
+#   GPG_PASSPHRASE   - passphrase for the private key               (required)
+#   WORKING_DIR      - directory to release from, relative or absolute (optional)
+#   GORELEASER_CONFIG- config path, relative to WORKING_DIR (default .goreleaser.yml)
+#   SKIP_VALIDATE    - "true" to pass --skip=validate               (optional)
+
+set -euo pipefail
+
+cleanup() {
+  # clear history just in case
+  history -c || true
+}
+trap cleanup EXIT TERM
+
+# Support releasing from a tag checked out into a subdirectory (manual releases)
+if [[ -n "${WORKING_DIR:-}" ]]; then
+  cd "${WORKING_DIR}"
+fi
+
+# sanitize variables
+if [[ -z "${GPG_PASSPHRASE:-}" ]]; then echo "Error: gpg passphrase empty" >&2; exit 1; fi
+if [[ -z "${GPG_KEY_ID:-}" ]]; then echo "Error: key id empty" >&2; exit 1; fi
+if [[ -z "${GPG_KEY:-}" ]]; then echo "Error: key contents empty" >&2; exit 1; fi
+
+# Trim whitespace/newlines so the key id matches what GPG reports
+export GPG_KEY_ID
+GPG_KEY_ID=$(echo -n "${GPG_KEY_ID}" | tr -d '[:space:]')
+
+echo "Importing gpg key"
+echo "${GPG_KEY}" | gpg --import --batch > /dev/null || { echo "Error: Failed to import GPG key" >&2; exit 1; }
+
+# Prefer the secret primary key id actually present in the keyring. Vault may hold
+# the id of an encryption subkey, which cannot sign. '|| true' avoids tripping
+# pipefail when grep matches nothing.
+SEC_LINE=$(gpg --batch --list-secret-keys --keyid-format LONG | grep -E '^sec' | head -n1 || true)
+if [[ -n "${SEC_LINE}" ]]; then
+  DETECTED_KEY_ID=$(echo "${SEC_LINE}" | awk '{print $2}' | cut -d'/' -f2)
+  if [[ -n "${DETECTED_KEY_ID}" ]]; then
+    echo "Detected gpg key id from imported key: ${DETECTED_KEY_ID}"
+    GPG_KEY_ID="${DETECTED_KEY_ID}"
+  fi
+fi
+
+# https://www.gnupg.org/documentation/manuals/gnupg24/gpg.1.html
+# https://goreleaser.com/customization/sign/sign/
+# troubleshooting information
+gpg --version
+# this only lists UIDs, no secret material
+gpg --batch --list-secret-keys --keyid-format LONG
+# this fails loudly here rather than deep inside a 17 minute goreleaser run
+gpg --batch --list-secret-keys --keyid-format LONG "${GPG_KEY_ID}" >/dev/null
+# troubleshooting information
+goreleaser --version
+
+CONFIG_FILE="${GORELEASER_CONFIG:-.goreleaser.yml}"
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  echo "Error: ${CONFIG_FILE} not found (working directory: $(pwd))" >&2
+  exit 1
+fi
+
+extra_args=()
+if [[ "${SKIP_VALIDATE:-false}" == "true" ]]; then
+  extra_args+=("--skip=validate")
+fi
+
+goreleaser release --clean --config "${CONFIG_FILE}" "${extra_args[@]+"${extra_args[@]}"}"

--- a/.github/workflows/scripts/nix-run.sh
+++ b/.github/workflows/scripts/nix-run.sh
@@ -64,4 +64,7 @@ sudo -E -u suse /home/suse/.nix-profile/bin/nix develop \
   --keep GPG_PASSPHRASE \
   --keep GPG_KEY_ID \
   --keep GPG_KEY \
+  --keep WORKING_DIR \
+  --keep GORELEASER_CONFIG \
+  --keep SKIP_VALIDATE \
   --command bash -e .nix-script.sh


### PR DESCRIPTION
## Problem

`manual-rc-release` run [31745926734](https://github.com/rancher/terraform-provider-rancher2/actions/runs/31745926734) got all the way through a 17 minute build and then failed at the last step:

```
• signing artifacts
  • signing  cmd=gpg artifact=terraform-provider-rancher2_15.0.0-rc.14_SHA256SUMS
⨯ release failed after 17m13s  error=exit status 2 message=could not sign artifact
  │ gpg: directory '/home/suse/.gnupg' created
  │ gpg: skipped "***": No secret key
  │ gpg: signing failed: No secret key
```

The `import_gpg_key` step runs as `root`, so the key landed in root's keyring. `nix-run.sh` drops privileges with `sudo -E -u suse`, so GoReleaser's `gpg` looked in a brand new, empty `/home/suse/.gnupg`. The giveaway is that GnuPG had to *create* that directory — nothing had ever written to it.

This affects every release path, not just the one that failed: both jobs in `release.yml` have the same split between a root-level import and a `nix-run.sh` GoReleaser call.

## Fix

Move the import into the same shell that runs GoReleaser, via a new `.github/workflows/scripts/goreleaser.sh`. Key and signer now share a GnuPG home by construction.

The script also resolves the signing key id from the keyring instead of trusting Vault's `privateKeyId`, which can point at an encryption subkey that cannot sign, and preflights `gpg --list-secret-keys "$GPG_KEY_ID"` so a keyring problem fails in seconds rather than after a full build.

`WORKING_DIR`, `GORELEASER_CONFIG` and `SKIP_VALIDATE` are added to the `--keep` allowlist in `nix-run.sh`, since `nix develop --ignore-environment` would otherwise drop them. `WORKING_DIR` is passed relative to the repo root, which sidesteps the container/host workspace path difference that caused #2376.

## Verification

Linted with `actionlint` and `shellcheck` (both clean), and exercised against stub `gpg`/`goreleaser` binaries:

- key present, Vault supplies a **subkey** id → resolves to the secret primary key, exports it so GoReleaser's `--local-user {{ .Env.GPG_KEY_ID }}` picks it up, `cd`s into the tag dir, appends `--skip=validate`
- **key absent** (the bug above) → exits 2 at the preflight check, before any build work
- missing config → exits 1 naming the file and working directory
- empty `GPG_KEY` → exits 1
- hostile tag such as `v1";echo PWNED;"` → inert, `cd` fails and nothing is re-parsed as shell source

## Note

The `v15.0.0-rc.14` tag was pushed before the signing step failed, but no release was published, so it is a dangling tag like `rc.13`. A retry needs a fresh tag (`v15.0.0-rc.15`).