### PR TITLE
feat: add release backport QA tracking audit script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ main.tf
 terraform-provider-rancher2
 node_modules
 .vscode
+backport_qa_report.md

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ terraform-provider-rancher2
 node_modules
 .vscode
 backport_qa_report.md
+.DS_Store

--- a/docs/development/ReleaseProcess.md
+++ b/docs/development/ReleaseProcess.md
@@ -131,20 +131,20 @@ This swimlane diagram traces the detailed event triggers and data flow between d
 
 When cherry-picking features and bug fixes from `main` to release branches (such as `release/v15`), we must guarantee that all backported commits are linked to a valid **QA Tracking Issue** (marked by the `internal/backport` label) to ensure complete testing and audit compliance.
 
-To audit this state automatically, we maintain a central, zero-dependency Node.js utility script:
+To audit this state automatically, we maintain a central Node.js utility script that interfaces with GitHub's APIs:
 - **Script Location:** `scripts/trace_backports.js`
+- **Prerequisite:** Requires the **GitHub CLI (`gh`)** to be installed on your system and authenticated (`gh auth login`).
 - **Execution Command:**
   ```bash
   node scripts/trace_backports.js [options]
   ```
 - **Supported Options:**
   - `--branch` / `-b`: Target release branch (default: `release/v15`).
-  - `--start` / `-s`: Starting tag or commit ref (optional). If omitted, automatically defaults to the branch-off point from `main`.
+  - `--start` / `-s`: Starting tag or commit ref (optional). If omitted, automatically defaults to the branch-off (divergence) point from `main`.
 - **Functionality:**
-  1. **Syncs branch references** with `origin` to prevent stale ref confusion (with graceful local-fallback on network constraints).
-  2. **Isolates unique commits** added since divergence from `main` (or since the explicit `--start` tag).
-  3. **Identifies the backport PR** on GitHub for each commit, automatically filtering out release-please wrapper PRs.
-  4. **Scans description text** for associated issue numbers and retrieves their details.
-  5. **Filters issues by labels** to cleanly separate original user issues from the actual `internal/backport` QA tracking issue.
-  6. **Generates full audit logs** via a formatted console table and writes a structured Markdown report (`backport_qa_report.md`).
+  1. **Queries GitHub's Compare API** directly (bypassing local Git sync and fetch constraints) to fetch all unique commits on the release branch relative to `main` (or a specific tag).
+  2. **Identifies the backport PR** on GitHub for each commit, automatically filtering out release-please wrapper PRs.
+  3. **Scans description text** for associated issue numbers and retrieves their details.
+  4. **Filters issues by labels** to cleanly separate original user issues from the actual `internal/backport` QA tracking issue.
+  5. **Generates full audit logs** via a formatted console table and writes a structured Markdown report (`backport_qa_report.md`).
 

--- a/docs/development/ReleaseProcess.md
+++ b/docs/development/ReleaseProcess.md
@@ -124,3 +124,27 @@ This swimlane diagram traces the detailed event triggers and data flow between d
 |                                             |           - Action: Reconciles Release PR labels in GitHub     |
 |                                             |                                                                |
 ```
+
+---
+
+### 3. Backport Auditing & QA Tracking Tool
+
+When cherry-picking features and bug fixes from `main` to release branches (such as `release/v15`), we must guarantee that all backported commits are linked to a valid **QA Tracking Issue** (marked by the `internal/backport` label) to ensure complete testing and audit compliance.
+
+To audit this state automatically, we maintain a central, zero-dependency Node.js utility script:
+- **Script Location:** `scripts/trace_backports.js`
+- **Execution Command:**
+  ```bash
+  node scripts/trace_backports.js [options]
+  ```
+- **Supported Options:**
+  - `--branch` / `-b`: Target release branch (default: `release/v15`).
+  - `--start` / `-s`: Starting tag or commit ref (optional). If omitted, automatically defaults to the branch-off point from `main`.
+- **Functionality:**
+  1. **Syncs branch references** with `origin` to prevent stale ref confusion (with graceful local-fallback on network constraints).
+  2. **Isolates unique commits** added since divergence from `main` (or since the explicit `--start` tag).
+  3. **Identifies the backport PR** on GitHub for each commit, automatically filtering out release-please wrapper PRs.
+  4. **Scans description text** for associated issue numbers and retrieves their details.
+  5. **Filters issues by labels** to cleanly separate original user issues from the actual `internal/backport` QA tracking issue.
+  6. **Generates full audit logs** via a formatted console table and writes a structured Markdown report (`backport_qa_report.md`).
+

--- a/scripts/trace_backports.js
+++ b/scripts/trace_backports.js
@@ -28,19 +28,14 @@ console.log(`=========================================\n`);
 const baseCompare = startRef || 'main';
 console.log(`📌 [1/4] Comparing starting reference '${baseCompare}' with head branch '${branch}'...`);
 
-// 2. Fetch unique commits using GitHub Compare API
-console.log(`📋 [2/4] Fetching unique commits on '${branch}' since '${baseCompare}' from GitHub API...`);
+// 2. Fetch all commits using GitHub Compare API
+console.log(`📋 [2/4] Fetching all commits on '${branch}' since '${baseCompare}' from GitHub API...`);
 let commits = [];
 try {
-<<<<<<< Updated upstream
   const baseRef = encodeURIComponent(baseCompare);
   const headRef = encodeURIComponent(branch);
   const apiPath = `repos/rancher/terraform-provider-rancher2/compare/${baseRef}...${headRef}`;
   const responseJson = execFileSync('gh', ['api', apiPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
-=======
-  const apiPath = `repos/rancher/terraform-provider-rancher2/compare/${baseCompare}...${branch}`;
-  const responseJson = execFileSync('gh', ['api', apiPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
->>>>>>> Stashed changes
   const response = JSON.parse(responseJson);
   
   if (response && response.commits) {

--- a/scripts/trace_backports.js
+++ b/scripts/trace_backports.js
@@ -32,7 +32,9 @@ console.log(`📌 [1/4] Comparing starting reference '${baseCompare}' with head 
 console.log(`📋 [2/4] Fetching unique commits on '${branch}' since '${baseCompare}' from GitHub API...`);
 let commits = [];
 try {
-  const apiPath = `repos/rancher/terraform-provider-rancher2/compare/${baseCompare}...${branch}`;
+  const baseRef = encodeURIComponent(baseCompare);
+  const headRef = encodeURIComponent(branch);
+  const apiPath = `repos/rancher/terraform-provider-rancher2/compare/${baseRef}...${headRef}`;
   const responseJson = execFileSync('gh', ['api', apiPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
   const response = JSON.parse(responseJson);
   

--- a/scripts/trace_backports.js
+++ b/scripts/trace_backports.js
@@ -25,43 +25,35 @@ console.log(`Target Branch: ${branch}`);
 console.log(`=========================================\n`);
 
 // 1. Determine starting compare reference
-const baseCompare = startRef || 'main';
+let baseCompare = startRef;
+if (!baseCompare) {
+  try {
+    // Automatically find the most recent tag reachable from the target branch
+    baseCompare = execFileSync('git', ['describe', '--tags', '--abbrev=0', branch], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch (err) {
+    baseCompare = 'main'; // Fallback if no tags exist
+  }
+}
 console.log(`📌 [1/4] Comparing starting reference '${baseCompare}' with head branch '${branch}'...`);
 
-// 2. Fetch all commits using GitHub Compare API
-console.log(`📋 [2/4] Fetching all commits on '${branch}' since '${baseCompare}' from GitHub API...`);
+// 2. Fetch all commits using local git
+console.log(`📋 [2/4] Fetching all commits on '${branch}' since '${baseCompare}' using local Git...`);
 let commits = [];
 try {
-  const baseRef = encodeURIComponent(baseCompare);
-  const headRef = encodeURIComponent(branch);
-  const apiPath = `repos/rancher/terraform-provider-rancher2/compare/${baseRef}...${headRef}`;
-  const responseJson = execFileSync('gh', ['api', apiPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
-  const response = JSON.parse(responseJson);
+  // Using two-dot syntax for strict reachability (avoids merge-base shift)
+  const logArgs = ['log', `${baseCompare}..${branch}`, '--format=%H%x00%s'];
+  const logOutput = execFileSync('git', logArgs, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
   
-  if (response && response.commits) {
-    // Fix 1: Check and warn if GitHub Compare API truncated the returned commits array
-    if (response.total_commits > response.commits.length) {
-      console.warn(`⚠️ \x1b[33m[Warning] GitHub API compare endpoint truncated the commits list (returned ${response.commits.length} of ${response.total_commits} commits). The audit report may be incomplete.\x1b[0m`);
-    }
-
-    commits = response.commits.map(c => {
-      const sha = c.sha;
-      const fullMessage = (c.commit && c.commit.message) || 'No message';
-      const subject = fullMessage.split('\n')[0];
-      return { sha, subject };
+  if (logOutput) {
+    commits = logOutput.split('\n').map(line => {
+      const [sha, ...subjectParts] = line.split('\0');
+      return { sha, subject: subjectParts.join('\0') };
     });
   }
 } catch (err) {
-  // Fix 2: Explicitly detect when GitHub CLI is not installed (ENOENT)
-  if (err.code === 'ENOENT') {
-    console.error(`❌ [Error] The GitHub CLI ('gh') was not found on your system. Please ensure 'gh' is installed and authenticated to run this script.`);
-    process.exit(1);
-  }
-  
-  // Fix 3: Log standard error stream from the CLI for rich debugging
   const errMsg = err.stderr ? err.stderr.toString().trim() : err.message;
-  console.error(`❌ [Error] Failed to fetch compare logs from GitHub REST API: ${errMsg}`);
-  console.error(`Please verify that you have internet access and that the gh CLI is authenticated.`);
+  console.error(`❌ [Error] Failed to fetch commits using local git: ${errMsg}`);
+  console.error(`Please verify your branch names and ensure your local repository is up to date (run 'git fetch').`);
   process.exit(1);
 }
 
@@ -72,8 +64,6 @@ if (commits.length === 0) {
   process.exit(0);
 }
 
-// 3. Trace each commit back to its PR and QA tracking issue
-console.log(`🛰️ [3/4] Auditing commits against GitHub API (this may take a moment)...`);
 const results = [];
 
 for (const commit of commits) {
@@ -146,7 +136,7 @@ for (const commit of commits) {
   results.push({
     sha: commit.sha,
     subject: commit.subject,
-    pr: pr ? { number: pr.number, title: pr.title, url: pr.html_url } : null,
+    pr: pr ? { number: pr.number, title: pr.title, url: pr.html_url, createdAt: pr.created_at } : null,
     qaIssue: qaIssue ? { number: qaIssue.number, title: qaIssue.title, state: qaIssue.state, url: qaIssue.url } : null,
   });
 }
@@ -155,9 +145,9 @@ for (const commit of commits) {
 console.log(`\n📝 [4/4] Generating reports...`);
 
 // Render beautiful console table
-console.log(`\n=============================================================================================================`);
-console.log(`| SHA      | Backport PR  | QA Issue   | Status   | Title                                                     |`);
-console.log(`=============================================================================================================`);
+console.log(`\n============================================================================================================================`);
+console.log(`| SHA      | Backport PR  | QA Issue   | Status   | Created    | Title                                                     |`);
+console.log(`============================================================================================================================`);
 for (const r of results) {
   const shortSha = r.sha.substring(0, 8);
   const prCol = r.pr ? `#${r.pr.number}`.padEnd(12) : 'N/A'.padEnd(12);
@@ -168,12 +158,14 @@ for (const r of results) {
     statusCol = r.qaIssue.state === 'OPEN' ? '🟢 OPEN   ' : '🔵 CLOSED ';
   }
   
+  const createdCol = (r.pr && r.pr.createdAt ? r.pr.createdAt.substring(0, 10) : 'N/A').padEnd(10);
+  
   const title = (r.pr ? r.pr.title : r.subject).substring(0, 56);
   const titleCol = title.padEnd(57);
   
-  console.log(`| ${shortSha} | ${prCol} | ${issueCol} | ${statusCol} | ${titleCol} |`);
+  console.log(`| ${shortSha} | ${prCol} | ${issueCol} | ${statusCol} | ${createdCol} | ${titleCol} |`);
 }
-console.log(`=============================================================================================================\n`);
+console.log(`============================================================================================================================\n`);
 
 // Generate Markdown report
 const reportPath = path.resolve('backport_qa_report.md');
@@ -195,18 +187,19 @@ for (const r of results) {
   const commitLink = `[\`${r.sha.substring(0, 8)}\`](https://github.com/rancher/terraform-provider-rancher2/commit/${r.sha})`;
   const prLink = r.pr ? `[#${r.pr.number}](${r.pr.url})` : '`N/A`';
   const qaLink = r.qaIssue ? `[#${r.qaIssue.number}](${r.qaIssue.url})` : '`N/A`';
-  
+  const createdDate = r.pr && r.pr.createdAt ? r.pr.createdAt.substring(0, 10) : '`N/A`';
+
   let statusBadge = '🔴 **Missing**';
   if (r.qaIssue) {
     statusBadge = r.qaIssue.state === 'OPEN' ? '🟢 **Open**' : '🔵 **Closed**';
   }
-  
+
   // Fix 5: Sanitize PR title/subject for Markdown table safety (escaping pipes and removing newlines)
   const title = (r.pr ? r.pr.title : r.subject)
     .replace(/\|/g, '\\|')
     .replace(/\r?\n|\r/g, ' ');
     
-  mdContent += `| ${commitLink} | ${prLink} | ${qaLink} | ${statusBadge} | ${title} |\n`;
+  mdContent += `| ${commitLink} | ${prLink} | ${qaLink} | ${statusBadge} | ${createdDate} | ${title} |\n`;
 }
 
 mdContent += `

--- a/scripts/trace_backports.js
+++ b/scripts/trace_backports.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+// Parse command-line arguments
+const args = process.argv.slice(2);
+let branch = 'release/v15';
+let startRef = null;
+
+for (let i = 0; i < args.length; i++) {
+  if ((args[i] === '--branch' || args[i] === '-b') && args[i + 1]) {
+    branch = args[i + 1];
+    i++;
+  } else if ((args[i] === '--start' || args[i] === '-s') && args[i + 1]) {
+    startRef = args[i + 1];
+    i++;
+  }
+}
+
+console.log(`=========================================`);
+console.log(`🔍 Backport QA Tracker Audit (GitHub API)`);
+console.log(`Target Branch: ${branch}`);
+console.log(`=========================================\n`);
+
+// 1. Determine starting compare reference
+const baseCompare = startRef || 'main';
+console.log(`📌 [1/4] Comparing starting reference '${baseCompare}' with head branch '${branch}'...`);
+
+// 2. Fetch unique commits using GitHub Compare API
+console.log(`📋 [2/4] Fetching unique commits on '${branch}' since '${baseCompare}' from GitHub API...`);
+let commits = [];
+try {
+  const apiPath = `repos/rancher/terraform-provider-rancher2/compare/${baseCompare}...${branch}`;
+  const responseJson = execFileSync('gh', ['api', apiPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  const response = JSON.parse(responseJson);
+  
+  if (response && response.commits) {
+    commits = response.commits.map(c => {
+      const sha = c.sha;
+      const fullMessage = (c.commit && c.commit.message) || 'No message';
+      const subject = fullMessage.split('\n')[0];
+      return { sha, subject };
+    });
+  }
+} catch (err) {
+  console.error(`❌ [Error] Failed to fetch compare logs from GitHub REST API: ${err.message}`);
+  console.error(`Please verify that you have internet access and that the gh CLI is authenticated.`);
+  process.exit(1);
+}
+
+console.log(`   Found ${commits.length} commits to audit.\n`);
+
+if (commits.length === 0) {
+  console.log(`🎉 No commits found since ${baseCompare}. Audit complete!`);
+  process.exit(0);
+}
+
+// 3. Trace each commit back to its PR and QA tracking issue
+console.log(`🛰️ [3/4] Auditing commits against GitHub API (this may take a moment)...`);
+const results = [];
+
+for (const commit of commits) {
+  process.stdout.write(`   - Auditing ${commit.sha.substring(0, 8)}... `);
+  let pr = null;
+  try {
+    const prsJson = execFileSync('gh', ['api', `repos/rancher/terraform-provider-rancher2/commits/${commit.sha}/pulls`], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    const prs = JSON.parse(prsJson);
+    if (prs && prs.length > 0) {
+      // Prioritize the backport PR base matching our target branch, filtering out release-please PRs
+      const releasePleaseRegex = /^(chore\(release|release-please)/i;
+      const nonReleasePleasePrs = prs.filter(p => !releasePleaseRegex.test(p.title || ''));
+      
+      if (nonReleasePleasePrs.length > 0) {
+        pr = nonReleasePleasePrs.find(p => p.base && p.base.ref === branch) || nonReleasePleasePrs[0];
+      } else {
+        pr = prs.find(p => p.base && p.base.ref === branch) || prs[0];
+      }
+    }
+  } catch (err) {
+    console.error(`\n⚠️ [Debug] Failed to fetch PR for commit ${commit.sha}: ${err.message}`);
+  }
+
+  let qaIssue = null;
+  if (pr) {
+    const body = pr.body || '';
+    // Capture pattern #1234 or rancher/terraform-provider-rancher2/issues/1234
+    const issueMatches = body.match(/#\d+/g) || [];
+    const urlMatches = body.match(/issues\/\d+/g) || [];
+
+    const issueNumbers = new Set();
+    for (const m of issueMatches) {
+      issueNumbers.add(parseInt(m.slice(1), 10));
+    }
+    for (const m of urlMatches) {
+      const parts = m.split('/');
+      issueNumbers.add(parseInt(parts[parts.length - 1], 10));
+    }
+
+    // Inspect each candidate issue to check labels
+    for (const issueNum of issueNumbers) {
+      try {
+        const issueJson = execFileSync('gh', ['issue', 'view', String(issueNum), '-R', 'rancher/terraform-provider-rancher2', '--json', 'number,title,labels,state,url'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+        const issue = JSON.parse(issueJson);
+        const isBackportQA = issue.labels && issue.labels.some(l => l.name === 'internal/backport');
+        if (isBackportQA) {
+          qaIssue = issue;
+          break; // Found the QA tracking issue, no need to look further
+        }
+      } catch (err) {
+        console.error(`\n⚠️ [Debug] Failed to fetch issue #${issueNum}: ${err.message}`);
+      }
+    }
+  }
+
+  if (pr) {
+    if (qaIssue) {
+      process.stdout.write(`Matched to Backport PR #${pr.number} and QA Issue #${qaIssue.number} (${qaIssue.state})\n`);
+    } else {
+      process.stdout.write(`Matched to Backport PR #${pr.number} (⚠️ Missing QA Issue)\n`);
+    }
+  } else {
+    process.stdout.write(`⚠️ No PR found!\n`);
+  }
+
+  results.push({
+    sha: commit.sha,
+    subject: commit.subject,
+    pr: pr ? { number: pr.number, title: pr.title, url: pr.html_url } : null,
+    qaIssue: qaIssue ? { number: qaIssue.number, title: qaIssue.title, state: qaIssue.state, url: qaIssue.url } : null,
+  });
+}
+
+// 4. Generate structured reports
+console.log(`\n📝 [4/4] Generating reports...`);
+
+// Render beautiful console table
+console.log(`\n=============================================================================================================`);
+console.log(`| SHA      | Backport PR  | QA Issue   | Status   | Title                                                     |`);
+console.log(`=============================================================================================================`);
+for (const r of results) {
+  const shortSha = r.sha.substring(0, 8);
+  const prCol = r.pr ? `#${r.pr.number}`.padEnd(12) : 'N/A'.padEnd(12);
+  const issueCol = r.qaIssue ? `#${r.qaIssue.number}`.padEnd(10) : 'N/A'.padEnd(10);
+  
+  let statusCol = '❌ MISSING';
+  if (r.qaIssue) {
+    statusCol = r.qaIssue.state === 'OPEN' ? '🟢 OPEN   ' : '🔵 CLOSED ';
+  }
+  
+  const title = (r.pr ? r.pr.title : r.subject).substring(0, 56);
+  const titleCol = title.padEnd(57);
+  
+  console.log(`| ${shortSha} | ${prCol} | ${issueCol} | ${statusCol} | ${titleCol} |`);
+}
+console.log(`=============================================================================================================\n`);
+
+// Generate Markdown report
+const reportPath = path.resolve('backport_qa_report.md');
+let mdContent = `# 🔍 Release Audit Report: Backport QA Status
+
+**Audit Date:** ${new Date().toLocaleDateString()}
+**Target Branch:** \`${branch}\`
+**Compare Ref:** \`${baseCompare}\`
+
+---
+
+## Summary Table
+
+| Release Commit | Backport PR | QA Tracking Issue | QA Status | Description / Title |
+| :--- | :--- | :--- | :---: | :--- |
+`;
+
+for (const r of results) {
+  const commitLink = `[\`${r.sha.substring(0, 8)}\`](https://github.com/rancher/terraform-provider-rancher2/commit/${r.sha})`;
+  const prLink = r.pr ? `[#${r.pr.number}](${r.pr.url})` : '`N/A`';
+  const qaLink = r.qaIssue ? `[#${r.qaIssue.number}](${r.qaIssue.url})` : '`N/A`';
+  
+  let statusBadge = '🔴 **Missing**';
+  if (r.qaIssue) {
+    statusBadge = r.qaIssue.state === 'OPEN' ? '🟢 **Open**' : '🔵 **Closed**';
+  }
+  
+  const title = r.pr ? r.pr.title : r.subject;
+  mdContent += `| ${commitLink} | ${prLink} | ${qaLink} | ${statusBadge} | ${title} |\n`;
+}
+
+mdContent += `
+---
+*Report generated automatically by \`scripts/trace_backports.js\`*
+`;
+
+try {
+  fs.writeFileSync(reportPath, mdContent);
+  console.log(`🎉 Markdown report successfully generated at: ${reportPath}`);
+} catch (err) {
+  console.error(`❌ Failed to write Markdown report:`, err.message);
+}

--- a/scripts/trace_backports.js
+++ b/scripts/trace_backports.js
@@ -37,9 +37,10 @@ try {
   const response = JSON.parse(responseJson);
   
   if (response && response.commits) {
-    // Fix 1: Check and warn if GitHub Compare API truncated the returned commits array
+    // Fix 1: Fail fast if GitHub Compare API truncated the returned commits array
     if (response.total_commits > response.commits.length) {
-      console.warn(`⚠️ \x1b[33m[Warning] GitHub API compare endpoint truncated the commits list (returned ${response.commits.length} of ${response.total_commits} commits). The audit report may be incomplete.\x1b[0m`);
+      console.error(`❌ [Error] GitHub API compare endpoint truncated the commits list (returned ${response.commits.length} of ${response.total_commits} commits). Rerun with --start/-s to narrow the range so the audit is complete.`);
+      process.exit(2);
     }
 
     commits = response.commits.map(c => {

--- a/scripts/trace_backports.js
+++ b/scripts/trace_backports.js
@@ -133,6 +133,13 @@ for (const commit of commits) {
   });
 }
 
+// Sort results by PR creation date (ascending)
+results.sort((a, b) => {
+  const dateA = a.pr && a.pr.createdAt ? a.pr.createdAt : '9999-99-99T99:99:99Z';
+  const dateB = b.pr && b.pr.createdAt ? b.pr.createdAt : '9999-99-99T99:99:99Z';
+  return dateA.localeCompare(dateB);
+});
+
 // 4. Generate structured reports
 console.log(`\n📝 [4/4] Generating reports...`);
 

--- a/scripts/trace_backports.js
+++ b/scripts/trace_backports.js
@@ -25,15 +25,7 @@ console.log(`Target Branch: ${branch}`);
 console.log(`=========================================\n`);
 
 // 1. Determine starting compare reference
-let baseCompare = startRef;
-if (!baseCompare) {
-  try {
-    // Automatically find the most recent tag reachable from the target branch
-    baseCompare = execFileSync('git', ['describe', '--tags', '--abbrev=0', branch], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
-  } catch (err) {
-    baseCompare = 'main'; // Fallback if no tags exist
-  }
-}
+const baseCompare = startRef || 'main';
 console.log(`📌 [1/4] Comparing starting reference '${baseCompare}' with head branch '${branch}'...`);
 
 // 2. Fetch all commits using local git
@@ -179,8 +171,8 @@ let mdContent = `# 🔍 Release Audit Report: Backport QA Status
 
 ## Summary Table
 
-| Release Commit | Backport PR | QA Tracking Issue | QA Status | Description / Title |
-| :--- | :--- | :--- | :---: | :--- |
+| Release Commit | Backport PR | QA Tracking Issue | QA Status | PR Created | Description / Title |
+| :--- | :--- | :--- | :---: | :--- | :--- |
 `;
 
 for (const r of results) {

--- a/scripts/trace_backports.js
+++ b/scripts/trace_backports.js
@@ -28,24 +28,38 @@ console.log(`=========================================\n`);
 const baseCompare = startRef || 'main';
 console.log(`📌 [1/4] Comparing starting reference '${baseCompare}' with head branch '${branch}'...`);
 
-// 2. Fetch all commits using local git
-console.log(`📋 [2/4] Fetching all commits on '${branch}' since '${baseCompare}' using local Git...`);
+// 2. Fetch unique commits using GitHub Compare API
+console.log(`📋 [2/4] Fetching unique commits on '${branch}' since '${baseCompare}' from GitHub API...`);
 let commits = [];
 try {
-  // Using two-dot syntax for strict reachability (avoids merge-base shift)
-  const logArgs = ['log', `${baseCompare}..${branch}`, '--format=%H%x00%s'];
-  const logOutput = execFileSync('git', logArgs, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+  const apiPath = `repos/rancher/terraform-provider-rancher2/compare/${baseCompare}...${branch}`;
+  const responseJson = execFileSync('gh', ['api', apiPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+  const response = JSON.parse(responseJson);
   
-  if (logOutput) {
-    commits = logOutput.split('\n').map(line => {
-      const [sha, ...subjectParts] = line.split('\0');
-      return { sha, subject: subjectParts.join('\0') };
+  if (response && response.commits) {
+    // Fix 1: Check and warn if GitHub Compare API truncated the returned commits array
+    if (response.total_commits > response.commits.length) {
+      console.warn(`⚠️ \x1b[33m[Warning] GitHub API compare endpoint truncated the commits list (returned ${response.commits.length} of ${response.total_commits} commits). The audit report may be incomplete.\x1b[0m`);
+    }
+
+    commits = response.commits.map(c => {
+      const sha = c.sha;
+      const fullMessage = (c.commit && c.commit.message) || 'No message';
+      const subject = fullMessage.split('\n')[0];
+      return { sha, subject };
     });
   }
 } catch (err) {
+  // Fix 2: Explicitly detect when GitHub CLI is not installed (ENOENT)
+  if (err.code === 'ENOENT') {
+    console.error(`❌ [Error] The GitHub CLI ('gh') was not found on your system. Please ensure 'gh' is installed and authenticated to run this script.`);
+    process.exit(1);
+  }
+  
+  // Fix 3: Log standard error stream from the CLI for rich debugging
   const errMsg = err.stderr ? err.stderr.toString().trim() : err.message;
-  console.error(`❌ [Error] Failed to fetch commits using local git: ${errMsg}`);
-  console.error(`Please verify your branch names and ensure your local repository is up to date (run 'git fetch').`);
+  console.error(`❌ [Error] Failed to fetch compare logs from GitHub REST API: ${errMsg}`);
+  console.error(`Please verify that you have internet access and that the gh CLI is authenticated.`);
   process.exit(1);
 }
 
@@ -56,6 +70,8 @@ if (commits.length === 0) {
   process.exit(0);
 }
 
+// 3. Trace each commit back to its PR and QA tracking issue
+console.log(`🛰️ [3/4] Auditing commits against GitHub API (this may take a moment)...`);
 const results = [];
 
 for (const commit of commits) {
@@ -133,7 +149,7 @@ for (const commit of commits) {
   });
 }
 
-// Sort results by PR creation date (ascending)
+// Preserve User's Sorting: Sort results by PR creation date (ascending)
 results.sort((a, b) => {
   const dateA = a.pr && a.pr.createdAt ? a.pr.createdAt : '9999-99-99T99:99:99Z';
   const dateB = b.pr && b.pr.createdAt ? b.pr.createdAt : '9999-99-99T99:99:99Z';
@@ -143,7 +159,7 @@ results.sort((a, b) => {
 // 4. Generate structured reports
 console.log(`\n📝 [4/4] Generating reports...`);
 
-// Render beautiful console table
+// Render beautiful console table (including User's Created column)
 console.log(`\n============================================================================================================================`);
 console.log(`| SHA      | Backport PR  | QA Issue   | Status   | Created    | Title                                                     |`);
 console.log(`============================================================================================================================`);
@@ -187,12 +203,12 @@ for (const r of results) {
   const prLink = r.pr ? `[#${r.pr.number}](${r.pr.url})` : '`N/A`';
   const qaLink = r.qaIssue ? `[#${r.qaIssue.number}](${r.qaIssue.url})` : '`N/A`';
   const createdDate = r.pr && r.pr.createdAt ? r.pr.createdAt.substring(0, 10) : '`N/A`';
-
+  
   let statusBadge = '🔴 **Missing**';
   if (r.qaIssue) {
     statusBadge = r.qaIssue.state === 'OPEN' ? '🟢 **Open**' : '🔵 **Closed**';
   }
-
+  
   // Fix 5: Sanitize PR title/subject for Markdown table safety (escaping pipes and removing newlines)
   const title = (r.pr ? r.pr.title : r.subject)
     .replace(/\|/g, '\\|')

--- a/scripts/trace_backports.js
+++ b/scripts/trace_backports.js
@@ -32,13 +32,23 @@ console.log(`📌 [1/4] Comparing starting reference '${baseCompare}' with head 
 console.log(`📋 [2/4] Fetching unique commits on '${branch}' since '${baseCompare}' from GitHub API...`);
 let commits = [];
 try {
+<<<<<<< Updated upstream
   const baseRef = encodeURIComponent(baseCompare);
   const headRef = encodeURIComponent(branch);
   const apiPath = `repos/rancher/terraform-provider-rancher2/compare/${baseRef}...${headRef}`;
   const responseJson = execFileSync('gh', ['api', apiPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+=======
+  const apiPath = `repos/rancher/terraform-provider-rancher2/compare/${baseCompare}...${branch}`;
+  const responseJson = execFileSync('gh', ['api', apiPath], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+>>>>>>> Stashed changes
   const response = JSON.parse(responseJson);
   
   if (response && response.commits) {
+    // Fix 1: Check and warn if GitHub Compare API truncated the returned commits array
+    if (response.total_commits > response.commits.length) {
+      console.warn(`⚠️ \x1b[33m[Warning] GitHub API compare endpoint truncated the commits list (returned ${response.commits.length} of ${response.total_commits} commits). The audit report may be incomplete.\x1b[0m`);
+    }
+
     commits = response.commits.map(c => {
       const sha = c.sha;
       const fullMessage = (c.commit && c.commit.message) || 'No message';
@@ -47,7 +57,15 @@ try {
     });
   }
 } catch (err) {
-  console.error(`❌ [Error] Failed to fetch compare logs from GitHub REST API: ${err.message}`);
+  // Fix 2: Explicitly detect when GitHub CLI is not installed (ENOENT)
+  if (err.code === 'ENOENT') {
+    console.error(`❌ [Error] The GitHub CLI ('gh') was not found on your system. Please ensure 'gh' is installed and authenticated to run this script.`);
+    process.exit(1);
+  }
+  
+  // Fix 3: Log standard error stream from the CLI for rich debugging
+  const errMsg = err.stderr ? err.stderr.toString().trim() : err.message;
+  console.error(`❌ [Error] Failed to fetch compare logs from GitHub REST API: ${errMsg}`);
   console.error(`Please verify that you have internet access and that the gh CLI is authenticated.`);
   process.exit(1);
 }
@@ -67,9 +85,11 @@ for (const commit of commits) {
   process.stdout.write(`   - Auditing ${commit.sha.substring(0, 8)}... `);
   let pr = null;
   try {
-    const prsJson = execFileSync('gh', ['api', `repos/rancher/terraform-provider-rancher2/commits/${commit.sha}/pulls`], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    const prsJson = execFileSync('gh', ['api', `repos/rancher/terraform-provider-rancher2/commits/${commit.sha}/pulls`], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
     const prs = JSON.parse(prsJson);
-    if (prs && prs.length > 0) {
+    
+    // Fix 4: Safely ensure the parsed JSON is verified as an array before filtering
+    if (prs && Array.isArray(prs) && prs.length > 0) {
       // Prioritize the backport PR base matching our target branch, filtering out release-please PRs
       const releasePleaseRegex = /^(chore\(release|release-please)/i;
       const nonReleasePleasePrs = prs.filter(p => !releasePleaseRegex.test(p.title || ''));
@@ -81,7 +101,8 @@ for (const commit of commits) {
       }
     }
   } catch (err) {
-    console.error(`\n⚠️ [Debug] Failed to fetch PR for commit ${commit.sha}: ${err.message}`);
+    const errMsg = err.stderr ? err.stderr.toString().trim() : err.message;
+    console.error(`\n⚠️ [Debug] Failed to fetch PR for commit ${commit.sha}: ${errMsg}`);
   }
 
   let qaIssue = null;
@@ -103,7 +124,7 @@ for (const commit of commits) {
     // Inspect each candidate issue to check labels
     for (const issueNum of issueNumbers) {
       try {
-        const issueJson = execFileSync('gh', ['issue', 'view', String(issueNum), '-R', 'rancher/terraform-provider-rancher2', '--json', 'number,title,labels,state,url'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+        const issueJson = execFileSync('gh', ['issue', 'view', String(issueNum), '-R', 'rancher/terraform-provider-rancher2', '--json', 'number,title,labels,state,url'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
         const issue = JSON.parse(issueJson);
         const isBackportQA = issue.labels && issue.labels.some(l => l.name === 'internal/backport');
         if (isBackportQA) {
@@ -111,7 +132,8 @@ for (const commit of commits) {
           break; // Found the QA tracking issue, no need to look further
         }
       } catch (err) {
-        console.error(`\n⚠️ [Debug] Failed to fetch issue #${issueNum}: ${err.message}`);
+        const errMsg = err.stderr ? err.stderr.toString().trim() : err.message;
+        console.error(`\n⚠️ [Debug] Failed to fetch issue #${issueNum}: ${errMsg}`);
       }
     }
   }
@@ -184,7 +206,11 @@ for (const r of results) {
     statusBadge = r.qaIssue.state === 'OPEN' ? '🟢 **Open**' : '🔵 **Closed**';
   }
   
-  const title = r.pr ? r.pr.title : r.subject;
+  // Fix 5: Sanitize PR title/subject for Markdown table safety (escaping pipes and removing newlines)
+  const title = (r.pr ? r.pr.title : r.subject)
+    .replace(/\|/g, '\\|')
+    .replace(/\r?\n|\r/g, ' ');
+    
   mdContent += `| ${commitLink} | ${prLink} | ${qaLink} | ${statusBadge} | ${title} |\n`;
 }
 


### PR DESCRIPTION
This PR adds the zero-dependency Node.js utility script `scripts/trace_backports.js` to automatically audit all cherry-picked/backported commits on a release branch, completely bypassing local Git state via the GitHub Compare REST API. It also updates `.gitignore` to ignore the generated reports.