### PR TITLE
Don't configure the refresh seconds if not set.

### DIFF
--- a/rancher2/resource_rancher2_oidc_client.go
+++ b/rancher2/resource_rancher2_oidc_client.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 	"maps"
-	"time"
 	"net/url"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -128,7 +128,7 @@ func oidcClientStateRefreshFunc(client *managementClient.Client, clientID string
 			return nil, "reading client", fmt.Errorf("reading OIDC Client %s: %w", clientID, err)
 		}
 
-		if oidcClient.Status.ClientSecrets == nil || len(oidcClient.Status.ClientSecrets) == 0 {
+		if len(oidcClient.Status.ClientSecrets) == 0 {
 			return oidcClient, "pending", nil
 		}
 
@@ -178,12 +178,18 @@ func resourceRancher2OIDCClientUpdate(d *schema.ResourceData, meta any) error {
 	}
 
 	update := map[string]any{
-		"labels":                        toMapString(d.Get("labels").(map[string]any)),
-		"annotations":                   toMapString(d.Get("annotations").(map[string]any)),
-		"description":                   d.Get("description"),
-		"redirectURIs":                  toArrayString(d.Get("redirect_uris").([]any)),
-		"tokenExpirationSeconds":        d.Get("token_expiration_seconds"),
-		"refreshTokenExpirationSeconds": d.Get("refresh_token_expiration_seconds"),
+		"labels":       toMapString(d.Get("labels").(map[string]any)),
+		"annotations":  toMapString(d.Get("annotations").(map[string]any)),
+		"description":  d.Get("description"),
+		"redirectURIs": toArrayString(d.Get("redirect_uris").([]any)),
+	}
+
+	if v, ok := d.GetOk("token_expiration_seconds"); ok {
+		update["tokenExpirationSeconds"] = v
+	}
+
+	if v, ok := d.GetOk("refresh_token_expiration_seconds"); ok {
+		update["refreshTokenExpirationSeconds"] = v
 	}
 
 	_, err = client.OIDCClient.Update(oidcClient, update)

--- a/rancher2/resource_rancher2_oidc_client_test.go
+++ b/rancher2/resource_rancher2_oidc_client_test.go
@@ -418,6 +418,86 @@ func TestResourceRancher2OIDCClientUpdate(t *testing.T) {
 		assert.Equal(t, wantPayload, ops.updateCalledWith)
 	})
 
+	t.Run("omits token_expiration_seconds from payload when not set", func(t *testing.T) {
+		existing := &managementClient.OIDCClient{
+			Resource: types.Resource{ID: "oidc-client-1"},
+			Status: managementClient.OIDCClientStatus{
+				ClientID: "oidc-client-1",
+				ClientSecrets: map[string]managementClient.OIDCClientSecretStatus{
+					"client-secret-1": {LastFiveCharacters: "ecret"},
+				},
+			},
+		}
+		ops := &fakeOIDCClientOperations{oidcClient: existing, updateResult: existing}
+
+		d := schema.TestResourceDataRaw(t, oidcClientFields(), map[string]any{
+			"description":                      "Updated description",
+			"redirect_uris":                    []any{"http://127.0.0.1:5556/auth/rancher/callback"},
+			"refresh_token_expiration_seconds": 7200,
+		})
+		d.SetId("oidc-client-1")
+
+		err := resourceRancher2OIDCClientUpdate(d, newGetter(ops))
+
+		require.NoError(t, err)
+		payload := ops.updateCalledWith.(map[string]any)
+		assert.NotContains(t, payload, "tokenExpirationSeconds")
+		assert.Equal(t, 7200, payload["refreshTokenExpirationSeconds"])
+	})
+
+	t.Run("omits refresh_token_expiration_seconds from payload when not set", func(t *testing.T) {
+		existing := &managementClient.OIDCClient{
+			Resource: types.Resource{ID: "oidc-client-1"},
+			Status: managementClient.OIDCClientStatus{
+				ClientID: "oidc-client-1",
+				ClientSecrets: map[string]managementClient.OIDCClientSecretStatus{
+					"client-secret-1": {LastFiveCharacters: "ecret"},
+				},
+			},
+		}
+		ops := &fakeOIDCClientOperations{oidcClient: existing, updateResult: existing}
+
+		d := schema.TestResourceDataRaw(t, oidcClientFields(), map[string]any{
+			"description":              "Updated description",
+			"redirect_uris":            []any{"http://127.0.0.1:5556/auth/rancher/callback"},
+			"token_expiration_seconds": 3600,
+		})
+		d.SetId("oidc-client-1")
+
+		err := resourceRancher2OIDCClientUpdate(d, newGetter(ops))
+
+		require.NoError(t, err)
+		payload := ops.updateCalledWith.(map[string]any)
+		assert.Equal(t, 3600, payload["tokenExpirationSeconds"])
+		assert.NotContains(t, payload, "refreshTokenExpirationSeconds")
+	})
+
+	t.Run("omits both seconds fields from payload when neither is set", func(t *testing.T) {
+		existing := &managementClient.OIDCClient{
+			Resource: types.Resource{ID: "oidc-client-1"},
+			Status: managementClient.OIDCClientStatus{
+				ClientID: "oidc-client-1",
+				ClientSecrets: map[string]managementClient.OIDCClientSecretStatus{
+					"client-secret-1": {LastFiveCharacters: "ecret"},
+				},
+			},
+		}
+		ops := &fakeOIDCClientOperations{oidcClient: existing, updateResult: existing}
+
+		d := schema.TestResourceDataRaw(t, oidcClientFields(), map[string]any{
+			"description":   "Updated description",
+			"redirect_uris": []any{"http://127.0.0.1:5556/auth/rancher/callback"},
+		})
+		d.SetId("oidc-client-1")
+
+		err := resourceRancher2OIDCClientUpdate(d, newGetter(ops))
+
+		require.NoError(t, err)
+		payload := ops.updateCalledWith.(map[string]any)
+		assert.NotContains(t, payload, "tokenExpirationSeconds")
+		assert.NotContains(t, payload, "refreshTokenExpirationSeconds")
+	})
+
 	t.Run("updates resource and refreshes state on success", func(t *testing.T) {
 		existing := &managementClient.OIDCClient{
 			Resource: types.Resource{

--- a/rancher2/structure_oidc_client.go
+++ b/rancher2/structure_oidc_client.go
@@ -27,22 +27,16 @@ func expandOIDCClient(in *schema.ResourceData) (*managementClient.OIDCClient, er
 	v := in.Get("redirect_uris")
 	obj.RedirectURIs = toArrayString(v.([]any))
 
-	v, ok := in.GetOk("token_expiration_seconds")
-	if ok {
+	if v, ok := in.GetOk("token_expiration_seconds"); ok {
 		// This should be safe because the field is declared as an integer.
 		tokenExpirationSeconds := v.(int)
 		obj.TokenExpirationSeconds = int64(tokenExpirationSeconds)
-	} else {
-		obj.TokenExpirationSeconds = 0
 	}
 
-	v, ok = in.GetOk("refresh_token_expiration_seconds")
-	if ok {
-		// This should be safe because the field is declared as an integer.
+	if v, ok := in.GetOk("refresh_token_expiration_seconds"); ok {
 		refreshTokenExpirationSeconds := v.(int)
 		obj.RefreshTokenExpirationSeconds = int64(refreshTokenExpirationSeconds)
-	} else {
-		obj.RefreshTokenExpirationSeconds = 0
+
 	}
 
 	if v, ok := in.Get("annotations").(map[string]any); ok && len(v) > 0 {


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->
- Addresses https://github.com/rancher/terraform-provider-rancher2/issues/2418
<!--- Add labels (eg. release/v15) for each release branch to target --->
<!--- Please don't manually add "internal" labels, those are for automation only --->

## Description
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
This fixes an issue where even when the values weren't set the value was still put into the update payload.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? -->
<!--- If so, change the following line with an explanation. --->
Not a breaking change.
