### PR TITLE
feat: add secure agent commit and push gating skills

### DIFF
--- a/.agent/hooks/block-rancher-git.js
+++ b/.agent/hooks/block-rancher-git.js
@@ -1,22 +1,23 @@
 #!/usr/bin/env node
 //
-// Runs as a PreToolUse (Claude Code) / BeforeTool (Gemini) hook. Both hosts send the
-// same stdin shape (tool_name, tool_input, cwd) but use different tool-name vocabularies
-// and different decision fields, so allow()/deny() below emit a JSON object that satisfies
-// both: top-level decision/reason (Gemini) plus hookSpecificOutput.permissionDecision
-// (Claude Code). Each host reads only the fields it recognizes and ignores the rest.
-import { execSync, execFileSync } from 'child_process';
+// Hook for Claude Code & Gemini. Both share stdin shape but use different output schemas.
+// Emits a unified JSON payload with Gemini's top-level decision/reason and Claude's
+// hookSpecificOutput; each host reads only the fields it recognizes and ignores the rest.
+import { execFileSync, execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
 // Claude Code's shell tool vs Gemini's
 const SHELL_TOOL_NAMES = new Set(['run_shell_command', 'Bash']);
 
-// Claude Code validates the whole hook output against a schema where top-level
-// `decision` only accepts "approve"|"block" — "allow"/"deny" (Gemini's values) fail
-// that validation and silently drop the entire payload, including hookSpecificOutput.
-// So the top-level decision/reason pair is only emitted for Gemini; Claude Code reads
-// hookSpecificOutput.permissionDecision instead, which is present either way.
+// Match the URL owner segment exactly (`/:/`) to prevent false
+// positives on safe forks. A blanket `/rancher/i` substring test would match the repo
+// name ("terraform-provider-rancher2") on all remotes, breaking the check.
+const RANCHER_OWNER_RE = /[/:](rancher|rancherlabs)\//i;
+
+// Gemini reads top-level "allow"/"deny", while Claude Code requires "hookSpecificOutput".
+// Emitting "allow"/"deny" at the top level for Claude Code causes schema validation 
+// failures that drop the entire payload, so it's only included when responding to Gemini.
 function allow(isClaudeCode) {
   console.log(JSON.stringify(isClaudeCode ? {} : { decision: "allow" }));
   process.exit(0);
@@ -83,9 +84,8 @@ function main() {
     isBranchSwitch = true;
   } else if (/\bgit\s+checkout\b/.test(commandClean)) {
     // Check if it is a file-only checkout.
-    // A file checkout is characterized by:
-    // 1. It contains " -- " followed by a file path, e.g. "git checkout -- file.js".
-    // 2. Or the arguments (excluding flags like -f, -q) correspond to existing files/folders on disk.
+    // 1. The presence of " -- " before a file path.
+    // 2. Or non-flag arguments matching existing files/folders on disk.
     const hasDoubleDash = commandClean.includes(' -- ');
     if (hasDoubleDash) {
       isBranchSwitch = false;
@@ -179,34 +179,29 @@ function main() {
     );
   }
 
-  // Check if it is a git command and performs a remote-interacting operation. Matched
-  // unanchored (not "immediately after git") so a leading global flag like `git -C /tmp
-  // fetch ...` can't slip past this gate entirely — it only needs to appear somewhere in
-  // the command, same as the original (pre-narrowing) check did.
-  const isGitCmd = /^(?:sudo\s+)?git\b/.test(commandClean);
-  const isRemoteOp = /\b(push|pull|fetch|clone|remote)\b/.test(commandClean);
+  // Check for remote-interacting git commands, preventing bypasses and text false positives.
+  // "git" must be at a command boundary, and its subcommand separator must stay on the same line.
+  // Normalizes line continuations to spaces and supports `sudo` with optional flags.
+  const remoteOpCheckTarget = commandClean.replace(/\\\r?\n[ \t]*/g, ' ');
+  const isRemoteOp = /(?:^|[;&|`(){]|\$\(|\n)[ \t]*(?:sudo[ \t]+(?:[^\s;&|`(){]+[ \t]+)*?)?git[ \t]+(?:[^\s;&|`(){]+[ \t]+)*?(push|pull|fetch|clone|remote)\b/.test(remoteOpCheckTarget);
 
-  if (isGitCmd && isRemoteOp) {
+  if (isRemoteOp) {
     const targetDir = tool_input.dir_path || cwd || process.cwd();
 
-    // Identify the subcommand by exact whole-token match, not by searching for the keyword
-    // as a substring anywhere in the command — a `\b`-bounded substring search would still
-    // match "remote"/"clone"/etc. inside an unrelated argument like a `-C /tmp/remote-mirror`
-    // path segment appearing before the real subcommand, misclassifying it and skipping the
-    // actual safety check below entirely.
-    const commandTokens = commandClean.split(/\s+/).filter(Boolean);
+    // Match the subcommand exactly to prevent false positives (e.g., `-C /tmp/remote-mirror`).
+    // Strip shell grouping punctuation from tokens so wrapped commands like `(git fetch origin)`
+    // don't leave trailing parenthesis attached, which would break remote name lookups.
+    const stripGroupingPunct = (t) => t.replace(/^[(){}]+/, '').replace(/[(){};]+$/, '');
+    const commandTokens = commandClean.split(/\s+/).filter(Boolean).map(stripGroupingPunct).filter(Boolean);
     const subcommandIndex = commandTokens.findIndex((t, i) => i > 0 && /^(push|pull|fetch|clone|remote)$/.test(t));
     const subcommand = subcommandIndex !== -1 ? commandTokens[subcommandIndex] : null;
     const remainingArgs = subcommandIndex !== -1 ? commandTokens.slice(subcommandIndex + 1) : [];
     const nonFlagArgs = remainingArgs.filter(a => !a.startsWith('-'));
     const remoteAction = nonFlagArgs[0];
 
-    // `git remote` read-only forms (bare, -v, show, get-url) and mutations that don't
-    // introduce a URL (remove/rm/rename) can't leak or introduce anything, so they must stay
-    // usable no matter what — including when the remote being removed/renamed is merely
-    // NAMED with "rancher" in it. This runs before the literal-text scan below specifically
-    // so that case doesn't get caught by it; denying it is exactly what traps a repo with a
-    // rancher-pointing remote in an unrecoverable blocked state.
+    // Allow read-only/non-URL `git remote` actions (e.g., rm, rename, show, -v).
+    // This runs before the Rancher literal-text scan so users can remove/rename existing
+    // rancher-pointing remotes without getting permanently blocked by the safety hook.
     const NON_URL_REMOTE_ACTIONS = new Set(['remove', 'rm', 'rename', 'show', 'get-url']);
     const isSafeRemoteAction = subcommand === 'remote' &&
       (!remoteAction || NON_URL_REMOTE_ACTIONS.has(remoteAction) || remainingArgs.includes('-v'));
@@ -214,10 +209,16 @@ function main() {
       allow(isClaudeCode);
     }
 
-    // Check command string directly to catch inline URL references or remote additions
-    // Ignore false positives from the filename "block-rancher-git.js"
-    const hasRancherRef = /rancher/i.test(command.replace(/block-rancher-git\.js/g, ''));
-    if (hasRancherRef) {
+    // Check command tokens directly to catch inline URL/SSH references or remote additions,
+    // while ignoring false positives from local filesystem paths containing "rancher" (e.g. git -C /home/me/rancher/repo).
+    const isUrlOrSshRef = (token) => {
+      return /^[a-z0-9+.-]+:\/\//i.test(token) || /^([^@:\s]+@)?[a-z0-9.-]+\.[a-z]{2,}:[^\s]+$/i.test(token);
+    };
+    const hasInlineRancherRef = commandTokens.some(token => {
+      if (token.includes('block-rancher-git.js')) return false;
+      return RANCHER_OWNER_RE.test(token) && isUrlOrSshRef(token);
+    });
+    if (hasInlineRancherRef) {
       deny(
         "Security Policy Violation: Git command contains references to Rancher remote/URLs, which is strictly blocked.",
         "🔒 Security Block: Prohibited remote/URL reference detected.",
@@ -226,51 +227,109 @@ function main() {
     }
 
     // `git clone <url>` targets a brand-new location, not this repo's configured remotes —
-    // hasRancherRef above already covers a literal rancher URL in the command.
+    // hasInlineRancherRef above already covers a literal rancher URL in the command.
     if (subcommand === 'clone') {
       allow(isClaudeCode);
     }
 
-    // Only a URL-introducing `remote` action (add/set-url) reaches here; hasRancherRef above
+    // Only a URL-introducing `remote` action (add/set-url) reaches here; hasInlineRancherRef above
     // already denies if the new name/URL mentions "rancher", and no pre-existing remote needs
-    // consulting for those actions.
-    if (subcommand === 'remote') {
+    // consulting for those actions. Exclude 'git remote update' as it triggers network fetches.
+    if (subcommand === 'remote' && remoteAction !== 'update') {
       allow(isClaudeCode);
     }
 
-    // push/pull/fetch: only deny when the SPECIFIC remote this command targets points at
-    // rancher — not just because some other configured remote (e.g. a temporary `upstream`
-    // added by a sync script) happens to. Falls back to checking every configured remote
-    // whenever we can't confidently resolve a single target — either no remote was named
-    // explicitly, or the first non-flag token isn't actually a saved remote (e.g. a flag's
-    // separate-token value like the `1` in `--depth 1` was mistaken for one) — safety over
-    // precision in the ambiguous case.
+    // For push/pull/fetch: only block if the SPECIFIC targeted remote points to Rancher.
+    // If we cannot confidently resolve the target remotes (e.g., --all or --multiple flags used,
+    // or ambiguous arguments), fall back to checking all configured remotes for maximum safety.
     try {
-      let targetRemoteUrl = null;
-      if (remoteAction) {
+      let targetRemotes = [];
+      let checkAllRemotes = false;
+
+      try {
+        const remotesOutput = execFileSync('git', ['remote'], {
+          cwd: path.resolve(targetDir),
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore']
+        });
+        const configuredRemotes = remotesOutput.split(/\r?\n/).map(r => r.trim()).filter(Boolean);
+        
+        const hasAllOrMultipleFlag = remainingArgs.some(arg => arg === '--all' || arg === '--multiple');
+        const isRemoteUpdate = subcommand === 'remote' && remoteAction === 'update';
+
+        if (hasAllOrMultipleFlag || isRemoteUpdate) {
+          checkAllRemotes = true;
+        } else {
+          // Collect all explicit remote names targeted in the command arguments
+          targetRemotes = remainingArgs.filter(arg => configuredRemotes.includes(arg));
+
+          // If no explicit remote arguments are found, try to resolve the current branch's tracking remote
+          if (targetRemotes.length === 0) {
+            const currentBranch = execFileSync('git', ['branch', '--show-current'], {
+              cwd: path.resolve(targetDir),
+              encoding: 'utf8',
+              stdio: ['ignore', 'pipe', 'ignore']
+            }).trim();
+            if (currentBranch) {
+              try {
+                const trackingRemote = execFileSync('git', ['config', '--get', `branch.${currentBranch}.remote`], {
+                  cwd: path.resolve(targetDir),
+                  encoding: 'utf8',
+                  stdio: ['ignore', 'pipe', 'ignore']
+                }).trim();
+                if (trackingRemote && configuredRemotes.includes(trackingRemote)) {
+                  targetRemotes = [trackingRemote];
+                }
+              } catch {}
+            }
+          }
+
+          // If we still have no remotes, fall back to checking all configured remotes for maximum safety
+          if (targetRemotes.length === 0) {
+            checkAllRemotes = true;
+          }
+        }
+
+        if (checkAllRemotes) {
+          targetRemotes = configuredRemotes;
+        }
+      } catch {
+        checkAllRemotes = true;
+      }
+
+      // Verify all targeted remotes
+      for (const remote of targetRemotes) {
+        let targetRemoteUrl = null;
         try {
-          targetRemoteUrl = execFileSync('git', ['remote', 'get-url', remoteAction], {
+          // Use standard '--' options terminator to defend against flag injection in remote names
+          targetRemoteUrl = execFileSync('git', ['remote', 'get-url', '--', remote], {
             cwd: path.resolve(targetDir),
             stdio: ['ignore', 'pipe', 'ignore']
           }).toString();
         } catch {
           targetRemoteUrl = null;
         }
-      }
-      if (targetRemoteUrl !== null) {
-        if (/rancher/i.test(targetRemoteUrl)) {
-          deny(
-            "Security Policy Violation: Operations (push, pull, fetch) targeting Rancher-owned remotes are strictly blocked.",
-            "🔒 Security Block: Git remote operation against a Rancher remote is prohibited.",
-            isClaudeCode
-          );
+
+        if (targetRemoteUrl !== null) {
+          if (RANCHER_OWNER_RE.test(targetRemoteUrl)) {
+            deny(
+              `Security Policy Violation: Operations targeting Rancher-owned remotes are strictly blocked.\n` +
+              `Targeted Remote: '${remote}' -> '${targetRemoteUrl.trim()}'`,
+              "🔒 Security Block: Git remote operation against a Rancher remote is prohibited.",
+              isClaudeCode
+            );
+          }
         }
-      } else {
+      }
+
+      // If we checked a subset and they were all safe, or if targetRemotes resolution failed completely,
+      // fallback to scanning all remotes with 'git remote -v' (safety over precision)
+      if (targetRemotes.length === 0 || checkAllRemotes) {
         const remotesOutput = execSync('git remote -v', {
           cwd: path.resolve(targetDir),
           stdio: ['ignore', 'pipe', 'ignore']
         }).toString();
-        if (/rancher/i.test(remotesOutput)) {
+        if (RANCHER_OWNER_RE.test(remotesOutput)) {
           deny(
             "Security Policy Violation: Operations (push, pull, fetch) targeting Rancher-owned remotes are strictly blocked.",
             "🔒 Security Block: Git remote operation against a Rancher remote is prohibited.",

--- a/.agent/skills/commit-push.sh
+++ b/.agent/skills/commit-push.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+#
+# Skill: commit-push.sh
+# Description: Programmatically commit and push local changes with GPG/SSH signature, sign-off, and fork synchronization.
+# Conforms to shell-scripts.instructions.md guidelines.
+
+set -euo pipefail
+
+# Determine repository root directory
+REPO_ROOT=""
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+fi
+
+# ==============================================================================
+# HELPER FUNCTIONS
+# ==============================================================================
+
+# Helper to check if a command exists
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Display script help usage instructions
+show_help() {
+  cat <<EOF
+Usage: commit-push.sh [options] -m "COMMIT_MESSAGE"
+
+Programmatically commit and push local changes with GPG/SSH signature, sign-off, and fork synchronization.
+
+Options:
+  -h, --help            Show this message and exit.
+  -m MESSAGE            The conventional commit message (Required).
+  -f, --force           Bypass remote ancestry check and perform safe force-push with lease.
+
+Examples:
+  .agent/skills/commit-push.sh -m "ci(workflows): add new automated checks"
+  .agent/skills/commit-push.sh -f -m "refactor(hooks): force push after rebase"
+EOF
+}
+
+verify_environment() {
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Error: Must be run inside a Git repository." >&2
+    exit 1
+  fi
+
+  if ! command_exists gh; then
+    echo "Error: 'gh' (GitHub CLI) is required to run this script. Please install gh." >&2
+    exit 1
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "Error: GitHub CLI is not authenticated. Please run 'gh auth login' to authenticate." >&2
+    exit 1
+  fi
+}
+
+get_file_owner_uid() {
+  local file="$1"
+  stat -c %u "$file" 2>/dev/null || stat -f %u "$file" 2>/dev/null || echo ""
+}
+
+calculate_sha256() {
+  if command_exists shasum; then
+    shasum -a 256 | cut -d' ' -f1
+  elif command_exists sha256sum; then
+    sha256sum | cut -d' ' -f1
+  else
+    echo "Error: No SHA-256 utility (shasum or sha256sum) found on this system." >&2
+    exit 1
+  fi
+}
+
+verify_push_safety() {
+  local remote_name="$1"
+  local url
+  url=$(git remote get-url "$remote_name" 2>/dev/null || true)
+  if [[ -z "$url" ]]; then
+    echo "Error: Remote '$remote_name' has no configured URL." >&2
+    exit 1
+  fi
+  # Compare against a lowercased copy — bash's [[ =~ ]] is case-sensitive by default, and
+  # GitHub org names aren't (github.com/Rancher/... would otherwise bypass this check).
+  local url_lower="${url,,}"
+  if [[ "$url_lower" =~ [/:](rancher|rancherlabs)/ ]]; then
+    echo "======================================================================" >&2
+    echo "❌ CRITICAL SECURITY ERROR: UNSAFE PUSH PREVENTED!" >&2
+    echo "   The remote '$remote_name' points to a Rancher-owned repository:" >&2
+    echo "   $url" >&2
+    echo "   Pushing directly to upstream Rancher repositories is strictly forbidden." >&2
+    echo "======================================================================" >&2
+    exit 1
+  fi
+}
+
+# ==============================================================================
+# OPERATION STAGES
+# ==============================================================================
+
+# Parse options and arguments
+parse_args() {
+  # Initialize variables with global defaults
+  COMMIT_MSG=""
+  FORCE_PUSH=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        show_help
+        exit 0
+        ;;
+      -f|--force)
+        FORCE_PUSH=true
+        shift
+        ;;
+      -m)
+        if [[ -z "${2:-}" ]]; then
+          echo "Error: -m option requires a non-empty commit message argument." >&2
+          exit 1
+        fi
+        COMMIT_MSG="$2"
+        shift 2
+        ;;
+      *)
+        echo "Error: Unknown argument '$1'" >&2
+        show_help >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ -z "$COMMIT_MSG" ]]; then
+    echo "Error: Commit message is required. Specify using -m \"message\"." >&2
+    show_help >&2
+    exit 1
+  fi
+}
+
+# Check if the current branch has an already merged PR on GitHub (Branch Defunct Protection)
+check_defunct_branch() {
+  local branch="$1"
+  if [[ "$branch" != "main" ]]; then
+    local pr_status
+    if pr_status=$(gh pr view "$branch" --json state,number --template '{{.state}} {{.number}}' 2>/dev/null); then
+      local pr_state
+      pr_state=$(echo "$pr_status" | cut -d' ' -f1)
+      local pr_number
+      pr_number=$(echo "$pr_status" | cut -d' ' -f2)
+      
+      if [[ "$pr_state" == "MERGED" ]]; then
+        echo "Error: The current branch '$branch' already has a merged Pull Request (#$pr_number) on GitHub." >&2
+        echo "       This branch is defunct. In accordance with 'development-process.md' Phase 5, Step 12, you MUST:" >&2
+        echo "       1. Switch to 'main': git checkout main" >&2
+        echo "       2. Synchronize with upstream default branch: bash .agent/skills/git-sync.sh" >&2
+        echo "       3. Check out a clean, new branch off updated main: git checkout -b feature/workflows-new-branch" >&2
+        exit 1
+      fi
+    fi
+  fi
+}
+
+# Verify staging files and file-count limits
+verify_staging_limits() {
+  local max_allowed=5
+  STAGED_COUNT=$(git diff --cached --name-only | wc -l | tr -d ' ')
+
+  if [[ "$STAGED_COUNT" -eq 0 ]]; then
+    echo "Error: No changes are currently staged for commit." >&2
+    echo "       Please stage your changes first using 'git add <files>...'." >&2
+    exit 1
+  fi
+
+  if [[ "$STAGED_COUNT" -gt "$max_allowed" ]]; then
+    echo "Error: Committing too much code at once is prohibited ($STAGED_COUNT files staged; max allowed is $max_allowed)." >&2
+    echo "       In accordance with Phase 5, Step 11 of 'development-process.md', please split your commit into smaller, surgical layers." >&2
+    exit 1
+  fi
+}
+
+# Enforce secure proactive review validation
+verify_proactive_review() {
+  # Delegate verification cleanly and securely to write-approval.sh skill
+  if ! bash "$REPO_ROOT/.agent/skills/write-approval.sh" --verify; then
+    exit 1
+  fi
+}
+
+# Sync with Upstream parent repository
+sync_default_branch() {
+  local branch="$1"
+  if [[ "$branch" != "main" ]]; then
+    echo "Synchronizing local 'main' branch and tags with upstream parent repository..."
+    # NOTE: Do NOT stash before calling git-sync.sh. That skill already auto-stashes
+    # uncommitted AND untracked files itself (see its verify_git_env) and restores them
+    # with 'git stash pop --index', so the staged index survives. Stashing here as well
+    # is redundant and actively harmful: much of '.agent/skills/' is untracked, so a
+    # 'git stash push -u' sweeps away git-sync.sh itself before this line can invoke it,
+    # failing with "No such file or directory".
+    if ! bash "$REPO_ROOT/.agent/skills/git-sync.sh"; then
+      echo "Error: Upstream synchronization failed." >&2
+      exit 1
+    fi
+
+    # Switch back to the active feature branch in case git-sync.sh left the checkout on main
+    echo "Switching back to branch '$branch'..."
+    if ! git checkout "$branch" >/dev/null 2>&1; then
+      echo "Error: Failed to switch back to branch '$branch' after sync." >&2
+      exit 1
+    fi
+  fi
+}
+
+# Verify ancestry check to fail fast if we are behind remote
+verify_remote_ancestry() {
+  local branch="$1"
+  if [[ "$FORCE_PUSH" == "true" ]]; then
+    echo "Force-push option specified. Skipping ancestry check."
+  else
+    echo "Checking remote branch status on origin..."
+    # Check existence separately from fetching it — treating a fetch failure as "branch
+    # doesn't exist" would also silently swallow real failures (network/auth issues) and let
+    # the push proceed without ever checking whether we're behind.
+    if git ls-remote --exit-code origin "$branch" >/dev/null 2>&1; then
+      if ! git fetch origin "$branch" >/dev/null 2>&1; then
+        echo "Error: Remote branch 'origin/$branch' exists but fetching it failed (network or authentication issue?)." >&2
+        echo "       Please resolve connectivity/authentication and try again." >&2
+        exit 1
+      fi
+      local behind_count
+      behind_count=$(git rev-list --count "HEAD..origin/$branch" 2>/dev/null || echo "0")
+      if [[ "$behind_count" -gt 0 ]]; then
+        echo "Error: Your local branch is behind 'origin/$branch' by $behind_count commit(s)." >&2
+        echo "       Please pull and integrate the remote changes before pushing." >&2
+        exit 1
+      fi
+      echo "  -> Local branch is up to date with remote."
+    else
+      echo "  -> Remote branch 'origin/$branch' does not exist yet. Safe to proceed."
+    fi
+  fi
+}
+
+# Verify developer manual IDE review approval
+verify_developer_approval() {
+  # If a valid user-approval signature is already present, verify it cleanly
+  if node "$REPO_ROOT/.agent/skills/user-approval.js" --verify >/dev/null 2>&1; then
+    echo "✅ Developer visual IDE review approval verified!" >&2
+    return 0
+  fi
+
+  # Otherwise, programmatically prompt the developer for approval now
+  echo "No prior developer approval signature found on disk." >&2
+  if ! node "$REPO_ROOT/.agent/skills/user-approval.js" "Do you approve GPG-signing, committing, and pushing these changes?"; then
+    echo "❌ Commit and push aborted by developer." >&2
+    exit 1
+  fi
+}
+
+# Execute signed and signed-off git commit
+execute_signed_commit() {
+  echo "Committing $STAGED_COUNT staged file(s) with signature (-S) and sign-off (-s)..."
+  if ! git commit -s -S -m "$COMMIT_MSG"; then
+    echo "Error: Git commit failed. Ensure GPG/SSH signing is configured." >&2
+    exit 1
+  fi
+}
+
+# Perform secure push to fork remote
+secure_push() {
+  local branch="$1"
+  if [[ "$FORCE_PUSH" == "true" ]]; then
+    echo "Pushing signed commit with FORCE securely to fork remote 'origin/$branch'..."
+    if ! git push origin "$branch" --force-with-lease; then
+      echo "Error: Git push failed." >&2
+      exit 1
+    fi
+  else
+    echo "Pushing signed commit securely to fork remote 'origin/$branch'..."
+    if ! git push origin "$branch"; then
+      echo "Error: Git push failed." >&2
+      exit 1
+    fi
+  fi
+}
+
+# ==============================================================================
+# MAIN ENTRY POINT
+# ==============================================================================
+main() {
+  # Global state variables
+  STAGED_COUNT=0
+
+  parse_args "$@"
+  verify_environment
+  verify_push_safety origin
+
+  local current_branch
+  current_branch=$(git branch --show-current)
+  if [[ -z "$current_branch" ]]; then
+    echo "Error: Could not determine current branch name." >&2
+    exit 1
+  fi
+
+  check_defunct_branch "$current_branch"
+  verify_staging_limits
+  verify_proactive_review
+  sync_default_branch "$current_branch"
+  verify_remote_ancestry "$current_branch"
+  verify_developer_approval
+  execute_signed_commit
+  secure_push "$current_branch"
+
+  echo "✅ Changes programmatically committed and pushed successfully!"
+}
+
+main "$@"

--- a/.agent/skills/generate-otp.sh
+++ b/.agent/skills/generate-otp.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Skill: generate-otp.sh
+# Description: Generates a secure, cryptographically random One-Time Pad (OTP) token.
+#              Writes the token safely to disk with strict 0600 permissions and outputs the token.
+# Conforms to shell-scripts.instructions.md guidelines.
+# Usage: 
+#   OTP_TOKEN=$(bash .agent/skills/generate-otp.sh)
+
+set -euo pipefail
+
+# Helper to check if a command exists
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Display script help usage instructions
+show_help() {
+  cat <<EOF
+Usage: generate-otp.sh [options]
+
+Generates a secure, cryptographically random 16-byte (32-character) One-Time Pad (OTP) token.
+The token is securely saved to ~/.gemini/tmp/terraform-provider-rancher2/active-otp.token with 0600 permissions.
+The generated token hex string is printed directly to standard output.
+
+Options:
+  -h, --help           Show this message and exit.
+
+Examples:
+  OTP_TOKEN=\$(bash .agent/skills/generate-otp.sh)
+EOF
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        show_help
+        exit 0
+        ;;
+      *)
+        echo "Error: Unknown argument '$1'" >&2
+        show_help >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ -z "${HOME:-}" ]]; then
+    echo "Error: HOME environment variable is not set or is empty." >&2
+    exit 1
+  fi
+
+  if ! command_exists openssl; then
+    echo "Error: 'openssl' utility is required for secure random generation. Please install openssl." >&2
+    exit 1
+  fi
+
+  local target_dir="$HOME/.gemini/tmp/terraform-provider-rancher2"
+  local token_file="${target_dir}/active-otp.token"
+
+  # Generate 16 bytes of cryptographically secure randomness
+  local otp_token
+  otp_token=$(openssl rand -hex 16)
+
+  # Create directories safely
+  mkdir -p "$target_dir"
+
+  # Write to a freshly-created temp file, then atomically rename it into place, rather than
+  # rm -f followed by a redirect. The rm-then-write pattern leaves a TOCTOU window: a symlink
+  # could be recreated at $token_file between the two steps, and the write would follow it.
+  # mv -f on the same filesystem uses rename(2), which replaces whatever is at the destination
+  # atomically without ever dereferencing an existing symlink there.
+  local old_umask
+  old_umask="$(umask)"
+  umask 077
+  local tmp_file
+  tmp_file="$(mktemp "${target_dir}/.otp.XXXXXX")"
+  umask "$old_umask"
+
+  echo "$otp_token" > "$tmp_file"
+  mv -f "$tmp_file" "$token_file"
+
+  # Output the token string natively to stdout so calling scripts can bind it to a variable
+  echo "$otp_token"
+}
+
+main "$@"

--- a/.agent/skills/git-sync.sh
+++ b/.agent/skills/git-sync.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+#
+# Skill: git-sync.sh
+# Description: Safely syncs the default branch, tags, and optionally the current branch of a local fork with the upstream parent repository.
+#              Enforces strict security checks to ensure we never push to any Rancher-owned remote/repository.
+# Usage: .agent/skills/git-sync.sh [stay]
+#        If 'stay' (or any non-empty value) is provided, it will also sync and checkout the current branch.
+
+set -euo pipefail
+
+# ==============================================================================
+# CORE FUNCTIONS
+# ==============================================================================
+
+# Global variable to track auto-stash state
+AUTO_STASH_CREATED=false
+
+verify_git_env() {
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Error: This command must be run inside a Git repository." >&2
+    exit 1
+  fi
+
+  # Securely auto-stash uncommitted or untracked changes rather than erroring
+  if [[ "$(git status --porcelain=v1 2>/dev/null | wc -l)" -gt 0 ]]; then
+    echo "  -> Uncommitted or untracked changes detected in local tree."
+    echo "  -> Securely stashing changes to guarantee zero data loss..."
+    if ! git stash push -u -m "git-sync-auto-stash" >/dev/null; then
+      echo "Error: Failed to stash changes cleanly. Aborting sync." >&2
+      exit 1
+    fi
+    AUTO_STASH_CREATED=true
+  fi
+}
+
+get_origin_url() {
+  local url
+  url=$(git remote get-url origin 2>/dev/null || true)
+  if [[ -z "$url" ]]; then
+    echo "Error: Could not retrieve configured origin remote URL." >&2
+    echo "       Please ensure 'origin' is set up." >&2
+    exit 1
+  fi
+  echo "$url"
+}
+
+verify_push_safety() {
+  local remote_name="$1"
+  local url
+  url=$(git remote get-url "$remote_name" 2>/dev/null || true)
+  if [[ -z "$url" ]]; then
+    echo "Error: Remote '$remote_name' has no configured URL." >&2
+    exit 1
+  fi
+  # Compare against a lowercased copy — bash's [[ =~ ]] is case-sensitive by default, and
+  # GitHub org names aren't (github.com/Rancher/... would otherwise bypass this check).
+  local url_lower="${url,,}"
+  if [[ "$url_lower" =~ [/:](rancher|rancherlabs)/ ]]; then
+    echo "======================================================================" >&2
+    echo "❌ CRITICAL SECURITY ERROR: UNSAFE PUSH PREVENTED!" >&2
+    echo "   The remote '$remote_name' points to a Rancher-owned repository:" >&2
+    echo "   $url" >&2
+    echo "   Pushing directly to upstream Rancher repositories is strictly forbidden." >&2
+    echo "======================================================================" >&2
+    exit 1
+  fi
+}
+
+safe_git_push() {
+  local remote=""
+  local arg
+  for arg in "$@"; do
+    if [[ ! "$arg" =~ ^- ]]; then
+      remote="$arg"
+      break
+    fi
+  done
+
+  if [[ -z "$remote" ]]; then
+    echo "Error: Could not determine remote from git push arguments." >&2
+    exit 1
+  fi
+
+  verify_push_safety "$remote"
+  git push "$@"
+}
+
+get_origin_owner() {
+  local origin_url="$1"
+  if [[ "$origin_url" =~ github\.com[:/]([^/]+)/ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo ""
+  fi
+}
+
+get_upstream_owner() {
+  # The parent repository owner is always "rancher"
+  echo "rancher"
+}
+
+get_upstream_repo() {
+  # Parse repository name from origin remote url
+  local origin_url
+  origin_url=$(git remote get-url origin 2>/dev/null || true)
+  
+  if [[ "$origin_url" =~ github\.com[:/][^/]+/([^/]+)\.git ]]; then
+    echo "${BASH_REMATCH[1]}"
+  elif [[ "$origin_url" =~ github\.com[:/][^/]+/([^/]+) ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    # Fallback to the local directory name
+    basename "$(git rev-parse --show-toplevel)"
+  fi
+}
+
+get_default_branch() {
+  local default_branch=""
+  default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || true)
+  if [[ -z "$default_branch" ]]; then
+    default_branch=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | cut -d' ' -f5 || true)
+  fi
+  if [[ -z "$default_branch" ]]; then
+    echo "Error: Could not determine the default branch for the origin remote." >&2
+    exit 1
+  fi
+  echo "$default_branch"
+}
+
+get_upstream_url() {
+  local origin_url="$1"
+  local owner="$2"
+  local repo="$3"
+  if [[ "$origin_url" =~ ^git@ ]]; then
+    echo "git@github.com:${owner}/${repo}.git"
+  else
+    echo "https://github.com/${owner}/${repo}.git"
+  fi
+}
+
+sync_branch() {
+  local branch="$1"
+  local upstream_url="$2"
+  local is_default="${3:-false}"
+  # Only meaningful for non-default branches: where to rebase onto when $branch itself
+  # doesn't exist on upstream (the normal case for a feature branch — it's local/fork-only).
+  local default_branch="${4:-$branch}"
+
+  echo "Syncing branch '$branch' with upstream..."
+  git checkout "$branch"
+  git remote rm upstream 2>/dev/null || true
+  git remote add upstream "$upstream_url"
+  git fetch --all
+
+  if [[ "$is_default" == "true" ]] || git ls-remote --exit-code upstream "$branch" >/dev/null 2>&1; then
+    git pull --rebase upstream "$branch"
+  else
+    echo "  -> Branch '$branch' doesn't exist on upstream; rebasing onto upstream's default branch '$default_branch' instead."
+    git rebase "upstream/$default_branch"
+  fi
+
+  if [[ "$is_default" == "true" ]]; then
+    safe_git_push --tags origin
+  fi
+
+  git remote rm upstream
+  # --force-with-lease (not a bare -f) refuses to push if origin moved since our last fetch,
+  # rather than unconditionally overwriting whatever is there.
+  safe_git_push --force-with-lease origin "$branch"
+}
+
+# ==============================================================================
+# MAIN ORCHESTRATION
+# ==============================================================================
+
+ORIGINAL_BRANCH=""
+
+cleanup() {
+  local exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
+    echo "⚠️ Script interrupted or failed. Running cleanup..." >&2
+    git remote rm upstream 2>/dev/null || true
+    if [[ -n "$ORIGINAL_BRANCH" ]]; then
+      echo "Restoring original branch '$ORIGINAL_BRANCH'..." >&2
+      git checkout "$ORIGINAL_BRANCH" 2>/dev/null || true
+    fi
+  fi
+
+  # Always restore the auto-stash on exit if it was successfully created
+  if [[ "$AUTO_STASH_CREATED" == "true" ]]; then
+    if [[ -n "${ORIGINAL_BRANCH:-}" && "$(git branch --show-current)" != "$ORIGINAL_BRANCH" ]]; then
+      echo "Switching back to original branch '$ORIGINAL_BRANCH' before restoring stash..." >&2
+      git checkout "$ORIGINAL_BRANCH" >/dev/null 2>&1 || true
+    fi
+    echo "  -> Restoring stashed changes from auto-stash..." >&2
+    if ! git stash pop --index >/dev/null 2>&1; then
+      echo "Warning: Re-applying stashed changes resulted in merge conflicts." >&2
+      echo "         Your changes have been safely preserved in the Git stash." >&2
+    fi
+    AUTO_STASH_CREATED=false
+  fi
+
+  exit "$exit_code"
+}
+
+show_help() {
+  cat <<EOF
+Usage: git-sync.sh [options] [stay]
+
+Safely syncs the default branch, tags, and optionally the current branch of a local fork with the upstream parent repository.
+
+Options:
+  stay                 Sync and checkout the current branch in addition to the default branch.
+  -h, --help           Show this help message and exit.
+
+Examples:
+  .agent/skills/git-sync.sh
+  .agent/skills/git-sync.sh stay
+EOF
+}
+
+main() {
+  trap cleanup EXIT
+
+  local stay=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        show_help
+        exit 0
+        ;;
+      stay)
+        stay="true"
+        shift
+        ;;
+      -*)
+        echo "Error: Unknown option: $1" >&2
+        show_help
+        exit 1
+        ;;
+      *)
+        echo "Error: Unexpected argument: $1" >&2
+        show_help
+        exit 1
+        ;;
+    esac
+  done
+
+  verify_git_env
+
+  ORIGINAL_BRANCH="$(git branch --show-current)"
+  echo "Current branch is $ORIGINAL_BRANCH..."
+
+  local origin_url
+  origin_url=$(get_origin_url)
+
+  echo "Running push safety verification on origin..."
+  verify_push_safety origin
+
+  local origin_owner
+  origin_owner=$(get_origin_owner "$origin_url")
+  echo "Found origin owner: \"$origin_owner\"..."
+
+  local upstream_owner
+  upstream_owner=$(get_upstream_owner)
+  echo "Found upstream owner: $upstream_owner..."
+
+  local upstream_repo
+  upstream_repo=$(get_upstream_repo)
+  echo "Found upstream repo name: $upstream_repo..."
+
+  if [[ "$origin_owner" == "$upstream_owner" ]]; then
+    echo "Origin is already the upstream repository ($upstream_owner), nothing to sync."
+    exit 0
+  fi
+
+  local default_branch
+  default_branch=$(get_default_branch)
+  echo "Found default branch as: $default_branch..."
+
+  local upstream_url
+  upstream_url=$(get_upstream_url "$origin_url" "$upstream_owner" "$upstream_repo")
+  echo "Configuring upstream URL: $upstream_url"
+
+  # Clear any legacy upstream remotes
+  git remote rm upstream 2>/dev/null || true
+
+  # Sync the default branch
+  git reset --hard
+  sync_branch "$default_branch" "$upstream_url" true
+
+  if [[ -n "$stay" ]]; then
+    echo "User requested to stay on current branch. Syncing '$ORIGINAL_BRANCH'..."
+    sync_branch "$ORIGINAL_BRANCH" "$upstream_url" false "$default_branch"
+  fi
+
+  echo "✅ Git sync completed successfully!"
+}
+
+main "$@"

--- a/.agent/skills/user-approval.js
+++ b/.agent/skills/user-approval.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+//
+// Skill: user-approval.js
+// Description: Securely prompts for developer approval and verifies user-approval status using diff-hash tieing.
+//              Conforms to repository standards and rules.
+// Usage:
+//   Write Mode:   node .agent/skills/user-approval.js --approve
+//   Verify Mode:  node .agent/skills/user-approval.js --verify
+//   Prompt Mode:  node .agent/skills/user-approval.js [message] [defaultOption=N]
+
+import { execSync } from 'child_process';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+// Refuse to run rather than fall back to /tmp — a world-writable directory undermines the
+// security properties of this approval gate (any local user/process could pre-create or swap
+// the approval file there).
+if (!process.env.HOME) {
+  console.error("Error: HOME environment variable is not set. Refusing to run rather than write approval state to a shared/world-writable location.");
+  process.exit(1);
+}
+
+const TARGET_DIR = path.resolve(process.env.HOME, '.gemini/tmp/terraform-provider-rancher2');
+const APPROVAL_FILE = path.join(TARGET_DIR, 'user-approval.json');
+
+// Helper to calculate active local diff hash securely using SHA-256
+function calculateSHA256() {
+  try {
+    const diff = execSync('git diff HEAD', { stdio: ['ignore', 'pipe', 'ignore'] }).toString();
+    return crypto.createHash('sha256').update(diff).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+// ------------------------------------------------------------------------------
+// VERIFY OPERATION
+// ------------------------------------------------------------------------------
+function verifyApproval() {
+  console.log("Verifying developer manual IDE review approval status...");
+
+  if (!fs.existsSync(APPROVAL_FILE)) {
+    console.error("Error: Developer manual IDE review approval not found!");
+    console.error("       In accordance with Gate 2 (IDE & Commit Gate) of 'development-process.md',");
+    console.error("       you MUST request developer approval first: @user-approval");
+    process.exit(1);
+  }
+
+  // Reject symbolic links to prevent symlink bypasses
+  const stat = fs.lstatSync(APPROVAL_FILE);
+  if (stat.isSymbolicLink()) {
+    console.error("Error: Developer approval file is a symbolic link (Prohibited).");
+    process.exit(1);
+  }
+
+  // Verify file ownership matches current user UID natively
+  if (process.getuid) {
+    const fileUid = fs.statSync(APPROVAL_FILE).uid;
+    const currentUid = process.getuid();
+    if (fileUid !== currentUid) {
+      console.error(`Error: Developer approval file is not owned by the current user (UID: ${currentUid}, Owner: ${fileUid}).`);
+      process.exit(1);
+    }
+  }
+
+  try {
+    const content = JSON.parse(fs.readFileSync(APPROVAL_FILE, 'utf-8'));
+    if (content.status !== 'approved') {
+      console.error(`Error: Developer approval status is '${content.status}' (not approved).`);
+      process.exit(1);
+    }
+
+    const activeHash = calculateSHA256();
+    if (activeHash === null) {
+      console.error("Error: Failed to calculate the active diff hash (is this a git repository?).");
+      process.exit(1);
+    }
+    if (content.diff_hash !== activeHash) {
+      console.error("Error: Local changes have been modified since your last manual developer approval!");
+      console.error(`       Approved SHA-256 hash: ${content.diff_hash}`);
+      console.error(`       Current active SHA-256 hash: ${activeHash}`);
+      console.error("       Please request developer approval again on your latest changes.");
+      process.exit(1);
+    }
+
+    console.log(`✅ Developer visual IDE review approval verified! (SHA-256 Hash: ${activeHash})`);
+    process.exit(0);
+  } catch (err) {
+    console.error("Error: Failed to parse developer approval file:", err.message);
+    process.exit(1);
+  }
+}
+
+// ------------------------------------------------------------------------------
+// APPROVE OPERATION
+// ------------------------------------------------------------------------------
+function writeApproval() {
+  const activeHash = calculateSHA256();
+  if (!activeHash) {
+    console.error("Error: Failed to calculate active diff hash.");
+    process.exit(1);
+  }
+
+  const approvalData = {
+    status: 'approved',
+    diff_hash: activeHash,
+    timestamp: new Date().toISOString()
+  };
+
+  try {
+    fs.mkdirSync(TARGET_DIR, { recursive: true });
+
+    // Write to a freshly-created temp file, then atomically rename it into place, rather than
+    // unlinking the existing file/symlink and writing separately. That leaves a TOCTOU window
+    // where a symlink recreated at APPROVAL_FILE between the unlink and the write could
+    // redirect it to an unintended path. fs.renameSync (rename(2) on the same filesystem)
+    // replaces whatever is at the destination atomically without dereferencing an existing
+    // symlink there.
+    const tmpFile = path.join(TARGET_DIR, `.user-approval.${crypto.randomBytes(8).toString('hex')}.tmp`);
+    try {
+      fs.writeFileSync(tmpFile, JSON.stringify(approvalData, null, 2), { mode: 0o600 });
+      fs.renameSync(tmpFile, APPROVAL_FILE);
+    } catch (err) {
+      try { fs.unlinkSync(tmpFile); } catch { /* best-effort cleanup */ }
+      throw err;
+    }
+    console.log(`✅ Developer approval successfully recorded and tied to diff hash: ${activeHash}`);
+    process.exit(0);
+  } catch (err) {
+    console.error("Error: Failed to write developer approval file:", err.message);
+    process.exit(1);
+  }
+}
+
+// ------------------------------------------------------------------------------
+// PROMPT OPERATION
+// ------------------------------------------------------------------------------
+function promptApproval(message, defaultOption) {
+  console.log("============================================================");
+  console.log("🚨 HOOK GATEWAY: DEVELOPER CONFIRMATION REQUIRED");
+  console.log("============================================================");
+  console.log(message);
+  console.log("=============================================================");
+
+  const isDefaultYes = defaultOption.toLowerCase() === 'y' || defaultOption.toLowerCase() === 'yes';
+  const optionPrompt = isDefaultYes ? "[Y/n]" : "[y/N]";
+
+  let response = defaultOption;
+
+  try {
+    // Open direct TTY read/write streams
+    const ttyRead = fs.openSync('/dev/tty', 'r');
+    const ttyWrite = fs.openSync('/dev/tty', 'w');
+
+    fs.writeSync(ttyWrite, `Confirm ${optionPrompt}: `);
+
+    const buffer = Buffer.alloc(1024);
+    const bytesRead = fs.readSync(ttyRead, buffer, 0, 1024, null);
+
+    fs.closeSync(ttyRead);
+    fs.closeSync(ttyWrite);
+
+    response = buffer.toString('utf8', 0, bytesRead).trim();
+  } catch {
+    // Fallback gracefully in headless/piped environments without throwing
+    console.warn(`Non-interactive terminal detected. Fallback to default: ${defaultOption}`);
+    response = defaultOption;
+  }
+
+  if (response.toLowerCase() === 'y' || response.toLowerCase() === 'yes') {
+    writeApproval();
+  } else {
+    console.error("❌ Action aborted by developer.");
+    process.exit(1);
+  }
+}
+
+// ==============================================================================
+// MAIN ENTRY
+// ==============================================================================
+function main() {
+  const arg = process.argv[2] || '';
+
+  if (arg === '-h' || arg === '--help') {
+    console.log("Usage: node user-approval.js [--verify | --approve | message]");
+    process.exit(0);
+  }
+
+  if (arg === '--verify') {
+    verifyApproval();
+  }
+
+  if (arg === '--approve') {
+    writeApproval();
+  }
+
+  const message = arg || "Do you approve GPG-signing, committing, and pushing these changes?";
+  const defaultOption = process.argv[3] || "N";
+  promptApproval(message, defaultOption);
+}
+
+main();

--- a/.agent/skills/write-approval.sh
+++ b/.agent/skills/write-approval.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+#
+# Skill: write-approval.sh
+# Description: Securely writes and verifies the programmatic proactive review approval JSON file.
+# Conforms to shell-scripts.instructions.md guidelines.
+# Usage: 
+#   Write Mode:  .agent/skills/write-approval.sh -t TOKEN -d DIFF_HASH -m "MESSAGE"
+#   Verify Mode: .agent/skills/write-approval.sh --verify
+
+set -euo pipefail
+
+# ==============================================================================
+# HELPER FUNCTIONS
+# ==============================================================================
+
+# Helper to check if a command exists
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Display script help usage instructions
+show_help() {
+  cat <<EOF
+Usage: write-approval.sh [options] -t TOKEN -d DIFF_HASH -m "MESSAGE"
+   or  write-approval.sh --verify
+
+Securely writes and verifies the programmatic proactive review approval JSON file.
+
+Options:
+  -h, --help           Show this message and exit.
+  --verify             Verify the active proactive review approval file.
+  -t TOKEN             The secure One-Time Pad (OTP) token (Required for write).
+  -d DIFF_HASH         The cryptographic SHA-256 diff hash of active changes (Required for write).
+  -m MESSAGE           The review approval message (Required for write).
+
+Examples:
+  .agent/skills/write-approval.sh -t "token" -d "sha256" -m "PR Review status: 🟢 PERFECT - 0 findings."
+  .agent/skills/write-approval.sh --verify
+EOF
+}
+
+get_file_owner_uid() {
+  local file="$1"
+  stat -c %u "$file" 2>/dev/null || stat -f %u "$file" 2>/dev/null || echo ""
+}
+
+calculate_sha256() {
+  if command_exists shasum; then
+    shasum -a 256 | cut -d' ' -f1
+  elif command_exists sha256sum; then
+    sha256sum | cut -d' ' -f1
+  else
+    echo "Error: No SHA-256 utility (shasum or sha256sum) found on this system." >&2
+    exit 1
+  fi
+}
+
+# ==============================================================================
+# OPERATION STAGES
+# ==============================================================================
+
+verify_approval() {
+  local approval_file="$1"
+  echo "Verifying proactive review approval status..." >&2
+
+  if [[ ! -f "$approval_file" ]]; then
+    echo "Error: Proactive review approval not found!" >&2
+    echo "       In accordance with 'development-process.md', you MUST delegate" >&2
+    echo "       a proactive review of your changes to our specialized subagent" >&2
+    echo "       before committing: @review_agent" >&2
+    exit 1
+  fi
+
+  if [[ -L "$approval_file" ]]; then
+    echo "Error: Proactive review approval file at '$approval_file' is a symbolic link." >&2
+    echo "       Symlink-based approval files are prohibited for security." >&2
+    exit 1
+  fi
+
+  local owner_uid
+  owner_uid=$(get_file_owner_uid "$approval_file")
+  if [[ "$owner_uid" != "$UID" ]]; then
+    echo "Error: Proactive review approval file at '$approval_file' is not owned by the current user (UID: $UID, Owner: $owner_uid)." >&2
+    echo "       This is a security violation. Please ensure the file is generated securely." >&2
+    exit 1
+  fi
+
+  if ! command_exists jq; then
+    echo "Error: 'jq' utility is required to parse review approval file. Please install jq." >&2
+    exit 1
+  fi
+
+  local status
+  status=$(jq -r '.status' "$approval_file" 2>/dev/null || true)
+  local approval_hash
+  approval_hash=$(jq -r '.diff_hash' "$approval_file" 2>/dev/null || true)
+
+  if [[ "$status" != "approved" ]]; then
+    echo "Error: The proactive review approval status is '$status' (not approved)." >&2
+    exit 1
+  fi
+
+  # Recalculate the active local diff hash securely using SHA-256 (staged + unstaged combined)
+  local active_hash
+  active_hash=$(git diff HEAD | calculate_sha256)
+
+  if [[ "$approval_hash" != "$active_hash" ]]; then
+    echo "Error: Local changes have been modified since your last proactive review approval!" >&2
+    echo "       Approved SHA-256 hash: ${approval_hash}" >&2
+    echo "       Current active SHA-256 hash: ${active_hash}" >&2
+    echo "       Please re-run the review agent on your latest changes: @review_agent" >&2
+    exit 1
+  fi
+
+  echo "✅ Proactive review approval verified! (SHA-256 Hash: $active_hash)"
+  exit 0
+}
+
+write_approval() {
+  local token="$1"
+  local diff_hash="$2"
+  local message="$3"
+  local target_dir="$4"
+  local approval_file="$5"
+  local token_file="$6"
+
+  if [[ -z "$token" || -z "$diff_hash" || -z "$message" ]]; then
+    echo "Error: Missing required arguments for write mode." >&2
+    show_help >&2
+    exit 1
+  fi
+
+  # ----------------------------------------------------------------------------
+  # SECURE TOKEN VALIDATION (Anti-Spoofing Symlink/Owner checks)
+  # ----------------------------------------------------------------------------
+  if [[ ! -f "$token_file" ]]; then
+    echo "Error: No active verification token found on disk. Proactive review is unauthorized." >&2
+    exit 1
+  fi
+
+  if [[ -L "$token_file" ]]; then
+    echo "Error: Token file at '$token_file' is a symbolic link. Prohibited for security." >&2
+    exit 1
+  fi
+
+  local token_uid
+  token_uid=$(get_file_owner_uid "$token_file")
+  if [[ "$token_uid" != "$UID" ]]; then
+    echo "Error: Token file is not owned by current user (UID: $UID, Owner: $token_uid). Security violation." >&2
+    exit 1
+  fi
+
+  local active_token
+  active_token=$(tr -d ' \n' < "$token_file")
+  if [[ "$token" != "$active_token" || ${#active_token} -lt 16 ]]; then
+    echo "Error: Invalid verification token. Proactive review signature rejected." >&2
+    exit 1
+  fi
+
+  # ----------------------------------------------------------------------------
+  # SECURE APPROVAL GENERATION
+  # ----------------------------------------------------------------------------
+  
+  # Ensure target diff_hash exactly matches active diff (prevents hash mismatch spoofing)
+  local active_hash
+  active_hash=$(git diff HEAD | calculate_sha256)
+  if [[ "$diff_hash" != "$active_hash" ]]; then
+    echo "Error: Requested hash '$diff_hash' does not match current active hash '$active_hash'." >&2
+    exit 1
+  fi
+
+  if ! command_exists jq; then
+    echo "Error: 'jq' utility is required for secure JSON generation. Please install jq." >&2
+    exit 1
+  fi
+
+  # Success! Construct the approval JSON securely with umask 077 (0600 permissions)
+  mkdir -p "$target_dir"
+
+  # Write to a freshly-created temp file, then atomically rename it into place, rather than
+  # `rm -f` followed by a plain `> file` redirect. The rm-then-write pattern leaves a TOCTOU
+  # window: a symlink could be recreated at $approval_file between the two steps, and the
+  # write would silently follow it. `mv` on the same filesystem uses rename(2), which replaces
+  # whatever is at the destination atomically without ever dereferencing an existing symlink
+  # there, so a pre-existing symlink can't redirect the write.
+  local old_umask
+  old_umask="$(umask)"
+  umask 077
+  local tmp_file
+  tmp_file="$(mktemp "${target_dir}/.approval.XXXXXX")"
+  umask "$old_umask"
+
+  jq -n \
+    --arg status "approved" \
+    --arg msg "${message}" \
+    --arg sha "$(git rev-parse HEAD 2>/dev/null || echo 'unknown')" \
+    --arg hash "${diff_hash}" \
+    '{status: $status, message: $msg, commit_sha: $sha, diff_hash: $hash}' > "$tmp_file"
+  mv -f "$tmp_file" "$approval_file"
+
+  # Single-use token: Immediately destroy the active token to prevent replay
+  rm -f "$token_file"
+
+  echo "✅ Proactive review approval file successfully generated at: $approval_file"
+}
+
+# ==============================================================================
+# MAIN ENTRY POINT
+# ==============================================================================
+
+main() {
+  if [[ -z "${HOME:-}" ]]; then
+    echo "Error: HOME environment variable is not set or is empty." >&2
+    exit 1
+  fi
+
+  local token=""
+  local diff_hash=""
+  local message=""
+  local verify_only=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        show_help
+        exit 0
+        ;;
+      --verify)
+        verify_only=true
+        shift
+        ;;
+      -t)
+        if [[ $# -lt 2 ]]; then
+          echo "Error: Option -t requires an argument." >&2
+          show_help >&2
+          exit 1
+        fi
+        token="$2"
+        shift 2
+        ;;
+      -d)
+        if [[ $# -lt 2 ]]; then
+          echo "Error: Option -d requires an argument." >&2
+          show_help >&2
+          exit 1
+        fi
+        diff_hash="$2"
+        shift 2
+        ;;
+      -m)
+        if [[ $# -lt 2 ]]; then
+          echo "Error: Option -m requires an argument." >&2
+          show_help >&2
+          exit 1
+        fi
+        message="$2"
+        shift 2
+        ;;
+      *)
+        echo "Error: Unknown argument '$1'" >&2
+        show_help >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Error: This command must be run inside a Git repository." >&2
+    exit 1
+  fi
+
+  local target_dir="$HOME/.gemini/tmp/terraform-provider-rancher2"
+  local approval_file="${target_dir}/review-approval.json"
+  local token_file="${target_dir}/active-otp.token"
+
+  if [[ "$verify_only" == "true" ]]; then
+    verify_approval "$approval_file"
+  else
+    write_approval "$token" "$diff_hash" "$message" "$target_dir" "$approval_file" "$token_file"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Adds `.agent/skills/` scripts that gate commits and pushes behind explicit developer approval:

- `user-approval.js` — prompts for developer approval and ties it to a SHA-256 hash of `git diff HEAD`, so approval is invalidated the moment the diff changes
- `generate-otp.sh` / `write-approval.sh` — generate and record the approval token
- `git-sync.sh` — hardened sync of the local `main` branch and tags with upstream, auto-stashing (including untracked files) before resetting and restoring afterward
- `commit-push.sh` — orchestrates staging, review-approval verification, signed commit, and push, capped at 5 staged files per commit to keep changes reviewable

These are additive; nothing existing is modified.