### PR TITLE
feat: add agent pull request and CI log skills

### DIFF
--- a/.agent/skills/create-pr.sh
+++ b/.agent/skills/create-pr.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# Skill: create-pr.sh
+# Description: Safely creates a pull request from your local fork branch to the upstream main branch,
+#              bypassing ambient GITHUB_TOKEN environment overrides to use the gh CLI's authenticated credential.
+# Usage: .agent/skills/create-pr.sh --title "<Title>" --body "<Body>" [--base "<Base>"] [--draft]
+
+set -euo pipefail
+
+show_help() {
+  cat <<EOF
+Usage: create-pr.sh [options]
+
+Safely creates or graduates a pull request from your local fork branch to the upstream repository.
+
+Options:
+  --title TITLE        The title of the pull request (Required for creation).
+  --body BODY          The markdown description body of the pull request (Required for creation).
+  --base BASE          The target upstream branch (default: main).
+  --draft              Create the pull request as a draft.
+  --ready [TARGET]     Graduate a draft pull request to ready-for-review (accepts PR number, branch, or URL; defaults to current branch).
+  -h, --help           Show this help message and exit.
+
+Examples:
+  .agent/skills/create-pr.sh --title "fix: logic error" --body "Fixes the loop bounds"
+  .agent/skills/create-pr.sh --title "feat: new helper" --body "Adds skill" --draft
+  .agent/skills/create-pr.sh --ready
+  .agent/skills/create-pr.sh --ready 280
+EOF
+}
+
+verify_git_env() {
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Error: This command must be run inside a Git repository." >&2
+    exit 1
+  fi
+}
+
+get_fork_owner() {
+  local origin_url
+  origin_url=$(git remote get-url origin 2>/dev/null || true)
+  if [[ -z "$origin_url" ]]; then
+    echo "Error: Could not retrieve configured origin remote URL." >&2
+    exit 1
+  fi
+
+  if [[ "$origin_url" =~ github\.com[:/]([^/]+)/ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo "Error: Could not parse fork owner from origin URL $origin_url" >&2
+    exit 1
+  fi
+}
+
+get_upstream_repo() {
+  local upstream_repo="rancher/terraform-provider-rancher2"
+  local origin_url
+  origin_url=$(git remote get-url origin 2>/dev/null || true)
+  if [[ "$origin_url" =~ github\.com[:/][^/]+/([^/]+)\.git ]]; then
+    upstream_repo="rancher/${BASH_REMATCH[1]}"
+  elif [[ "$origin_url" =~ github\.com[:/][^/]+/([^/]+) ]]; then
+    upstream_repo="rancher/${BASH_REMATCH[1]}"
+  fi
+  echo "$upstream_repo"
+}
+
+create_pull_request() {
+  local title="$1"
+  local body="$2"
+  local base="$3"
+  local draft_flag="$4"
+  local branch
+  local fork_owner
+  local upstream_repo
+
+  branch=$(git branch --show-current)
+  fork_owner=$(get_fork_owner)
+  upstream_repo=$(get_upstream_repo)
+
+  echo "Creating Pull Request for branch '${branch}' on fork '${fork_owner}' to upstream '${upstream_repo}'..."
+
+  local extra_flags=()
+  if [[ -n "$draft_flag" ]]; then
+    extra_flags+=("$draft_flag")
+  fi
+
+  # Create the PR non-interactively, bypassing token overrides
+  GITHUB_TOKEN="" GH_TOKEN="" gh pr create \
+    --repo "$upstream_repo" \
+    --base "$base" \
+    --head "${fork_owner}:${branch}" \
+    --title "$title" \
+    --body "$body" \
+    "${extra_flags[@]}"
+}
+
+graduate_pull_request() {
+  local target="$1"
+  local branch
+  branch=$(git branch --show-current)
+  local upstream_repo
+  upstream_repo=$(get_upstream_repo)
+
+  if [[ -z "$target" ]]; then
+    echo "Graduating draft pull request for the current branch '${branch}'..."
+    GITHUB_TOKEN="" GH_TOKEN="" gh pr ready --repo "$upstream_repo"
+  else
+    echo "Graduating draft pull request for target '${target}'..."
+    GITHUB_TOKEN="" GH_TOKEN="" gh pr ready "$target" --repo "$upstream_repo"
+  fi
+  echo "✅ Pull Request successfully graduated to ready for review!"
+}
+
+main() {
+  local title=""
+  local body=""
+  local base="main"
+  local draft_flag=""
+  local action="create"
+  local ready_target=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        show_help
+        exit 0
+        ;;
+      --title)
+        if [[ -z "${2:-}" ]]; then
+          echo "Error: --title requires an argument." >&2
+          exit 1
+        fi
+        title="$2"
+        shift 2
+        ;;
+      --body)
+        if [[ -z "${2:-}" ]]; then
+          echo "Error: --body requires an argument." >&2
+          exit 1
+        fi
+        body="$2"
+        shift 2
+        ;;
+      --base)
+        if [[ -z "${2:-}" ]]; then
+          echo "Error: --base requires an argument." >&2
+          exit 1
+        fi
+        base="$2"
+        shift 2
+        ;;
+      --draft)
+        draft_flag="--draft"
+        shift
+        ;;
+      --ready)
+        action="ready"
+        if [[ $# -gt 1 && ! "$2" =~ ^- ]]; then
+          ready_target="$2"
+          shift 2
+        else
+          ready_target=""
+          shift
+        fi
+        ;;
+      *)
+        echo "Unknown parameter: $1" >&2
+        show_help
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ "$action" == "ready" ]]; then
+    verify_git_env
+    graduate_pull_request "$ready_target"
+    exit 0
+  fi
+
+  if [[ -z "$title" || -z "$body" ]]; then
+    echo "Error: Both --title and --body parameters are required." >&2
+    show_help
+    exit 1
+  fi
+
+  verify_git_env
+  create_pull_request "$title" "$body" "$base" "$draft_flag"
+}
+
+main "$@"

--- a/.agent/skills/get-pr-comments.sh
+++ b/.agent/skills/get-pr-comments.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+#
+# Skill: get-pr-comments.sh
+# Description: Retrieves and sorts general and inline PR review comments chronologically for an open PR.
+# Usage: .agent/skills/get-pr-comments.sh [PR_ID] [FORMAT]
 
 # Fail fast on any errors, unbound variables, or pipe failures
 set -euo pipefail
@@ -55,6 +59,34 @@ check_dependencies() {
     fi
 }
 
+# Safely executes a command with retry and exponential backoff
+# Usage: run_with_retry cmd args...
+run_with_retry() {
+    local max_attempts=5
+    local base_delay=2
+    local attempt=1
+    local exit_code=0
+
+    while true; do
+        if "$@"; then
+            return 0
+        else
+            exit_code=$?
+        fi
+
+        if [[ ${attempt} -ge ${max_attempts} ]]; then
+            echo "Error: Command '$*' failed after ${max_attempts} attempts." >&2
+            return ${exit_code}
+        fi
+
+        local delay
+        delay=$(( base_delay * (2 ** (attempt - 1)) ))
+        echo "Warning: Command failed (exit code ${exit_code}). Retrying in ${delay} seconds (attempt ${attempt}/${max_attempts})..." >&2
+        sleep "${delay}"
+        attempt=$((attempt + 1))
+    done
+}
+
 # Parse the owner/repo from the git remote url, defaulting to canonical upstream
 get_repo_context() {
     # Allow overriding via environment variable
@@ -69,8 +101,8 @@ get_repo_context() {
 
     # If no upstream, default to canonical rancher repository
     if [[ -z "${url}" ]]; then
-        echo "rancher/terraform-provider-rancher2"
-        return
+      echo "rancher/terraform-provider-rancher2"
+      return
     fi
 
     local clean_url="${url}"
@@ -110,12 +142,12 @@ get_current_branch_pr_id() {
     local fork_owner
     fork_owner=$(get_fork_owner)
     if [[ -n "${fork_owner}" && "${fork_owner}" != "rancher" ]]; then
-        pr_id=$(gh pr list --repo "${target_repo}" --state open --head "${fork_owner}:${branch}" --json number --jq '.[0].number' 2>/dev/null || echo "")
+        pr_id=$(run_with_retry gh pr list --repo "${target_repo}" --state open --head "${fork_owner}:${branch}" --json number --jq '.[0].number' 2>/dev/null || echo "")
     fi
 
     # 2. Try querying as a same-repository PR (branch) if cross-repo query yielded nothing
     if [[ -z "${pr_id}" ]]; then
-        pr_id=$(gh pr list --repo "${target_repo}" --state open --head "${branch}" --json number --jq '.[0].number' 2>/dev/null || echo "")
+        pr_id=$(run_with_retry gh pr list --repo "${target_repo}" --state open --head "${branch}" --json number --jq '.[0].number' 2>/dev/null || echo "")
     fi
     
     if [[ -z "${pr_id}" ]]; then
@@ -133,7 +165,7 @@ fetch_comments() {
     local format="${3:-markdown}"
 
     # Verify that the PR exists in the repository
-    if ! gh pr view "${pr_id}" --repo "${repo_context}" &> /dev/null; then
+    if ! run_with_retry gh pr view "${pr_id}" --repo "${repo_context}" &> /dev/null; then
         echo "Error: Pull Request #${pr_id} was not found in repo '${repo_context}'." >&2
         exit 1
     fi
@@ -142,12 +174,12 @@ fetch_comments() {
     local general_comments
     local review_comments
 
-    if ! general_comments=$(gh api "repos/${repo_context}/issues/${pr_id}/comments" --paginate 2>/dev/null); then
+    if ! general_comments=$(run_with_retry gh api "repos/${repo_context}/issues/${pr_id}/comments" --paginate 2>/dev/null); then
         echo "Error: Failed to fetch general comments from the GitHub API." >&2
         exit 1
     fi
 
-    if ! review_comments=$(gh api "repos/${repo_context}/pulls/${pr_id}/comments" --paginate 2>/dev/null); then
+    if ! review_comments=$(run_with_retry gh api "repos/${repo_context}/pulls/${pr_id}/comments" --paginate 2>/dev/null); then
         echo "Error: Failed to fetch review comments from the GitHub API." >&2
         exit 1
     fi
@@ -161,31 +193,49 @@ fetch_comments() {
 
     # Format the combined comments based on user preference
     if [[ "${format}" == "json" ]]; then
+        # Combine general and review comments, tag each with its type, and sort them chronologically
         jq -n \
             --argjson gen "${general_comments}" \
             --argjson rev "${review_comments}" \
             '
+                # 1. Map general comments and append type: "general"
                 ($gen | map(. + {type: "general"})) + 
+                # 2. Map review comments and append type: "review"
                 ($rev | map(. + {type: "review"})) | 
+                # 3. Combine both lists and sort by creation timestamp
                 sort_by(.created_at)
             '
     else
         local markdown_output
+        # Compile and format comments chronologically as a beautiful, aligned Markdown document
         markdown_output=$(jq -n -r \
             --argjson gen "${general_comments}" \
             --argjson rev "${review_comments}" \
             '
+                # 1. Combine and tag both comment streams
                 (($gen | map(. + {type: "general"})) + 
                  ($rev | map(. + {type: "review"}))) | 
+                # 2. Sort the combined list chronologically
                 sort_by(.created_at) |
+                # 3. Check if the list is empty
                 if length == 0 then
                     "No comments found."
                 else
+                    # 4. Iterate over each comment and generate its Markdown block
                     .[] | (
+                        # A. Header line with type icon (💬 for general, 📝 for review) and username
                         "### " + (if .type == "general" then "💬" else "📝" end) + " @" + .user.login + 
+                        
+                        # B. Context details (such as file path and line number for inline reviews)
                         " (" + (if .type == "general" then "General Comment" else "Inline Review on `" + .path + ":" + (.line // .original_line // "unknown" | tostring) + "`" end) + ") - " + 
+                        
+                        # C. Timestamp parsed to readable UTC format
                         (.created_at | sub("T"; " ") | sub("Z"; " UTC")) + "\n\n" + 
+                        
+                        # D. The markdown body of the comment itself
                         .body + "\n\n" + 
+                        
+                        # E. Standard separator line
                         "---"
                     )
                 end

--- a/.agent/skills/parse-test-logs.sh
+++ b/.agent/skills/parse-test-logs.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# Skill: parse-test-logs.sh
+# Description: Standard parser for gotestsum / go test -json output files.
+#              Extracts and formats passed/failed tests, packages, and elapsed times.
+# Usage: .agent/skills/parse-test-logs.sh [options]
+
+set -euo pipefail
+
+# Default options
+LOG_FILE=""
+NO_COLOR_OPTION=false
+FAILED_ONLY=false
+PASSED_ONLY=false
+
+show_help() {
+  cat <<EOF
+Usage: parse-test-logs.sh [options]
+
+Parses gotestsum JSON log files to generate a structured outcome report.
+
+Options:
+  -f, --file PATH         Direct path to the JSON log file to parse.
+                          If omitted, the newest log file matching /tmp/*_test.log is used.
+  --no-color              Disable colored output (respects standard NO_COLOR env var too).
+  --failed-only           Only display failed tests and packages.
+  --passed-only           Only display passed tests.
+  -h, --help              Show this help message and exit.
+
+Examples:
+  # Parse the newest test log file
+  $ .agent/skills/parse-test-logs.sh
+
+  # Parse a specific log file with color suppressed
+  $ .agent/skills/parse-test-logs.sh -f /tmp/my_test.log --no-color
+
+  # Show failures only
+  $ .agent/skills/parse-test-logs.sh --failed-only
+EOF
+}
+
+# Parse command line options
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--file)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: Option $1 requires an argument." >&2
+        show_help >&2
+        exit 1
+      fi
+      LOG_FILE="$2"
+      shift 2
+      ;;
+    --no-color)
+      NO_COLOR_OPTION=true
+      shift
+      ;;
+    --failed-only)
+      FAILED_ONLY=true
+      shift
+      ;;
+    --passed-only)
+      PASSED_ONLY=true
+      shift
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Error: Unknown option $1" >&2
+      show_help >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate mutual exclusion
+if [ "$FAILED_ONLY" = true ] && [ "$PASSED_ONLY" = true ]; then
+  echo "Error: --failed-only and --passed-only options are mutually exclusive." >&2
+  show_help >&2
+  exit 1
+fi
+
+# Initialize color settings
+if [ "$NO_COLOR_OPTION" = true ] || [ -n "${NO_COLOR:-}" ]; then
+  RED=""
+  GREEN=""
+  YELLOW=""
+  BLUE=""
+  NC=""
+  CHECK_MARK="✓"
+  CROSS_MARK="✗"
+else
+  RED='\033[1;31m'
+  GREEN='\033[1;32m'
+  YELLOW='\033[1;33m'
+  BLUE='\033[1;34m'
+  NC='\033[0m'
+  CHECK_MARK='\033[1;32m✓\033[0m'
+  CROSS_MARK='\033[1;31m✗\033[0m'
+fi
+
+# Locate log file if not specified
+if [ -z "$LOG_FILE" ]; then
+  # Find newest file matching /tmp/*_test.log
+  # Avoid using ls in pipe where possible, but here we find newest by time
+  LOG_FILE=$(find /tmp -maxdepth 1 -name "*_test.log" -type f -printf "%T@ %p\n" 2>/dev/null | sort -n | tail -n 1 | awk '{print $2}')
+fi
+
+if [ -z "$LOG_FILE" ] || [ ! -f "$LOG_FILE" ]; then
+  echo -e "${RED}[ERROR]${NC} No valid test log file found or specified." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo -e "${RED}[ERROR]${NC} jq command is required but not installed." >&2
+  exit 1
+fi
+
+echo -e "${BLUE}=== Parsing Test Log: $LOG_FILE ===${NC}"
+
+# Extract details from JSON
+passed_tests=$(jq -r '. | select(.Action == "pass") | select(.Test != null) | "\(.Test)\t\(.Elapsed)"' "$LOG_FILE" 2>/dev/null | sort -u || true)
+failed_tests=$(jq -r '. | select(.Action == "fail") | select(.Test != null) | "\(.Test)\t\(.Elapsed)"' "$LOG_FILE" 2>/dev/null | sort -u || true)
+failed_pkgs=$(jq -r '. | select(.Action == "fail") | select(.Test == null) | "\(.Package)\t\(.Elapsed)"' "$LOG_FILE" 2>/dev/null | sort -u || true)
+
+# Count summaries
+passed_count=0
+if [ -n "$passed_tests" ]; then
+  passed_count=$(echo "$passed_tests" | wc -l)
+fi
+
+failed_test_count=0
+if [ -n "$failed_tests" ]; then
+  failed_test_count=$(echo "$failed_tests" | wc -l)
+fi
+
+failed_pkg_count=0
+if [ -n "$failed_pkgs" ]; then
+  failed_pkg_count=$(echo "$failed_pkgs" | wc -l)
+fi
+
+total_failures=$((failed_test_count + failed_pkg_count))
+
+# Print PASSED section
+if [ "$FAILED_ONLY" = false ]; then
+  echo ""
+  echo -e "${GREEN}PASSED TESTS ($passed_count):${NC}"
+  if [ -n "$passed_tests" ]; then
+    while IFS=$'\t' read -r name elapsed; do
+      if [ -n "$name" ]; then
+        printf "  %b %s (%ss)\n" "${CHECK_MARK}" "$name" "$elapsed"
+      fi
+    done <<< "$passed_tests"
+  else
+    echo "  None"
+  fi
+fi
+
+# Print FAILED section
+if [ "$PASSED_ONLY" = false ]; then
+  echo ""
+  echo -e "${RED}FAILED ITEMS ($total_failures):${NC}"
+  
+  if [ "$failed_test_count" -gt 0 ]; then
+    echo -e "  ${YELLOW}Individual Tests:${NC}"
+    while IFS=$'\t' read -r name elapsed; do
+      if [ -n "$name" ]; then
+        printf "    %b %s (%ss)\n" "${CROSS_MARK}" "$name" "$elapsed"
+      fi
+    done <<< "$failed_tests"
+  fi
+
+  if [ "$failed_pkg_count" -gt 0 ]; then
+    echo -e "  ${YELLOW}Packages/Builds:${NC}"
+    while IFS=$'\t' read -r name elapsed; do
+      if [ -n "$name" ]; then
+        printf "    %b Package: %s (%ss)\n" "${CROSS_MARK}" "$name" "$elapsed"
+      fi
+    done <<< "$failed_pkgs"
+  fi
+
+  if [ "$total_failures" -eq 0 ]; then
+    echo "  None"
+  fi
+fi
+
+echo ""
+echo -e "${BLUE}=======================================${NC}"
+if [ "$total_failures" -gt 0 ]; then
+  echo -e "${RED}Overall Outcome: FAILED${NC}"
+  exit 1
+else
+  echo -e "${GREEN}Overall Outcome: SUCCESS${NC}"
+  exit 0
+fi

--- a/.agent/skills/pull-ci-logs.sh
+++ b/.agent/skills/pull-ci-logs.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+#
+# Skill: pull-ci-logs.sh
+# Description: Retrieve GitHub CI workflow logs and save to a temporary file, supporting listing failed runs and jobs.
+#              Conforms to shell-scripts.instructions.md guidelines.
+# Usage: .agent/skills/pull-ci-logs.sh [run-id] [options]
+
+set -euo pipefail
+
+show_help() {
+  cat <<EOF
+Usage: pull-ci-logs.sh [run-id] [options]
+
+Downloads workflow logs from a GitHub Actions run or specific job to a temporary file.
+
+Arguments:
+  run-id                  Optional. The database ID of the run. If omitted,
+                          the single most recent run matching the criteria is used.
+
+Options:
+  -r, --repo OWNER/REPO   The GitHub repository (default: rancher/terraform-provider-rancher2).
+  -w, --workflow NAME     Filter runs by workflow name (e.g., "Release", "pull_request").
+  -s, --status STATUS     Filter runs by status (e.g., "completed", "failure").
+  -f, --failed-only       Only fetch logs for failed steps.
+  -o, --output FILE       The file path to save logs (defaults to a securely generated temp file).
+  --list-failed           List recently failed workflow runs and exit.
+  --list-jobs RUN_ID      List failed jobs inside a specific workflow run and exit.
+  -j, --job JOB_ID        Download/view logs for a specific job ID instead of the full run.
+  -h, --help              Show this help message and exit.
+
+Examples:
+  # List recently failed workflow runs
+  $ .agent/skills/pull-ci-logs.sh --list-failed
+
+  # List failed jobs within workflow run 123456789
+  $ .agent/skills/pull-ci-logs.sh --list-jobs 123456789
+
+  # Download logs for the most recent run
+  $ .agent/skills/pull-ci-logs.sh
+
+  # Download logs from a specific failed job ID
+  $ .agent/skills/pull-ci-logs.sh --job 987654321
+EOF
+}
+
+# Safely executes a command with retry and exponential backoff
+# Usage: run_with_retry cmd args...
+run_with_retry() {
+  local max_attempts=5
+  local base_delay=2
+  local attempt=1
+  local exit_code=0
+
+  while true; do
+    if "$@"; then
+      return 0
+    else
+      exit_code=$?
+    fi
+
+    if [[ ${attempt} -ge ${max_attempts} ]]; then
+      echo "Error: Command '$*' failed after ${max_attempts} attempts." >&2
+      return ${exit_code}
+    fi
+
+    local delay
+    delay=$(( base_delay * (2 ** (attempt - 1)) ))
+    echo "Warning: Command failed (exit code ${exit_code}). Retrying in ${delay} seconds (attempt ${attempt}/${max_attempts})..." >&2
+    sleep "${delay}"
+    attempt=$((attempt + 1))
+  done
+}
+
+list_failed_runs() {
+  local repo="$1"
+  echo "Fetching recently failed runs for $repo..." >&2
+
+  local run_data
+  run_data=$(run_with_retry gh run list -R "$repo" -s failure --limit 10 --json databaseId,workflowName,headBranch,createdAt,displayTitle 2>/dev/null)
+
+  if [[ -z "$run_data" || "$run_data" == "[]" ]]; then
+    echo "No recently failed workflow runs found for $repo." >&2
+    return 0
+  fi
+
+  echo -e "RUN ID\t\tWORKFLOW / DETAILS"
+  echo "================================================================================"
+  echo "$run_data" | jq -r '.[] | "\(.databaseId)\t\(.workflowName) (\(.headBranch)) - \(.displayTitle) (\(.createdAt))"'
+}
+
+list_failed_jobs() {
+  local repo="$1"
+  local run_id="$2"
+  echo "Fetching failed jobs for run $run_id in $repo..." >&2
+
+  local jobs_data
+  jobs_data=$(run_with_retry gh api "repos/${repo}/actions/runs/${run_id}/jobs" 2>/dev/null)
+
+  if [[ -z "$jobs_data" ]]; then
+    echo "Error: Could not retrieve jobs for run $run_id." >&2
+    exit 1
+  fi
+
+  local failed_jobs
+  failed_jobs=$(echo "$jobs_data" | jq -r '.jobs[] | select(.conclusion == "failure") | "\(.id)\t\(.name)"' || true)
+
+  if [[ -z "$failed_jobs" ]]; then
+    echo "No failed jobs found for run $run_id (all jobs passed or are pending)." >&2
+    return 0
+  fi
+
+  echo -e "JOB ID\t\tFAILED JOB NAME"
+  echo "================================================================================"
+  echo "$failed_jobs"
+}
+
+get_latest_run_id() {
+  local repo="$1"
+  local workflow="$2"
+  local status="$3"
+
+  local msg="Fetching the latest run ID"
+  if [[ -n "$workflow" ]]; then
+    msg="$msg for workflow '$workflow'"
+  fi
+  if [[ -n "$status" ]]; then
+    msg="$msg with status '$status'"
+  fi
+  msg="$msg from $repo..."
+  echo "$msg" >&2
+
+  local extra_args=()
+  if [[ -n "$workflow" ]]; then
+    extra_args+=("-w" "$workflow")
+  fi
+  if [[ -n "$status" ]]; then
+    extra_args+=("-s" "$status")
+  fi
+
+  local run_id
+  run_id=$(run_with_retry gh run list -R "$repo" --limit 1 "${extra_args[@]}" --json databaseId --jq '.[0].databaseId' 2>/dev/null || echo "")
+
+  if [[ -z "$run_id" || "$run_id" == "null" ]]; then
+    echo "Error: No recent workflow runs found matching the criteria for repository '$repo'." >&2
+    exit 1
+  fi
+
+  echo "$run_id"
+}
+
+main() {
+  local repo="rancher/terraform-provider-rancher2"
+  local failed_only=false
+  local output_file=""
+  local run_id=""
+  local workflow=""
+  local status=""
+  local job_id=""
+  
+  local action="download"
+  local target_run_id=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        show_help
+        exit 0
+        ;;
+      -r|--repo)
+        if [[ -z "${2:-}" ]]; then
+          echo "Error: --repo requires an argument." >&2
+          exit 1
+        fi
+        repo="$2"
+        shift 2
+        ;;
+      -w|--workflow)
+        if [[ -z "${2:-}" ]]; then
+          echo "Error: --workflow requires an argument." >&2
+          exit 1
+        fi
+        workflow="$2"
+        shift 2
+        ;;
+      -s|--status)
+        if [[ -z "${2:-}" ]]; then
+          echo "Error: --status requires an argument." >&2
+          exit 1
+        fi
+        status="$2"
+        shift 2
+        ;;
+      -f|--failed-only)
+        failed_only=true
+        shift
+        ;;
+      -o|--output)
+        if [[ -z "${2:-}" ]]; then
+          echo "Error: --output requires an argument." >&2
+          exit 1
+        fi
+        output_file="$2"
+        shift 2
+        ;;
+      -j|--job)
+        if [[ -z "${2:-}" ]]; then
+          echo "Error: --job requires a job ID." >&2
+          exit 1
+        fi
+        job_id="$2"
+        shift 2
+        ;;
+      --list-failed)
+        action="list-failed"
+        shift
+        ;;
+      --list-jobs)
+        if [[ -z "${2:-}" ]]; then
+          echo "Error: --list-jobs requires a run ID argument." >&2
+          exit 1
+        fi
+        action="list-jobs"
+        target_run_id="$2"
+        shift 2
+        ;;
+      -*)
+        echo "Error: Unknown option: $1" >&2
+        show_help
+        exit 1
+        ;;
+      *)
+        if [[ -n "$run_id" ]]; then
+          echo "Error: Only one run-id can be specified." >&2
+          exit 1
+        fi
+        if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+          echo "Error: Invalid run-id '$1'. Run-id must be a number." >&2
+          exit 1
+        fi
+        run_id="$1"
+        shift
+        ;;
+    esac
+  done
+
+  # Ensure gh CLI is installed
+  if ! command -v gh &>/dev/null; then
+    echo "Error: The GitHub CLI (gh) is not installed or not in PATH." >&2
+    exit 1
+  fi
+
+  # Ensure jq is installed
+  if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required but not installed or not in PATH." >&2
+    exit 1
+  fi
+
+  # Execute requested action
+  if [[ "$action" == "list-failed" ]]; then
+    list_failed_runs "$repo"
+    exit 0
+  fi
+
+  if [[ "$action" == "list-jobs" ]]; then
+    list_failed_jobs "$repo" "$target_run_id"
+    exit 0
+  fi
+
+  # Retrieve logs path (for downloading logs)
+  local view_flags=()
+  if [[ "$failed_only" == "true" ]]; then
+    view_flags+=("--log-failed")
+  else
+    view_flags+=("--log")
+  fi
+
+  if [[ -n "$job_id" ]]; then
+    if [[ -z "$output_file" ]]; then
+      output_file="$(mktemp "/tmp/gh-job-${job_id}.XXXXXX.log")"
+    fi
+    mkdir -p "$(dirname "$output_file")"
+    echo "Downloading logs for job $job_id from $repo..."
+    if ! run_with_retry gh run view --job "$job_id" -R "$repo" "${view_flags[@]}" > "$output_file"; then
+      echo "Error: Failed to fetch logs for job $job_id." >&2
+      exit 1
+    fi
+  else
+    if [[ -z "$run_id" ]]; then
+      run_id=$(get_latest_run_id "$repo" "$workflow" "$status")
+    fi
+    if [[ -z "$output_file" ]]; then
+      output_file="$(mktemp "/tmp/gh-run-${run_id}.XXXXXX.log")"
+    fi
+    mkdir -p "$(dirname "$output_file")"
+    echo "Downloading logs for run $run_id from $repo..."
+    if ! run_with_retry gh run view "$run_id" -R "$repo" "${view_flags[@]}" > "$output_file"; then
+      echo "Error: Failed to fetch logs for run $run_id." >&2
+      exit 1
+    fi
+  fi
+
+  echo "Logs successfully written to: $output_file"
+  echo "You can view them using: less -R \"$output_file\" or code \"$output_file\""
+}
+
+main "$@"

--- a/.agent/skills/resolve-pr-reviews.sh
+++ b/.agent/skills/resolve-pr-reviews.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+#
+# Skill: resolve-pr-reviews.sh
+# Description: Programmatically list and resolve review comment threads on a GitHub Pull Request using GraphQL and the GitHub CLI.
+# Conforms to shell-scripts.instructions.md guidelines.
+
+set -euo pipefail
+
+# Helper to check if a command exists
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Display script help usage instructions
+show_help() {
+  cat <<EOF
+Usage: resolve-pr-reviews.sh [PR_ID] [options/file_pattern]
+
+Programmatically list and resolve review comment threads on a GitHub Pull Request.
+
+Arguments:
+  PR_ID                 The numeric ID of the Pull Request (optional if on a branch with an open PR).
+  OPTIONS/PATTERN       Filter or resolution command options.
+
+Options:
+  -h, --help            Show this message and exit.
+  --all                 Resolve ALL unresolved comment threads.
+  --bypass-token        Bypass ambient GITHUB_TOKEN environment variables and force local keyring auth.
+  <pattern>             Resolve threads where the file path contains the given literal pattern.
+
+Examples:
+  .agent/skills/resolve-pr-reviews.sh 390
+  .agent/skills/resolve-pr-reviews.sh 390 --all
+  .agent/skills/resolve-pr-reviews.sh 390 --bypass-token --all
+  .agent/skills/resolve-pr-reviews.sh 390 publish-release.test.js
+EOF
+}
+
+verify_environment() {
+  if ! command_exists gh; then
+    echo "Error: GitHub CLI (gh) is required but not installed." >&2
+    exit 1
+  fi
+
+  if ! command_exists jq; then
+    echo "Error: jq (JSON processor) is required but not installed." >&2
+    exit 1
+  fi
+
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Error: Must be run inside a Git repository." >&2
+    exit 1
+  fi
+}
+
+resolve_thread() {
+  local thread_id="$1"
+  local path="$2"
+  local author="$3"
+  local owner="$4"
+  local repo="$5"
+  
+  echo "Resolving thread $thread_id on '$path' by @$author..."
+  local mutation='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread {
+        id
+        isResolved
+      }
+    }
+  }
+  '
+  gh api graphql -F threadId="$thread_id" -f query="$mutation" >/dev/null
+  echo "✅ Thread successfully resolved!"
+}
+
+main() {
+  local pr_id=""
+  local mode="list"
+  local filter=""
+  local bypass_token=false
+
+  # Parse Help / Arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        show_help
+        exit 0
+        ;;
+      --bypass-token)
+        bypass_token=true
+        shift
+        ;;
+      --all)
+        mode="all"
+        shift
+        ;;
+      [0-9]*)
+        pr_id="$1"
+        shift
+        ;;
+      *)
+        # If it is not a recognized flag, treat it as the file path filter
+        mode="filter"
+        filter="$1"
+        shift
+        ;;
+    esac
+  done
+
+  # Perform conditional token bypass if explicitly requested
+  if [[ "$bypass_token" == "true" ]]; then
+    echo "Bypassing GITHUB_TOKEN and GH_TOKEN environment variables to use native keychain credentials..."
+    unset GITHUB_TOKEN
+    unset GH_TOKEN
+  fi
+
+  verify_environment
+
+  # Autodetect PR ID if missing
+  if [[ -z "$pr_id" ]]; then
+    local current_branch
+    current_branch=$(git branch --show-current)
+    if [[ -n "$current_branch" ]]; then
+      echo "Autodetecting open PR for branch '$current_branch' on origin/upstream..."
+      pr_id=$(gh pr list --head "$current_branch" --json number --jq '.[0].number' 2>/dev/null || true)
+    fi
+  fi
+
+  if [[ -z "$pr_id" ]]; then
+    echo "Error: No Pull Request number provided and could not autodetect an open PR for the current branch." >&2
+    show_help >&2
+    exit 1
+  fi
+
+  # Report Mode
+  if [[ "$mode" == "filter" ]]; then
+    echo "Filtering threads containing file path pattern: '$filter'"
+  fi
+
+  # Query the PR URL to parse the exact target upstream Owner and Repo
+  local pr_url
+  pr_url=$(gh pr view "$pr_id" --json url --jq '.url' 2>/dev/null || true)
+  
+  local owner=""
+  local repo=""
+  if [[ -n "$pr_url" && "$pr_url" =~ github\.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+    owner="${BASH_REMATCH[1]}"
+    repo="${BASH_REMATCH[2]}"
+    pr_id="${BASH_REMATCH[3]}"
+  else
+    # Local fallback if gh pr view fails - check upstream first, then origin
+    local origin_url
+    origin_url=$(git remote get-url upstream 2>/dev/null || git remote get-url origin 2>/dev/null || true)
+    if [[ -n "$origin_url" && "$origin_url" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
+      owner="${BASH_REMATCH[1]}"
+      repo="${BASH_REMATCH[2]}"
+    else
+      echo "Error: Could not determine target Owner and Repo." >&2
+      exit 1
+    fi
+  fi
+
+  echo "Connected to PR #$pr_id on $owner/$repo"
+
+  # Fetch Unresolved Threads via GraphQL with cursor pagination
+  echo "Fetching unresolved review comment threads..."
+  local has_next_page=true
+  local cursor=""
+  local all_threads_json="[]"
+
+  local query='
+  query($owner: String!, $repo: String!, $pullNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pullNumber) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            id
+            isResolved
+            comments(first: 1) {
+              nodes {
+                body
+                path
+                author {
+                  login
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  '
+
+  while [[ "$has_next_page" == "true" ]]; do
+    local response
+    if [[ -z "$cursor" ]]; then
+      response=$(gh api graphql -F owner="$owner" -F repo="$repo" -F pullNumber="$pr_id" -f query="$query")
+    else
+      response=$(gh api graphql -F owner="$owner" -F repo="$repo" -F pullNumber="$pr_id" -f cursor="$cursor" -f query="$query")
+    fi
+
+    # Detect and report GraphQL errors
+    if echo "$response" | jq -e '.errors' >/dev/null 2>&1; then
+      local err_msg
+      err_msg=$(echo "$response" | jq -r '.errors[0].message')
+      echo "Error: GitHub GraphQL API returned errors: $err_msg" >&2
+      exit 1
+    fi
+
+    has_next_page=$(echo "$response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+    cursor=$(echo "$response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+
+    local page_nodes
+    page_nodes=$(echo "$response" | jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+    if [[ "$page_nodes" != "null" ]]; then
+      all_threads_json=$(jq -n --argjson existing "$all_threads_json" --argjson additional "$page_nodes" '$existing + $additional')
+    fi
+  done
+
+  local unresolved_threads
+  unresolved_threads=$(echo "$all_threads_json" | jq 'map(select(.isResolved == false))')
+  
+  local thread_count
+  thread_count=$(echo "$unresolved_threads" | jq '. | length')
+
+  if [[ "$thread_count" -eq 0 ]]; then
+    echo "🎉 No unresolved comment threads found on PR #$pr_id!"
+    exit 0
+  fi
+
+  echo "Found $thread_count unresolved comment thread(s) on PR #$pr_id:"
+
+  # Loop and display/resolve
+  local thread_id=""
+  local file_path=""
+  local author=""
+  local body=""
+  local thread=""
+
+  for i in $(seq 0 $((thread_count - 1))); do
+    thread=$(echo "$unresolved_threads" | jq ".[$i]")
+    thread_id=$(echo "$thread" | jq -r '.id')
+    file_path=$(echo "$thread" | jq -r '.comments.nodes[0].path')
+    author=$(echo "$thread" | jq -r '.comments.nodes[0].author.login')
+    body=$(echo "$thread" | jq -r '.comments.nodes[0].body' | tr '\r\n' ' ' | cut -c1-80)
+
+    echo "------------------------------------------------------------"
+    echo "Thread ID : $thread_id"
+    echo "File Path : $file_path"
+    echo "Author    : @$author"
+    echo "Comment   : $body..."
+
+    if [[ "$mode" == "all" ]]; then
+      resolve_thread "$thread_id" "$file_path" "$author" "$owner" "$repo"
+    elif [[ "$mode" == "filter" ]]; then
+      # Safe literal substring matching to avoid regex crash and metacharacter matches
+      if [[ "$file_path" == *"$filter"* ]]; then
+        resolve_thread "$thread_id" "$file_path" "$author" "$owner" "$repo"
+      else
+        echo "  -> Skipping (does not match filter)"
+      fi
+    else
+      echo "  -> Running in list mode. Run with '$0 $pr_id --all' or '$0 $pr_id $file_path' to resolve."
+    fi
+  done
+  echo "------------------------------------------------------------"
+}
+
+main "$@"


### PR DESCRIPTION
Adds `.agent/skills/` scripts for working with pull requests and CI from the CLI:

- `create-pr.sh` — opens/graduates a PR from a fork branch to the upstream repo, bypassing ambient `GITHUB_TOKEN` overrides so `gh` uses the authenticated credential
- `resolve-pr-reviews.sh` — walks PR review threads via the GitHub GraphQL API
- `pull-ci-logs.sh` / `parse-test-logs.sh` — fetch and parse CI run logs
- `get-pr-comments.sh` — updated to fit the same conventions as the new scripts

Additive except for `get-pr-comments.sh`, which is a compatibility update.