### PR TITLE
fix: make machine_config kind and name Optional+Computed so unknowns survive (#1501)

### DIFF
--- a/rancher2/resource_rancher2_cluster_v2_customizediff_test.go
+++ b/rancher2/resource_rancher2_cluster_v2_customizediff_test.go
@@ -1,0 +1,193 @@
+package rancher2
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// unknownValue mirrors hcl2shim.UnknownVariableValue, the in-band marker the SDK
+// uses for a value that is not known until apply. That package is internal to
+// the SDK, so the constant is repeated here.
+const unknownValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
+
+const machineConfigNameKey = "rke_config.0.machine_pools.0.machine_config.0.name"
+
+// clusterV2DiffConfig builds a minimal rancher2_cluster_v2 config with a single
+// machine pool whose machine_config name is set to machineConfigName.
+func clusterV2DiffConfig(machineConfigName string) *terraform.ResourceConfig {
+	return clusterV2DiffConfigKind("VmwarevsphereConfig", machineConfigName)
+}
+
+// clusterV2DiffConfigKind is clusterV2DiffConfig with machine_config kind also
+// parameterised, so the kind attribute can be driven unknown independently.
+func clusterV2DiffConfigKind(machineConfigKind, machineConfigName string) *terraform.ResourceConfig {
+	return terraform.NewResourceConfigRaw(map[string]interface{}{
+		"name":               "test-cluster",
+		"fleet_namespace":    "fleet-default",
+		"kubernetes_version": "v1.31.5+rke2r1",
+		"rke_config": []interface{}{
+			map[string]interface{}{
+				"machine_pools": []interface{}{
+					map[string]interface{}{
+						"name":                         "pool1",
+						"cloud_credential_secret_name": "cattle-global-data:cc-test",
+						"control_plane_role":           true,
+						"etcd_role":                    true,
+						"worker_role":                  false,
+						"quantity":                     1,
+						"machine_config": []interface{}{
+							map[string]interface{}{
+								"kind": machineConfigKind,
+								"name": machineConfigName,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestResourceRancher2ClusterV2DiffUnknownMachineConfigName covers
+// rancher/terraform-provider-rancher2#1501: creating a rancher2_cluster_v2 in
+// the same apply as the rancher2_machine_config_v2 it references.
+//
+// rancher2_machine_config_v2 takes generate_name and exposes .name as Computed
+// only, so the name genuinely cannot be known at plan time. CustomizeDiff must
+// leave that unknown in place. Normalizing the block with
+// SetNew(flatten(expand(GetChange()))) plans a known "" instead, because
+// GetChange collapses unknowns to the zero value, and Terraform then aborts the
+// apply:
+//
+//	Provider produced inconsistent final plan ... produced an invalid new value
+//	for .rke_config[0].machine_pools[0].machine_config[0].name: was
+//	cty.StringVal(""), but now cty.StringVal("nc-mc-pool1-p5mqh")
+func TestResourceRancher2ClusterV2DiffUnknownMachineConfigName(t *testing.T) {
+	diff, err := resourceRancher2ClusterV2().Diff(nil, clusterV2DiffConfig(unknownValue), nil)
+	if err != nil {
+		t.Fatalf("Diff failed: %v", err)
+	}
+	if diff == nil {
+		t.Fatal("expected a diff for a resource being created, got nil")
+	}
+
+	attr, ok := diff.Attributes[machineConfigNameKey]
+	if !ok {
+		// This is how the bug presents: SetNew planned "", which matched the
+		// empty prior value, so the SDK dropped the attribute and the shim
+		// reports a known "" to Terraform.
+		t.Fatalf("%s was dropped from the planned diff; it must be planned as unknown", machineConfigNameKey)
+	}
+	if !attr.NewComputed {
+		t.Errorf("%s was planned as the known value %q; it must stay unknown so apply can supply the generated name",
+			machineConfigNameKey, attr.New)
+	}
+}
+
+// TestResourceRancher2ClusterV2DiffKnownMachineConfigName is one half of the
+// guard against the #1501 fix over-applying: a fully known machine_config name
+// must be planned as that known value.
+func TestResourceRancher2ClusterV2DiffKnownMachineConfigName(t *testing.T) {
+	diff, err := resourceRancher2ClusterV2().Diff(nil, clusterV2DiffConfig("nc-mc-pool1-p5mqh"), nil)
+	if err != nil {
+		t.Fatalf("Diff failed: %v", err)
+	}
+	if diff == nil {
+		t.Fatal("expected a diff for a resource being created, got nil")
+	}
+
+	attr, ok := diff.Attributes[machineConfigNameKey]
+	if !ok {
+		t.Fatalf("%s missing from the planned diff", machineConfigNameKey)
+	}
+	if attr.NewComputed {
+		t.Errorf("%s was planned as unknown even though the config supplies a known name", machineConfigNameKey)
+	}
+	if attr.New != "nc-mc-pool1-p5mqh" {
+		t.Errorf("%s planned as %q, want %q", machineConfigNameKey, attr.New, "nc-mc-pool1-p5mqh")
+	}
+}
+
+// clusterV2PriorState is an existing cluster whose machine pool points at an
+// already-created machine config named oldName.
+func clusterV2PriorState(oldName string) *terraform.InstanceState {
+	return &terraform.InstanceState{
+		ID: "fleet-default/test-cluster",
+		Attributes: map[string]string{
+			"id":                 "fleet-default/test-cluster",
+			"name":               "test-cluster",
+			"fleet_namespace":    "fleet-default",
+			"kubernetes_version": "v1.31.5+rke2r1",
+
+			"rke_config.#":                                              "1",
+			"rke_config.0.machine_pools.#":                              "1",
+			"rke_config.0.machine_pools.0.name":                         "pool1",
+			"rke_config.0.machine_pools.0.cloud_credential_secret_name": "cattle-global-data:cc-test",
+			"rke_config.0.machine_pools.0.control_plane_role":           "true",
+			"rke_config.0.machine_pools.0.etcd_role":                    "true",
+			"rke_config.0.machine_pools.0.worker_role":                  "false",
+			"rke_config.0.machine_pools.0.quantity":                     "1",
+			"rke_config.0.machine_pools.0.machine_config.#":             "1",
+			"rke_config.0.machine_pools.0.machine_config.0.kind":        "VmwarevsphereConfig",
+			"rke_config.0.machine_pools.0.machine_config.0.name":        oldName,
+		},
+	}
+}
+
+// TestResourceRancher2ClusterV2DiffReplacedMachineConfigName covers the same defect
+// reached by a different route: an existing cluster whose machine config is
+// replaced, so generate_name yields a new name that is again unknown at plan
+// time. Here the normalization plans the *old* name as the new value, which is
+// worse than the create case -- "" at least looks obviously wrong.
+func TestResourceRancher2ClusterV2DiffReplacedMachineConfigName(t *testing.T) {
+	const oldName = "nc-mc-pool1-oldxx"
+
+	diff, err := resourceRancher2ClusterV2().Diff(
+		clusterV2PriorState(oldName), clusterV2DiffConfig(unknownValue), nil)
+	if err != nil {
+		t.Fatalf("Diff failed: %v", err)
+	}
+	if diff == nil {
+		t.Fatal("expected a diff when the machine config name changes, got nil")
+	}
+
+	attr, ok := diff.Attributes[machineConfigNameKey]
+	if !ok {
+		t.Fatalf("%s was dropped from the planned diff; the cluster would keep pointing at the destroyed machine config %q", machineConfigNameKey, oldName)
+	}
+	if !attr.NewComputed {
+		t.Errorf("%s was planned as the known value %q (old value was %q); it must stay unknown so apply can supply the regenerated name",
+			machineConfigNameKey, attr.New, oldName)
+	}
+}
+
+const machineConfigKindKey = "rke_config.0.machine_pools.0.machine_config.0.kind"
+
+// TestResourceRancher2ClusterV2DiffUnknownMachineConfigKind covers the same
+// defect on the sibling attribute. rancher2_machine_config_v2 exposes both kind
+// and name as Computed only, so a config that references either of them --
+// kind = rancher2_machine_config_v2.pool1.kind -- has an unknown here at plan
+// time, and CustomizeDiff would collapse it to a known "" just the same.
+//
+// Fixing only name would leave this path broken; at least one reporter on #1501
+// worked around it by hardcoding the kind literal.
+func TestResourceRancher2ClusterV2DiffUnknownMachineConfigKind(t *testing.T) {
+	diff, err := resourceRancher2ClusterV2().Diff(
+		nil, clusterV2DiffConfigKind(unknownValue, "nc-mc-pool1-p5mqh"), nil)
+	if err != nil {
+		t.Fatalf("Diff failed: %v", err)
+	}
+	if diff == nil {
+		t.Fatal("expected a diff for a resource being created, got nil")
+	}
+
+	attr, ok := diff.Attributes[machineConfigKindKey]
+	if !ok {
+		t.Fatalf("%s was dropped from the planned diff; it must be planned as unknown", machineConfigKindKey)
+	}
+	if !attr.NewComputed {
+		t.Errorf("%s was planned as the known value %q; it must stay unknown so apply can supply the kind",
+			machineConfigKindKey, attr.New)
+	}
+}

--- a/rancher2/schema_cluster_v2_rke_config_machine_pool.go
+++ b/rancher2/schema_cluster_v2_rke_config_machine_pool.go
@@ -11,13 +11,23 @@ import (
 func clusterV2RKEConfigMachinePoolMachineConfigFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
 		"kind": {
-			Type:        schema.TypeString,
-			Required:    true,
+			Type:     schema.TypeString,
+			Optional: true,
+			// Computed for the same reason as name below: rancher2_machine_config_v2
+			// exposes kind as Computed only, so a config referencing it has an
+			// unknown here at plan time.
+			Computed:    true,
 			Description: "Machine config kind",
 		},
 		"name": {
-			Type:        schema.TypeString,
-			Required:    true,
+			Type:     schema.TypeString,
+			Optional: true,
+			// Computed so the SDK re-marks this as unknown after CustomizeDiff's
+			// SetNew writes a zero over it. rancher2_machine_config_v2 takes
+			// generate_name, so the name does not exist until create; without
+			// Computed the unknown is replaced by a known "" and apply then
+			// contradicts the plan. See #1501.
+			Computed:    true,
 			Description: "Machine config name",
 		},
 		"api_version": {


### PR DESCRIPTION
Fixes #1501. Reproduction and analysis in [this comment](https://github.com/rancher/terraform-provider-rancher2/issues/1501#issuecomment-5427678140).

## The bug

`rancher2_machine_config_v2` exposes **both** `kind` and `name` as `Computed` only, and it takes `generate_name`, so neither value can exist until the resource is created. When a `rancher2_cluster_v2` references them in the same operation, Terraform correctly plans them as unknown — and the provider then overwrites them with a known `""`:

```
Error: Provider produced inconsistent final plan

... produced an invalid new value for
.rke_config[0].machine_pools[0].machine_config[0].name: was cty.StringVal(""),
but now cty.StringVal("nc-mc-pool1-p5mqh").
```

`CustomizeDiff` normalizes the block by round-tripping it and writing the result back with `SetNew`. `ResourceDiff.GetChange` collapses **unknown** to the type's zero value, so `""` is what gets planned as a known value.

There is a second route to the same defect: a machine config **replaced** on an existing cluster. The regenerated name is unknown again, and there the normalization plans the **old** name as the new value — more insidious, since a stale-but-plausible name doesn't look wrong.

## The fix

The SDK already handles this for other fields. It re-marks a `Computed` node as computed after `SetNew` writes a zero over it, which is exactly why `etcd`, `machine_selector_config` and the `annotations`/`labels` maps keep their unknowns through this same code path. `kind` and `name` were `Required`, so they received no such treatment.

Making both `Optional + Computed` is therefore the entire fix. **`CustomizeDiff` is untouched**, so normalization behaves exactly as it does today for every other configuration.

Verified with `terraform plan`, on a config referencing both computed attributes, that all three properties hold at once:

```json
{"after":   [{"api_version": null}],
 "unknown": [{"kind": true, "name": true}],
 "machine_global_config": "cni: cilium\n"}
```

`kind` and `name` are known-after-apply, and `machine_global_config` is still normalized from `{"cni":"cilium"}`. On current `main` the same config plans `name` as a known `""`.

## An approach that does not work, in case it comes up

This PR originally proposed **skipping** normalization in `CustomizeDiff` while the block still contained unknowns. That is wrong, and the failure mode is not obvious, so it seems worth recording.

Terraform re-plans during apply. In the first pass the machine config name is unknown, so normalization was skipped and the saved plan held the **raw** config. By the apply-time pass the name is known, so normalization **ran** and produced the **normalized** config. A known value changing to a different known value is rejected, so it traded one inconsistent-final-plan error for several others — on `machine_global_config` and `machine_selector_config[0].config` (YAML re-serialized), `registries[0].configs[0].insecure` (null → false), `machine_pools[*].paused` (null → false) and `machine_pools[*].node_drain_timeout` (0 → null).

It passed unit tests and a real `terraform plan`. It failed on a production apply.

The invariant is that **`CustomizeDiff` must behave identically in both plan passes**, and any approach conditional on unknowns being present violates it, because that condition is precisely what differs between the two. The schema flags avoid the problem rather than working around it.

## Tests

Three fail on `main` and pass with this change:

| test | failure on `main` |
| --- | --- |
| `...DiffUnknownMachineConfigName` | name dropped from the planned diff |
| `...DiffReplacedMachineConfigName` | name planned as `""` where the old value was `nc-mc-pool1-oldxx` |
| `...DiffUnknownMachineConfigKind` | kind dropped from the planned diff |

A fourth asserts the fix does not over-apply: a known name is still planned as that known value. All drive a real plan through the exported `Resource.Diff`; no Rancher instance required.

## What is and is not production-validated

Being precise, since these differ:

- **The `name` paths are running in production** on our on-prem RKE2 fleet. Three consecutive applies on a real cluster exercised both: the initial create (cluster and machine configs in one apply), a machine config replace, and the replace back. No errors. Before the change, the same create reproduced the issue every time.
- **The `kind` change is not production-exercised.** Our configs hardcode `kind = "VmwarevsphereConfig"`, so that path is unreachable for us. It is the identical mechanism on a sibling attribute in the same block, verified by unit test and by the `terraform plan` above, but I want to be clear it has not run against a live Rancher. It was added after review feedback pointed out that fixing only `name` would leave the same bug reachable via `kind` — which matches at least one reporter on #1501 who worked around it by hardcoding the kind literal.

## Trade-off

Omitting `kind` or `name` is no longer a schema validation error — Rancher rejects an empty machine config kind/name at apply instead. That seemed the acceptable cost for values the provider populates anyway, but I am happy to revisit if you would rather keep the validation.

## Note on SDK v1

`GetRawPlan`/`GetRawConfig` are SDKv2 only, and `SetNew`/`SetNewComputed`/`Clear` all reject non-`Computed` keys and (for the first two) nested addresses. So there is no way to normalize the block while keeping a `Required` leaf unknown — the schema flags are the only available lever. Worth knowing if this area is revisited.