### PR TITLE
Fix OIDCClient import for missing IDs

### DIFF
--- a/rancher2/resource_rancher2_oidc_client.go
+++ b/rancher2/resource_rancher2_oidc_client.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 	"maps"
-	"time"
 	"net/url"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -237,9 +237,13 @@ func resourceRancher2OIDCClientDelete(d *schema.ResourceData, meta any) error {
 }
 
 func resourceRancher2OIDCClientImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	id := d.Id()
 	err := resourceRancher2OIDCClientRead(d, meta)
-	if err != nil || d.Id() == "" {
+	if err != nil {
 		return []*schema.ResourceData{}, err
+	}
+	if d.Id() == "" {
+		return []*schema.ResourceData{}, fmt.Errorf("OIDC Client %q not found", id)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/rancher2/resource_rancher2_oidc_client_test.go
+++ b/rancher2/resource_rancher2_oidc_client_test.go
@@ -525,6 +525,57 @@ func TestResourceRancher2OIDCClientUpdate(t *testing.T) {
 	})
 }
 
+func TestResourceRancher2OIDCClientImport(t *testing.T) {
+	newGetter := func(ops managementClient.OIDCClientOperations) *fakeManagementClientGetter {
+		return &fakeManagementClientGetter{
+			client: &managementClient.Client{OIDCClient: ops},
+		}
+	}
+
+	newResourceData := func(importID string) *schema.ResourceData {
+		d := schema.TestResourceDataRaw(t, oidcClientFields(), map[string]any{})
+		d.SetId(importID)
+		return d
+	}
+
+	t.Run("returns resource data when resource exists", func(t *testing.T) {
+		existing := &managementClient.OIDCClient{
+			Resource:     types.Resource{ID: "oidc-client-2"},
+			RedirectURIs: []string{"https://example.com/oidc"},
+		}
+		d := newResourceData("oidc-client-2")
+		result, err := resourceRancher2OIDCClientImport(d, newGetter(&fakeOIDCClientOperations{oidcClient: existing}))
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "oidc-client-2", result[0].Id())
+		assert.Equal(t, []any{"https://example.com/oidc"}, result[0].Get("redirect_uris").([]any))
+	})
+
+	notFoundTests := map[string]error{
+		"not found":            &clientbase.APIError{StatusCode: http.StatusNotFound},
+		"forbidden":            &clientbase.APIError{StatusCode: http.StatusForbidden},
+		"not accessible by ID": errors.New("can not be looked up by ID"),
+	}
+	for name, apiErr := range notFoundTests {
+		t.Run("returns error when resource is "+name, func(t *testing.T) {
+			d := newResourceData("oidc-client-1")
+			result, err := resourceRancher2OIDCClientImport(d, newGetter(&fakeOIDCClientOperations{err: apiErr}))
+
+			require.ErrorContains(t, err, "oidc-client-1")
+			assert.Empty(t, result)
+		})
+	}
+
+	t.Run("returns error on unexpected API error", func(t *testing.T) {
+		d := newResourceData("oidc-client-3")
+		result, err := resourceRancher2OIDCClientImport(d, newGetter(&fakeOIDCClientOperations{err: errors.New("internal server error")}))
+
+		require.Error(t, err)
+		assert.Empty(t, result)
+	})
+}
+
 func TestValidateRedirectURI(t *testing.T) {
 	tests := map[string]struct {
 		value   string


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->
- Addresses #2422
<!--- Add labels (eg. release/v15) for each release branch to target --->
<!--- Please don't manually add "internal" labels, those are for automation only --->

## Description
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
This updates the import functionality to fail if the read ID was empty.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? -->
<!--- If so, change the following line with an explanation. --->
Not a breaking change.
