### PR TITLE
add support for use_internal_ca_certs

### DIFF
--- a/docs/resources/cluster_v2.md
+++ b/docs/resources/cluster_v2.md
@@ -403,6 +403,73 @@ EOF
 }
 ```
 
+### Use the internal CA for an authorized cluster endpoint
+
+Set `use_internal_ca_certs` to use the cluster's internally generated CA certificate instead of specifying `ca_certs`.
+
+This option:
+* Requires `fqdn` to be configured.
+* Is mutually exclusive with `ca_certs`.
+* Should only be used when the cluster is reachable through an endpoint, such as a load balancer.
+* Requires the endpoint FQDN to be included in the API server certificate's SANs.
+
+Configure the FQDN through `tls-san` in `machine_global_config` to ensure the API server certificate is valid for the endpoint.
+
+For a node-driver cluster, the provider waits for the cluster to become active. The provider applies the CA during the same operation when Rancher provides it.
+
+```hcl
+resource "rancher2_cluster_v2" "node_driver" {
+  name               = "node-driver"
+  kubernetes_version = "<rke2/k3s-version>"
+
+  local_auth_endpoint {
+    enabled               = true
+    fqdn                  = "api.example.com"
+    use_internal_ca_certs = true
+  }
+
+  rke_config {
+    machine_global_config = yamlencode({
+      tls-san = ["api.example.com"]
+    })
+
+    machine_pools {
+      name                         = "pool1"
+      cloud_credential_secret_name = rancher2_cloud_credential.foo.id
+      control_plane_role           = true
+      etcd_role                    = true
+      worker_role                  = true
+      quantity                     = 1
+
+      machine_config {
+        kind = rancher2_machine_config_v2.foo.kind
+        name = rancher2_machine_config_v2.foo.name
+      }
+    }
+  }
+}
+```
+
+For a custom cluster, the CA is unavailable until a node registers and the cluster is active. Apply the configuration, register a node, wait for the cluster to be active, then run `terraform apply` again without changing the configuration.
+
+```hcl
+resource "rancher2_cluster_v2" "custom" {
+  name               = "custom"
+  kubernetes_version = "<rke2/k3s-version>"
+
+  local_auth_endpoint {
+    enabled               = true
+    fqdn                  = "api.example.com"
+    use_internal_ca_certs = true
+  }
+
+  rke_config {
+    machine_global_config = yamlencode({
+      tls-san = ["api.example.com"]
+    })
+  }
+}
+```
 
 ### Customize the agent environment variables
 
@@ -988,6 +1055,7 @@ The following attributes are exported:
 * `cluster_registration_token` - (Computed, sensitive, list, max length: 1) Cluster Registration Token generated for the cluster.
 * `kube_config` - (Computed/Sensitive) Kube Config generated for the cluster. Note: When the cluster has `local_auth_endpoint` enabled, the kube_config will not be available until the cluster is `connected`.
 * `cluster_v1_id` - (Computed, string) Cluster v1 id for cluster v2. (e.g. to be used with `rancher2_sync`).
+* `local_auth_endpoint_ca_sync_required` - (Computed, bool) Whether the authorized cluster endpoint requires internal CA synchronization. Users cannot configure this field.
 * `resource_version` - (Computed, string) Cluster's k8s resource version.
 
 **Note:** For Rancher 2.6.0 and above: if setting `kubeconfig-generate-token=false` then the generated `kube_config` will not contain any user token. `kubectl` will generate the user token executing the [rancher cli](https://github.com/rancher/cli/releases/tag/v2.6.0), so it should be installed previously.
@@ -1090,6 +1158,7 @@ see more information on [Resource Management for Pods and Containers](https://ku
 * `enabled` - (Optional, bool, default: false) Enable the authorized cluster endpoint.
 * `fqdn` - (Optional, string) FQDN for the authorized cluster endpoint. If one is entered, it should point to the downstream cluster.
 * `ca_certs` - (Optional, string) CA certs for the authorized cluster endpoint. It is only needed if there is a load balancer in front of the downstream cluster that is using an untrusted certificate. If you have a valid certificate, then nothing needs to be added to the CA Certificates field.
+* `use_internal_ca_certs` - (Optional, bool, default: false) Use the cluster's internally generated CA certificate for the authorized cluster endpoint instead of manually specifying `ca_certs`. This option should only be used when the cluster is reachable through an endpoint, such as a load balancer, and the endpoint FQDN is included in the API server certificate's SANs (configured through `tls-san` in `machine_global_config`). Requires `fqdn` to be configured and is mutually exclusive with `ca_certs`. During refresh, the provider compares the internally generated CA with the CA configured on the authorized cluster endpoint without making any changes to Rancher. If the internal CA is non-empty and differs from the endpoint CA, Terraform will detect the difference and show an in-place synchronization update in the next plan. A subsequent `terraform apply` fetches the current internal CA and applies it to the endpoint. This behavior supports scenarios where the CA becomes available only after cluster creation, as well as cases where the cluster's root CA is replaced later. If the fetched CA is empty, the provider preserves any existing endpoint CA and does not schedule a synchronization update. An empty CA does not cause an error. Real API and network errors still cause the operation to fail.
 
 #### `upgrade_strategy`
 

--- a/rancher2/resource_rancher2_cluster_v2.go
+++ b/rancher2/resource_rancher2_cluster_v2.go
@@ -51,16 +51,17 @@ func resourceRancher2ClusterV2() *schema.Resource {
 				oldInterface, oldOk := oldObj.([]interface{})
 				newInterface, newOk := newObj.([]interface{})
 				if oldOk && newOk && len(newInterface) > 0 {
-					oldConfig := expandClusterV2LocalAuthEndpoint(oldInterface)
-					newConfig := expandClusterV2LocalAuthEndpoint(newInterface)
-					if reflect.DeepEqual(oldConfig, newConfig) {
+					if err := validateClusterV2LocalAuthEndpointResourceDiff(d, newInterface); err != nil {
+						return err
+					}
+					if clusterV2LocalAuthEndpointDiffEqual(oldInterface, newInterface) {
 						d.Clear("local_auth_endpoint")
 					} else {
-						d.SetNew("local_auth_endpoint", flattenClusterV2LocalAuthEndpoint(newConfig))
+						d.SetNew("local_auth_endpoint", newObj)
 					}
 				}
 			}
-			return nil
+			return customizeClusterV2LocalAuthEndpointCASync(d, i)
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -130,10 +131,36 @@ func resourceRancher2ClusterV2Create(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	return resourceRancher2ClusterV2Read(d, meta)
+	if clusterV2LocalAuthEndpointShouldUseInternalCACerts(d) {
+		caCert, err := getClusterV2LocalAuthEndpointCACert(newCluster.Status.ClusterName, func(clusterV1ID string) (string, error) {
+			return getClusterCACert(meta.(*Config), clusterV1ID)
+		})
+		if err != nil {
+			return err
+		}
+		if caCert != "" {
+			newCluster, err = updateClusterV2LocalAuthEndpointCACerts(
+				func() (*ClusterV2, error) {
+					return getClusterV2ByID(meta.(*Config), newCluster.ID)
+				},
+				func(latest *ClusterV2) (*ClusterV2, error) {
+					return updateClusterV2Once(meta.(*Config), latest.ID, latest)
+				},
+				caCert, rancher2RetriesWait*time.Second, meta.(*Config).Timeout)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return resourceRancher2ClusterV2ReadInternal(d, meta, false)
 }
 
 func resourceRancher2ClusterV2Read(d *schema.ResourceData, meta interface{}) error {
+	return resourceRancher2ClusterV2ReadInternal(d, meta, true)
+}
+
+func resourceRancher2ClusterV2ReadInternal(d *schema.ResourceData, meta interface{}, detectInternalCADrift bool) error {
 	log.Printf("[INFO] Refreshing Cluster V2 %s", d.Id())
 
 	cluster, err := getClusterV2ByID(meta.(*Config), d.Id())
@@ -150,13 +177,54 @@ func resourceRancher2ClusterV2Read(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	return flattenClusterV2(d, cluster)
+
+	// use_internal_ca_certs has no server-side representation, so it must be
+	// captured before flattenClusterV2 rewrites the local_auth_endpoint block
+	// and reinjected afterward. It is never derived from cluster CA content
+	// (see clusterV2LocalAuthEndpointUseInternalCACerts).
+	useInternalCACerts := clusterV2LocalAuthEndpointUseInternalCACerts(d)
+	syncRequired := false
+	if detectInternalCADrift && useInternalCACerts && cluster.Spec.LocalClusterAuthEndpoint.Enabled {
+		caCert, err := getClusterV2LocalAuthEndpointCACert(cluster.Status.ClusterName, func(clusterV1ID string) (string, error) {
+			return getClusterCACert(meta.(*Config), clusterV1ID)
+		})
+		if err != nil {
+			return err
+		}
+		syncRequired = clusterV2LocalAuthEndpointCASyncRequired(useInternalCACerts, cluster, caCert)
+	}
+	if err := flattenClusterV2(d, cluster); err != nil {
+		return err
+	}
+	if err := setClusterV2LocalAuthEndpointUseInternalCACerts(d, useInternalCACerts); err != nil {
+		return err
+	}
+	return d.Set("local_auth_endpoint_ca_sync_required", syncRequired)
 }
 
 func resourceRancher2ClusterV2Update(d *schema.ResourceData, meta interface{}) error {
 	cluster, err := expandClusterV2(d)
 	if err != nil {
 		return err
+	}
+
+	if clusterV2LocalAuthEndpointShouldUseInternalCACerts(d) {
+		clusterV1ID := d.Get("cluster_v1_id").(string)
+		caCert, err := getClusterV2LocalAuthEndpointCACert(clusterV1ID, func(clusterV1ID string) (string, error) {
+			return getClusterCACert(meta.(*Config), clusterV1ID)
+		})
+		if err != nil {
+			return err
+		}
+		if caCert != "" {
+			cluster.Spec.LocalClusterAuthEndpoint.CACerts = caCert
+		} else {
+			current, err := getClusterV2ByID(meta.(*Config), d.Id())
+			if err != nil {
+				return err
+			}
+			cluster.Spec.LocalClusterAuthEndpoint.CACerts = current.Spec.LocalClusterAuthEndpoint.CACerts
+		}
 	}
 
 	log.Printf("[INFO] Updating Cluster V2 %s", d.Id())
@@ -172,7 +240,7 @@ func resourceRancher2ClusterV2Update(d *schema.ResourceData, meta interface{}) e
 			return err
 		}
 	}
-	return resourceRancher2ClusterV2Read(d, meta)
+	return resourceRancher2ClusterV2ReadInternal(d, meta, false)
 }
 
 func resourceRancher2ClusterV2Delete(d *schema.ResourceData, meta interface{}) error {
@@ -330,6 +398,25 @@ func updateClusterV2(c *Config, id string, obj *ClusterV2) (*ClusterV2, error) {
 	}
 }
 
+// updateClusterV2Once updates a cluster once and returns API conflicts to the
+// caller. This lets CA reconciliation refetch the complete cluster before retrying.
+func updateClusterV2Once(c *Config, id string, obj *ClusterV2) (*ClusterV2, error) {
+	if c == nil {
+		return nil, fmt.Errorf("Updating cluster V2: Provider config is nil")
+	}
+	if id == "" {
+		return nil, fmt.Errorf("Updating cluster V2: Cluster V2 ID is empty")
+	}
+	if obj == nil {
+		return nil, fmt.Errorf("Updating cluster V2: Cluster V2 is nil")
+	}
+	resp := &ClusterV2{}
+	if err := c.updateObjectV2(rancher2DefaultLocalClusterID, id, clusterV2APIType, obj, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 func waitForClusterV2State(c *Config, id, state string, interval time.Duration) (*ClusterV2, error) {
 	if id == "" || state == "" {
 		return nil, fmt.Errorf("Cluster V2 ID and/or condition is nil")
@@ -421,4 +508,213 @@ func setClusterV2LegacyData(d *schema.ResourceData, c *Config, generateKubeConfi
 	}
 
 	return nil
+}
+
+// clusterV2LocalAuthEndpointRawMap returns the single element of a
+// local_auth_endpoint list ([]interface{} as read from *schema.ResourceData
+// or a diff) as a map, or (nil, false) if the block is empty/absent.
+func clusterV2LocalAuthEndpointRawMap(v []interface{}) (map[string]interface{}, bool) {
+	if len(v) == 0 || v[0] == nil {
+		return nil, false
+	}
+	m, ok := v[0].(map[string]interface{})
+	return m, ok
+}
+
+// clusterV2LocalAuthEndpointUseInternalCACertsValue reads use_internal_ca_certs
+// out of a raw local_auth_endpoint list. It never inspects ca_certs, enabled,
+// or fqdn: use_internal_ca_certs has no server-side representation, so its
+// value is only ever what was explicitly stored here.
+func clusterV2LocalAuthEndpointUseInternalCACertsValue(v []interface{}) bool {
+	m, ok := clusterV2LocalAuthEndpointRawMap(v)
+	if !ok {
+		return false
+	}
+	b, _ := m["use_internal_ca_certs"].(bool)
+	return b
+}
+
+// clusterV2LocalAuthEndpointUseInternalCACerts reads the current
+// use_internal_ca_certs value out of d. It is used both to read the planned
+// value (Create/Update) and to capture the prior value before Read overwrites
+// the local_auth_endpoint block (see setClusterV2LocalAuthEndpointUseInternalCACerts).
+func clusterV2LocalAuthEndpointUseInternalCACerts(d *schema.ResourceData) bool {
+	v, _ := d.Get("local_auth_endpoint").([]interface{})
+	return clusterV2LocalAuthEndpointUseInternalCACertsValue(v)
+}
+
+// clusterV2LocalAuthEndpointShouldUseInternalCACerts reports whether the
+// endpoint is enabled and configured to use the internal CA.
+func clusterV2LocalAuthEndpointShouldUseInternalCACerts(d *schema.ResourceData) bool {
+	v, _ := d.Get("local_auth_endpoint").([]interface{})
+	m, ok := clusterV2LocalAuthEndpointRawMap(v)
+	if !ok {
+		return false
+	}
+	enabled, _ := m["enabled"].(bool)
+	return enabled && clusterV2LocalAuthEndpointUseInternalCACertsValue(v)
+}
+
+// clusterV2LocalAuthEndpointCASyncRequired reports whether the endpoint CA
+// differs from the available internal CA.
+func clusterV2LocalAuthEndpointCASyncRequired(useInternalCACerts bool, cluster *ClusterV2, caCert string) bool {
+	if !useInternalCACerts || cluster == nil || !cluster.Spec.LocalClusterAuthEndpoint.Enabled || caCert == "" {
+		return false
+	}
+	return caCert != cluster.Spec.LocalClusterAuthEndpoint.CACerts
+}
+
+// getClusterV2LocalAuthEndpointCACert skips the CA fetch until Rancher assigns
+// the management cluster ID.
+func getClusterV2LocalAuthEndpointCACert(clusterV1ID string, fetch func(string) (string, error)) (string, error) {
+	if clusterV1ID == "" {
+		log.Printf("[INFO] Skipping local_auth_endpoint CA certificate fetch because cluster_v1_id is not available")
+		return "", nil
+	}
+	log.Printf("[INFO] Fetching cluster %s CA certificate for local_auth_endpoint", clusterV1ID)
+	return fetch(clusterV1ID)
+}
+
+// customizeClusterV2LocalAuthEndpointCASync schedules an update when Read
+// detects internal CA drift for an enabled endpoint.
+func customizeClusterV2LocalAuthEndpointCASync(d *schema.ResourceDiff, _ interface{}) error {
+	syncRequired, _ := d.Get("local_auth_endpoint_ca_sync_required").(bool)
+	if !syncRequired || !d.NewValueKnown("local_auth_endpoint.0.enabled") ||
+		!d.NewValueKnown("local_auth_endpoint.0.use_internal_ca_certs") {
+		return nil
+	}
+	v, _ := d.Get("local_auth_endpoint").([]interface{})
+	m, ok := clusterV2LocalAuthEndpointRawMap(v)
+	if !ok {
+		return nil
+	}
+	enabled, _ := m["enabled"].(bool)
+	useInternalCACerts, _ := m["use_internal_ca_certs"].(bool)
+	if !enabled || !useInternalCACerts {
+		return nil
+	}
+	return d.SetNewComputed("local_auth_endpoint_ca_sync_required")
+}
+
+// updateClusterV2LocalAuthEndpointCACerts refetches the complete cluster before
+// each CA update attempt, so conflict retries preserve concurrent changes.
+func updateClusterV2LocalAuthEndpointCACerts(fetch func() (*ClusterV2, error), update func(*ClusterV2) (*ClusterV2, error),
+	caCert string, retryInterval, timeout time.Duration) (*ClusterV2, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	for {
+		cluster, err := fetch()
+		if err != nil {
+			return nil, err
+		}
+		cluster.Spec.LocalClusterAuthEndpoint.CACerts = caCert
+		updated, err := update(cluster)
+		if err == nil {
+			return updated, nil
+		}
+		if !IsConflict(err) {
+			return nil, err
+		}
+		select {
+		case <-time.After(retryInterval):
+		case <-ctx.Done():
+			return nil, fmt.Errorf("Timeout updating cluster V2 ID %s: %w", cluster.ID, err)
+		}
+	}
+}
+
+// setClusterV2LocalAuthEndpointUseInternalCACerts reinjects useInternalCACerts
+// into the current local_auth_endpoint block. It must be called after
+// flattenClusterV2 has repopulated enabled/fqdn/ca_certs from the API object,
+// since d.Set on a nested list block resets any sub-field not present in the
+// new value to its zero value. If Rancher omits the block, a preserved true
+// value recreates it so the next apply can fetch and apply the internal CA.
+//
+// When useInternalCACerts is true, it also blanks ca_certs back to empty.
+// ca_certs is Optional but not Computed, and the user's config never sets it
+// while use_internal_ca_certs is true (they are mutually exclusive), so if
+// the real CA value flattenClusterV2 just wrote were left in state, every
+// subsequent plan would show a diff trying to clear it back to what config
+// says (empty), and the plan would never converge. The real CA is still sent
+// to Rancher when available; only its reflection in Terraform state is
+// intentionally not tracked.
+func setClusterV2LocalAuthEndpointUseInternalCACerts(d *schema.ResourceData, useInternalCACerts bool) error {
+	v, _ := d.Get("local_auth_endpoint").([]interface{})
+	m, ok := clusterV2LocalAuthEndpointRawMap(v)
+	if !ok {
+		if !useInternalCACerts {
+			return nil
+		}
+		m = map[string]interface{}{}
+	}
+	m["use_internal_ca_certs"] = useInternalCACerts
+	if useInternalCACerts {
+		m["ca_certs"] = ""
+	}
+	return d.Set("local_auth_endpoint", []interface{}{m})
+}
+
+// validateClusterV2LocalAuthEndpointResourceDiff validates each known endpoint
+// field independently and defers checks that depend on unknown values.
+func validateClusterV2LocalAuthEndpointResourceDiff(d *schema.ResourceDiff, newInterface []interface{}) error {
+	if !d.NewValueKnown("local_auth_endpoint.0.use_internal_ca_certs") {
+		return nil
+	}
+	m, ok := clusterV2LocalAuthEndpointRawMap(newInterface)
+	if !ok {
+		return nil
+	}
+	useInternal, _ := m["use_internal_ca_certs"].(bool)
+	if !useInternal {
+		return nil
+	}
+	if d.NewValueKnown("local_auth_endpoint.0.ca_certs") {
+		if caCerts, _ := m["ca_certs"].(string); caCerts != "" {
+			return fmt.Errorf(`only one of "ca_certs" or "use_internal_ca_certs" can be set`)
+		}
+	}
+	if d.NewValueKnown("local_auth_endpoint.0.fqdn") {
+		if fqdn, _ := m["fqdn"].(string); fqdn == "" {
+			return fmt.Errorf(`"fqdn" is required in "local_auth_endpoint" when "use_internal_ca_certs" is true`)
+		}
+	}
+	return nil
+}
+
+// clusterV2LocalAuthEndpointDiffEqual reports whether old and new
+// local_auth_endpoint values are equivalent, including use_internal_ca_certs.
+// CustomizeDiff uses this to decide whether to clear a spurious diff; a
+// change to use_internal_ca_certs alone must always be reported as unequal.
+func clusterV2LocalAuthEndpointDiffEqual(oldInterface, newInterface []interface{}) bool {
+	oldConfig := expandClusterV2LocalAuthEndpoint(oldInterface)
+	newConfig := expandClusterV2LocalAuthEndpoint(newInterface)
+	if !reflect.DeepEqual(oldConfig, newConfig) {
+		return false
+	}
+
+	oldVal := clusterV2LocalAuthEndpointUseInternalCACertsValue(oldInterface)
+	newVal := clusterV2LocalAuthEndpointUseInternalCACertsValue(newInterface)
+	return oldVal == newVal
+}
+
+// getClusterCACert fetches and returns the v3 management cluster's CA
+// certificate, base64-decoded if necessary. It performs no retries and does
+// not treat an empty result as an error.
+func getClusterCACert(c *Config, clusterV1ID string) (string, error) {
+	if c == nil {
+		return "", fmt.Errorf("Getting cluster CA cert: Provider config is nil")
+	}
+	if clusterV1ID == "" {
+		return "", fmt.Errorf("Getting cluster CA cert: cluster_v1_id is empty")
+	}
+	client, err := c.ManagementClient()
+	if err != nil {
+		return "", fmt.Errorf("Getting cluster CA cert: %w", err)
+	}
+	cluster := &Cluster{}
+	err = client.APIBaseClient.ByID(managementClient.ClusterType, clusterV1ID, cluster)
+	if err != nil {
+		return "", fmt.Errorf("Getting cluster CA cert: %w", err)
+	}
+	return decodeCACertIfBase64(cluster.CACert), nil
 }

--- a/rancher2/resource_rancher2_cluster_v2_local_auth_endpoint_test.go
+++ b/rancher2/resource_rancher2_cluster_v2_local_auth_endpoint_test.go
@@ -1,0 +1,551 @@
+package rancher2
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/rancher/norman/clientbase"
+	"github.com/stretchr/testify/assert"
+)
+
+// testUnknownVariableValue is the same sentinel Terraform's SDK uses
+// internally (terraform-plugin-sdk/internal/configs/hcl2shim.UnknownVariableValue)
+// to represent a value that is not yet known at plan time, for example an
+// interpolation referencing a not-yet-created resource's computed attribute.
+// It is unexported in the SDK, so it is duplicated here only for simulating
+// that condition in tests.
+const testUnknownVariableValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
+
+func testClusterV2LocalAuthEndpointResourceSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"local_auth_endpoint": {
+			Type:     schema.TypeList,
+			MaxItems: 1,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: clusterV2LocalAuthEndpointFields(),
+			},
+		},
+	}
+}
+
+func TestClusterV2LocalAuthEndpointUseInternalCACerts(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  map[string]interface{}
+		want bool
+	}{
+		{
+			name: "no local_auth_endpoint block",
+			raw:  map[string]interface{}{},
+			want: false,
+		},
+		{
+			name: "use_internal_ca_certs not set defaults to false",
+			raw: map[string]interface{}{
+				"local_auth_endpoint": []interface{}{
+					map[string]interface{}{
+						"enabled": true,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			// Regression test for #2438: a legacy manually-supplied ca_certs that
+			// happens to equal the cluster's own CA must never be reported as
+			// use_internal_ca_certs = true. The helper only ever reads the stored
+			// boolean, it never inspects ca_certs' content.
+			name: "manually-supplied ca_certs does not imply use_internal_ca_certs",
+			raw: map[string]interface{}{
+				"local_auth_endpoint": []interface{}{
+					map[string]interface{}{
+						"enabled":  true,
+						"ca_certs": "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "use_internal_ca_certs true is read back",
+			raw: map[string]interface{}{
+				"local_auth_endpoint": []interface{}{
+					map[string]interface{}{
+						"enabled":               true,
+						"fqdn":                  "ace.example.com",
+						"use_internal_ca_certs": true,
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, testClusterV2LocalAuthEndpointResourceSchema(), tc.raw)
+			assert.Equal(t, tc.want, clusterV2LocalAuthEndpointUseInternalCACerts(d))
+		})
+	}
+}
+
+func TestClusterV2LocalAuthEndpointShouldUseInternalCACerts(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  map[string]interface{}
+		want bool
+	}{
+		{
+			name: "enabled with internal CA",
+			raw: map[string]interface{}{
+				"local_auth_endpoint": []interface{}{map[string]interface{}{
+					"enabled":               true,
+					"use_internal_ca_certs": true,
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "disabled with internal CA",
+			raw: map[string]interface{}{
+				"local_auth_endpoint": []interface{}{map[string]interface{}{
+					"enabled":               false,
+					"use_internal_ca_certs": true,
+				}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, testClusterV2LocalAuthEndpointResourceSchema(), tc.raw)
+			assert.Equal(t, tc.want, clusterV2LocalAuthEndpointShouldUseInternalCACerts(d))
+		})
+	}
+}
+
+func TestClusterV2LocalAuthEndpointSchemaLocations(t *testing.T) {
+	t.Run("top-level schema exposes use_internal_ca_certs", func(t *testing.T) {
+		_, ok := clusterV2LocalAuthEndpointFields()["use_internal_ca_certs"]
+		assert.True(t, ok)
+	})
+
+	t.Run("deprecated current nested schema excludes use_internal_ca_certs", func(t *testing.T) {
+		endpoint := clusterV2RKEConfigFields()["local_auth_endpoint"].Elem.(*schema.Resource)
+		_, ok := endpoint.Schema["use_internal_ca_certs"]
+		assert.False(t, ok)
+	})
+
+	t.Run("deprecated V0 nested schema excludes use_internal_ca_certs", func(t *testing.T) {
+		endpoint := clusterV2RKEConfigFieldsV0()["local_auth_endpoint"].Elem.(*schema.Resource)
+		_, ok := endpoint.Schema["use_internal_ca_certs"]
+		assert.False(t, ok)
+	})
+
+	t.Run("cluster exposes internal CA synchronization state", func(t *testing.T) {
+		syncRequired := clusterV2Fields()["local_auth_endpoint_ca_sync_required"]
+		assert.NotNil(t, syncRequired)
+		assert.True(t, syncRequired.Computed)
+		assert.False(t, syncRequired.Optional)
+	})
+}
+
+func TestClusterV2LocalAuthEndpointCASyncRequired(t *testing.T) {
+	cases := []struct {
+		name        string
+		useInternal bool
+		enabled     bool
+		endpointCA  string
+		internalCA  string
+		want        bool
+	}{
+		{name: "matching CA", useInternal: true, enabled: true, endpointCA: "ca-a", internalCA: "ca-a", want: false},
+		{name: "missing endpoint CA", useInternal: true, enabled: true, internalCA: "ca-a", want: true},
+		{name: "rotated internal CA", useInternal: true, enabled: true, endpointCA: "ca-a", internalCA: "ca-b", want: true},
+		{name: "internal CA unavailable", useInternal: true, enabled: true, endpointCA: "ca-a", want: false},
+		{name: "endpoint disabled", useInternal: true, endpointCA: "ca-a", internalCA: "ca-b", want: false},
+		{name: "manual CA mode", enabled: true, endpointCA: "ca-a", internalCA: "ca-b", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &ClusterV2{}
+			cluster.Spec.LocalClusterAuthEndpoint.Enabled = tc.enabled
+			cluster.Spec.LocalClusterAuthEndpoint.CACerts = tc.endpointCA
+			assert.Equal(t, tc.want, clusterV2LocalAuthEndpointCASyncRequired(tc.useInternal, cluster, tc.internalCA))
+		})
+	}
+}
+
+func TestGetClusterV2LocalAuthEndpointCACertSkipsEmptyClusterID(t *testing.T) {
+	var logs bytes.Buffer
+	oldOutput := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(oldOutput) })
+
+	called := false
+	caCert, err := getClusterV2LocalAuthEndpointCACert("", func(string) (string, error) {
+		called = true
+		return "internal-ca", nil
+	})
+
+	assert.NoError(t, err)
+	assert.Empty(t, caCert)
+	assert.False(t, called)
+	assert.Contains(t, logs.String(), "Skipping local_auth_endpoint CA certificate fetch because cluster_v1_id is not available")
+}
+
+func TestGetClusterV2LocalAuthEndpointCACertLogsClusterID(t *testing.T) {
+	var logs bytes.Buffer
+	oldOutput := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(oldOutput) })
+
+	_, err := getClusterV2LocalAuthEndpointCACert("c-m-test", func(string) (string, error) {
+		return "internal-ca", nil
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, logs.String(), "Fetching cluster c-m-test CA certificate for local_auth_endpoint")
+}
+
+func TestSetClusterV2LocalAuthEndpointUseInternalCACerts(t *testing.T) {
+	t.Run("reinjects the preserved value into an existing block", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, testClusterV2LocalAuthEndpointResourceSchema(), map[string]interface{}{
+			"local_auth_endpoint": []interface{}{
+				map[string]interface{}{
+					"enabled": true,
+					"fqdn":    "ace.example.com",
+				},
+			},
+		})
+
+		err := setClusterV2LocalAuthEndpointUseInternalCACerts(d, true)
+		assert.NoError(t, err)
+		assert.True(t, clusterV2LocalAuthEndpointUseInternalCACerts(d))
+	})
+
+	t.Run("restores true when there is no local_auth_endpoint block", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, testClusterV2LocalAuthEndpointResourceSchema(), map[string]interface{}{})
+
+		err := setClusterV2LocalAuthEndpointUseInternalCACerts(d, true)
+		assert.NoError(t, err)
+		assert.True(t, clusterV2LocalAuthEndpointUseInternalCACerts(d))
+	})
+
+	t.Run("blanks ca_certs when use_internal_ca_certs is true", func(t *testing.T) {
+		// ca_certs is Optional but not Computed. If the real, auto-populated
+		// CA value were left in state while config never sets ca_certs,
+		// Terraform's diff engine would treat "in state, not in config" as a
+		// removal on every subsequent plan, and the plan would never
+		// converge. See TestClusterV2LocalAuthEndpointUseInternalCACertsDoesNotProduceAPhantomDiff.
+		d := schema.TestResourceDataRaw(t, testClusterV2LocalAuthEndpointResourceSchema(), map[string]interface{}{
+			"local_auth_endpoint": []interface{}{
+				map[string]interface{}{
+					"enabled":  true,
+					"fqdn":     "ace.example.com",
+					"ca_certs": "-----BEGIN CERTIFICATE-----\nREAL\n-----END CERTIFICATE-----\n",
+				},
+			},
+		})
+
+		err := setClusterV2LocalAuthEndpointUseInternalCACerts(d, true)
+		assert.NoError(t, err)
+
+		v, _ := d.Get("local_auth_endpoint").([]interface{})
+		m, ok := clusterV2LocalAuthEndpointRawMap(v)
+		assert.True(t, ok)
+		assert.Equal(t, "", m["ca_certs"])
+	})
+
+	t.Run("preserves ca_certs when use_internal_ca_certs is false", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, testClusterV2LocalAuthEndpointResourceSchema(), map[string]interface{}{
+			"local_auth_endpoint": []interface{}{
+				map[string]interface{}{
+					"enabled":  true,
+					"ca_certs": "manual-ca",
+				},
+			},
+		})
+
+		err := setClusterV2LocalAuthEndpointUseInternalCACerts(d, false)
+		assert.NoError(t, err)
+
+		v, _ := d.Get("local_auth_endpoint").([]interface{})
+		m, ok := clusterV2LocalAuthEndpointRawMap(v)
+		assert.True(t, ok)
+		assert.Equal(t, "manual-ca", m["ca_certs"])
+	})
+}
+
+func TestClusterV2LocalAuthEndpointUseInternalCACertsDoesNotProduceAPhantomDiff(t *testing.T) {
+	// Regression test: once Read has captured a real, internally-populated
+	// CA and use_internal_ca_certs stays true in config, the *next* plan
+	// must not show a diff wanting to clear ca_certs back to empty.
+	d := schema.TestResourceDataRaw(t, testClusterV2LocalAuthEndpointResourceSchema(), map[string]interface{}{
+		"local_auth_endpoint": []interface{}{
+			map[string]interface{}{
+				"enabled":               true,
+				"fqdn":                  "ace.example.com",
+				"use_internal_ca_certs": true,
+			},
+		},
+	})
+
+	// Simulate flattenClusterV2LocalAuthEndpoint writing the real API value
+	// into ca_certs during Read, before the preserve step runs.
+	raw, _ := d.Get("local_auth_endpoint").([]interface{})
+	m, ok := clusterV2LocalAuthEndpointRawMap(raw)
+	assert.True(t, ok)
+	m["ca_certs"] = "-----BEGIN CERTIFICATE-----\nREAL\n-----END CERTIFICATE-----\n"
+	assert.NoError(t, d.Set("local_auth_endpoint", []interface{}{m}))
+
+	assert.NoError(t, setClusterV2LocalAuthEndpointUseInternalCACerts(d, true))
+
+	oldInterface, _ := d.Get("local_auth_endpoint").([]interface{})
+	// What the next plan's new value looks like when nothing in config changed:
+	// ca_certs is absent from config, so its planned value is the zero value.
+	newInterface := []interface{}{
+		map[string]interface{}{
+			"enabled":               true,
+			"fqdn":                  "ace.example.com",
+			"ca_certs":              "",
+			"use_internal_ca_certs": true,
+		},
+	}
+
+	assert.True(t, clusterV2LocalAuthEndpointDiffEqual(oldInterface, newInterface))
+}
+
+func TestClusterV2LocalAuthEndpointDiffEqual(t *testing.T) {
+	enabledTrue := map[string]interface{}{
+		"enabled":               true,
+		"fqdn":                  "ace.example.com",
+		"ca_certs":              "",
+		"use_internal_ca_certs": true,
+	}
+	enabledFalse := map[string]interface{}{
+		"enabled":               true,
+		"fqdn":                  "ace.example.com",
+		"ca_certs":              "",
+		"use_internal_ca_certs": false,
+	}
+
+	cases := []struct {
+		name string
+		old  []interface{}
+		new  []interface{}
+		want bool
+	}{
+		{
+			name: "identical blocks including the flag are equal",
+			old:  []interface{}{enabledTrue},
+			new:  []interface{}{enabledTrue},
+			want: true,
+		},
+		{
+			// Regression test for #2436: toggling use_internal_ca_certs with
+			// everything else equal must never be treated as diff noise, or the
+			// CustomizeDiff would clear the change and the plan would never
+			// converge.
+			name: "flag toggled true to false with everything else equal is not equal",
+			old:  []interface{}{enabledTrue},
+			new:  []interface{}{enabledFalse},
+			want: false,
+		},
+		{
+			name: "flag toggled false to true with everything else equal is not equal",
+			old:  []interface{}{enabledFalse},
+			new:  []interface{}{enabledTrue},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, clusterV2LocalAuthEndpointDiffEqual(tc.old, tc.new))
+		})
+	}
+}
+
+func TestClusterV2CustomizeDiffAllowsUnknownFQDN(t *testing.T) {
+	// Regression test: on the very first plan of a fresh configuration,
+	// fqdn commonly interpolates a not-yet-created resource's attribute
+	// (e.g. an aws_lb's dns_name). The SDK materializes such a value as the
+	// zero value ("") via GetChange, which endpoint diff validation
+	// would otherwise misinterpret as "fqdn not configured" and reject with
+	// a false positive, even though fqdn IS configured (just not yet known).
+	r := resourceRancher2ClusterV2()
+	c := terraform.NewResourceConfigRaw(map[string]any{
+		"name":               "test",
+		"kubernetes_version": "v1.30.0",
+		"local_auth_endpoint": []any{
+			map[string]any{
+				"enabled":               true,
+				"fqdn":                  testUnknownVariableValue,
+				"use_internal_ca_certs": true,
+			},
+		},
+	})
+
+	_, err := r.Diff(nil, c, nil)
+	assert.NoError(t, err)
+}
+
+func TestClusterV2CustomizeDiffRejectsKnownCACertsWithUnknownFQDN(t *testing.T) {
+	r := resourceRancher2ClusterV2()
+	c := terraform.NewResourceConfigRaw(map[string]any{
+		"name":               "test",
+		"kubernetes_version": "v1.30.0",
+		"local_auth_endpoint": []any{
+			map[string]any{
+				"enabled":               true,
+				"fqdn":                  testUnknownVariableValue,
+				"ca_certs":              "manual-ca",
+				"use_internal_ca_certs": true,
+			},
+		},
+	})
+
+	_, err := r.Diff(nil, c, nil)
+	assert.ErrorContains(t, err, `only one of "ca_certs" or "use_internal_ca_certs" can be set`)
+}
+
+func TestClusterV2CustomizeDiffAllowsUnknownCACerts(t *testing.T) {
+	r := resourceRancher2ClusterV2()
+	c := terraform.NewResourceConfigRaw(map[string]any{
+		"name":               "test",
+		"kubernetes_version": "v1.30.0",
+		"local_auth_endpoint": []any{
+			map[string]any{
+				"enabled":               true,
+				"fqdn":                  "ace.example.com",
+				"ca_certs":              testUnknownVariableValue,
+				"use_internal_ca_certs": true,
+			},
+		},
+	})
+
+	_, err := r.Diff(nil, c, nil)
+	assert.NoError(t, err)
+}
+
+func TestClusterV2CustomizeDiffStillRejectsKnownEmptyFQDN(t *testing.T) {
+	// Sanity check for the fix above: a genuinely empty (known, not
+	// unknown) fqdn alongside use_internal_ca_certs=true must still be
+	// rejected.
+	r := resourceRancher2ClusterV2()
+	c := terraform.NewResourceConfigRaw(map[string]any{
+		"name":               "test",
+		"kubernetes_version": "v1.30.0",
+		"local_auth_endpoint": []any{
+			map[string]any{
+				"enabled":               true,
+				"use_internal_ca_certs": true,
+			},
+		},
+	})
+
+	_, err := r.Diff(nil, c, nil)
+	assert.ErrorContains(t, err, `"fqdn" is required in "local_auth_endpoint" when "use_internal_ca_certs" is true`)
+}
+
+func TestClusterV2CustomizeDiffSchedulesInternalCASync(t *testing.T) {
+	cases := []struct {
+		name           string
+		syncRequired   bool
+		enabled        bool
+		useInternal    bool
+		wantMarkerDiff bool
+	}{
+		{name: "synchronization required", syncRequired: true, enabled: true, useInternal: true, wantMarkerDiff: true},
+		{name: "CA matches", enabled: true, useInternal: true},
+		{name: "endpoint disabled", syncRequired: true, useInternal: true},
+		{name: "manual CA mode", syncRequired: true, enabled: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"local_auth_endpoint": {
+						Type:     schema.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem:     &schema.Resource{Schema: clusterV2LocalAuthEndpointFields()},
+					},
+					"local_auth_endpoint_ca_sync_required": {
+						Type:     schema.TypeBool,
+						Computed: true,
+					},
+				},
+				CustomizeDiff: customizeClusterV2LocalAuthEndpointCASync,
+			}
+			state := &terraform.InstanceState{
+				ID: "test",
+				Attributes: map[string]string{
+					"local_auth_endpoint.#":                       "1",
+					"local_auth_endpoint.0.enabled":               strconv.FormatBool(tc.enabled),
+					"local_auth_endpoint.0.fqdn":                  "ace.example.com",
+					"local_auth_endpoint.0.ca_certs":              "",
+					"local_auth_endpoint.0.use_internal_ca_certs": strconv.FormatBool(tc.useInternal),
+					"local_auth_endpoint_ca_sync_required":        strconv.FormatBool(tc.syncRequired),
+				},
+			}
+			config := terraform.NewResourceConfigRaw(map[string]interface{}{
+				"local_auth_endpoint": []interface{}{map[string]interface{}{
+					"enabled":               tc.enabled,
+					"fqdn":                  "ace.example.com",
+					"use_internal_ca_certs": tc.useInternal,
+				}},
+			})
+
+			diff, err := r.Diff(state, config, nil)
+			assert.NoError(t, err)
+			if tc.wantMarkerDiff {
+				if assert.NotNil(t, diff) {
+					marker := diff.Attributes["local_auth_endpoint_ca_sync_required"]
+					if assert.NotNil(t, marker) {
+						assert.True(t, marker.NewComputed)
+					}
+				}
+			} else if diff != nil {
+				assert.Nil(t, diff.Attributes["local_auth_endpoint_ca_sync_required"])
+			}
+		})
+	}
+}
+
+func TestUpdateClusterV2LocalAuthEndpointCACerts(t *testing.T) {
+	latest := &ClusterV2{}
+	latest.Spec.KubernetesVersion = "v1.31.0"
+	fetches := 0
+	updates := 0
+
+	got, err := updateClusterV2LocalAuthEndpointCACerts(func() (*ClusterV2, error) {
+		fetches++
+		return latest, nil
+	}, func(cluster *ClusterV2) (*ClusterV2, error) {
+		updates++
+		if updates == 1 {
+			latest = &ClusterV2{}
+			latest.Spec.KubernetesVersion = "v1.32.0"
+			return nil, &clientbase.APIError{StatusCode: http.StatusConflict}
+		}
+		return cluster, nil
+	}, "internal-ca", 0, time.Second)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, fetches)
+	assert.Equal(t, 2, updates)
+	assert.Equal(t, "v1.32.0", got.Spec.KubernetesVersion)
+	assert.Equal(t, "internal-ca", got.Spec.LocalClusterAuthEndpoint.CACerts)
+}

--- a/rancher2/schema_cluster_v2.go
+++ b/rancher2/schema_cluster_v2.go
@@ -221,6 +221,11 @@ func clusterV2Fields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"local_auth_endpoint_ca_sync_required": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Whether the authorized cluster endpoint requires internal CA synchronization",
+		},
 		"resource_version": {
 			Type:     schema.TypeString,
 			Computed: true,

--- a/rancher2/schema_cluster_v2_rke_config.go
+++ b/rancher2/schema_cluster_v2_rke_config.go
@@ -29,7 +29,7 @@ func clusterV2RKEConfigFieldsV0() map[string]*schema.Schema {
 			Deprecated:  "Use rancher2_cluster_v2.local_auth_endpoint instead",
 			Description: "Cluster V2 local auth endpoint",
 			Elem: &schema.Resource{
-				Schema: clusterV2LocalAuthEndpointFields(),
+				Schema: clusterV2RKEConfigLocalAuthEndpointFields(),
 			},
 		},
 		"upgrade_strategy": {
@@ -229,7 +229,7 @@ func clusterV2RKEConfigFields() map[string]*schema.Schema {
 			Deprecated:  "Use rancher2_cluster_v2.local_auth_endpoint instead",
 			Description: "Cluster V2 local auth endpoint",
 			Elem: &schema.Resource{
-				Schema: clusterV2LocalAuthEndpointFields(),
+				Schema: clusterV2RKEConfigLocalAuthEndpointFields(),
 			},
 		},
 		"upgrade_strategy": {

--- a/rancher2/schema_cluster_v2_rke_config_local_auth_endpoint.go
+++ b/rancher2/schema_cluster_v2_rke_config_local_auth_endpoint.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-//Types
+// Types
 
 func clusterV2LocalAuthEndpointFields() map[string]*schema.Schema {
 	s := map[string]*schema.Schema{
@@ -21,7 +21,31 @@ func clusterV2LocalAuthEndpointFields() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		// use_internal_ca_certs makes the provider populate ca_certs from the
+		// cluster's own internally generated CA certificate. Only use this when:
+		// - The cluster sits behind a Layer 4 (TCP passthrough) load balancer.
+		// - The endpoint FQDN is included in the API server certificate's SANs
+		//   (configured via tls-san in machine_global_config).
+		// Requires fqdn to be set, and is mutually exclusive with ca_certs.
+		// use_internal_ca_certs is never derived from server state: its value in
+		// Terraform state always matches what was last configured, never a
+		// server-side comparison (see rancher2/resource_rancher2_cluster_v2.go).
+		"use_internal_ca_certs": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
 	}
 
+	return s
+}
+
+// clusterV2RKEConfigLocalAuthEndpointFields returns the same fields as
+// clusterV2LocalAuthEndpointFields, but without the use_internal_ca_certs field.
+// This is used for the deprecated RKEConfig.local_auth_endpoint,
+// which does not support that field.
+func clusterV2RKEConfigLocalAuthEndpointFields() map[string]*schema.Schema {
+	s := clusterV2LocalAuthEndpointFields()
+	delete(s, "use_internal_ca_certs")
 	return s
 }

--- a/rancher2/structure_cluster_v2_test.go
+++ b/rancher2/structure_cluster_v2_test.go
@@ -303,6 +303,18 @@ func TestFlattenClusterV2(t *testing.T) {
 				rkeConfig := actualOutput[k].([]interface{})[0].(map[string]interface{})
 				delete(rkeConfig, "local_auth_endpoint")
 			}
+			if k == "local_auth_endpoint" {
+				// use_internal_ca_certs has no server-side representation and is
+				// intentionally not set by flattenClusterV2LocalAuthEndpoint (see
+				// resourceRancher2ClusterV2Read); remove the schema-default value
+				// before comparing against the expected fixture.
+				lae := actualOutput[k].([]interface{})
+				if len(lae) > 0 {
+					if m, ok := lae[0].(map[string]interface{}); ok {
+						delete(m, "use_internal_ca_certs")
+					}
+				}
+			}
 		}
 		assert.Equal(t, tc.ExpectedOutput, actualOutput)
 	}

--- a/rancher2/util_certs.go
+++ b/rancher2/util_certs.go
@@ -1,0 +1,17 @@
+package rancher2
+
+import "encoding/base64"
+
+// decodeCACertIfBase64 decodes cert if it is base64 encoded, returning the
+// original string unchanged when it is not (or is empty). Rancher's v3
+// management API returns the cluster CA certificate base64-encoded; the
+// provisioning v1 API's local_auth_endpoint.ca_certs expects raw PEM.
+func decodeCACertIfBase64(cert string) string {
+	if cert == "" {
+		return cert
+	}
+	if b, err := base64.StdEncoding.DecodeString(cert); err == nil {
+		return string(b)
+	}
+	return cert
+}

--- a/rancher2/util_certs_test.go
+++ b/rancher2/util_certs_test.go
@@ -1,0 +1,21 @@
+package rancher2
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestDecodeCACertIfBase64(t *testing.T) {
+	pem := "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"
+	encoded := base64.StdEncoding.EncodeToString([]byte(pem))
+
+	if got := decodeCACertIfBase64(encoded); got != pem {
+		t.Fatalf("expected decoded cert, got %q", got)
+	}
+	if got := decodeCACertIfBase64(pem); got != pem {
+		t.Fatalf("expected unchanged cert, got %q", got)
+	}
+	if got := decodeCACertIfBase64(""); got != "" {
+		t.Fatalf("expected empty string to remain empty, got %q", got)
+	}
+}


### PR DESCRIPTION
<!--- If there is no user issue related to this then you should remove the next line --->

This PR implements this feature:
 - https://github.com/rancher/terraform-provider-rancher2/issues/1299

The following regressions caused by a [previous implementation](https://github.com/rancher/terraform-provider-rancher2/pull/1626) that was reverted should not happen anymore
- https://github.com/rancher/terraform-provider-rancher2/issues/2435 
- https://github.com/rancher/terraform-provider-rancher2/issues/2437 
- https://github.com/rancher/terraform-provider-rancher2/issues/2436 
- https://github.com/rancher/terraform-provider-rancher2/issues/2432 
- https://github.com/rancher/terraform-provider-rancher2/issues/2438 
- https://github.com/rancher/terraform-provider-rancher2/issues/2439 
- https://github.com/rancher/terraform-provider-rancher2/issues/2433 

<!--- Add labels (eg. release/v15) for each release branch to target --->
<!--- Please don't manually add "internal" labels, those are for automation only --->

## Description

<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->

This PR adds support for using the cluster's internally generated CA certificate for the authorized cluster endpoint instead of requiring users to manually configure `ca_certs`.

It replaces the customer-managed data source and conditional configuration with a single, stable Terraform configuration:

```hcl
resource "rancher2_cluster_v2" "cluster" {
  name               = "example"
  kubernetes_version = "v1.31.0+rke2r1"

  local_auth_endpoint {
    enabled               = true
    fqdn                  = "cluster.example.com"
    use_internal_ca_certs = true
  }
  rke_config {
    machine_global_config = <<EOF
tls-san:
  - "cluster.example.com"
EOF
  }
}
```

Users no longer need to configure `ca_certs` or retrieve the CA certificate through a separate data source.

### CA Availability

There is a technical limitation in how the internally generated CA certificate is exposed. The certificate is available in the management cluster's `status.CACert` field, but this field is only populated after Rancher establishes a connection to the downstream cluster—specifically, after the `cattle-cluster-agent` connects back to the Rancher server.

This introduces an unpredictable wait time for node-driver clusters.

For custom clusters, the CA certificate may remain unavailable indefinitely because a custom cluster can be created without registering any nodes.

To handle this limitation without introducing an indefinite wait, the configuration requires two Terraform applies:

1. The first apply creates the cluster and related resources.
2. After the cluster becomes active and `status.CACert` is populated, a subsequent apply detects and configures the CA certificate.

Both applies use the same Terraform configuration.

### First Apply

During `Create`, the provider:

1. Creates the RKE2 cluster.
2. Waits for the normal cluster creation conditions.
3. Retrieves the downstream cluster ID from `status.clusterName`.
4. Fetches the internally generated CA certificate from the management cluster's `status.CACert`.
5. Decodes the CA certificate when Rancher returns it as base64-encoded.
6. Writes a non-empty CA certificate to `spec.localClusterAuthEndpoint.caCerts`.

If the CA certificate is already available, the first apply configures the complete authorized endpoint.

If the CA certificate is not yet available, `Create` completes successfully without an error. This avoids indefinitely waiting for custom clusters where the CA may never become available.

### Subsequent Apply

Once Rancher receives a connection from `cattle-cluster-agent`, it populates `status.CACert`.

During the refresh phase of a subsequent plan or apply, the provider:

1. Fetches the current internal CA certificate.
2. Compares it with the CA certificate currently configured on the authorized endpoint.
3. Sets `local_auth_endpoint_ca_sync_required = true` in Terraform state when the certificates differ.
4. Does not modify Rancher during `Read`.

The resulting computed state change causes Terraform to schedule the cluster's `Update` operation, even though the customer has not changed the configuration:

```text
~ local_auth_endpoint_ca_sync_required = true -> (known after apply)
```

During `Update`, the provider:

1. Fetches `status.CACert` again.
2. Applies the current non-empty CA certificate to the authorized endpoint.
3. Preserves the existing endpoint CA certificate if `status.CACert` is still empty.
4. Refreshes Terraform state after the update.

### Resulting Workflow

```text
First apply
  -> Create cluster
  -> CA may be unavailable
  -> Complete successfully without CA

For custom clusters, register nodes

Wait for the cluster to become active

Second apply
  -> Refresh detects the CA
  -> Plan schedules Update
  -> Update configures the authorized endpoint
```

This results in an eventual two-apply workflow in some cases, but both applies use the same Terraform configuration and do not require users to manage or retrieve the CA certificate themselves.

### Limitations

* A single Terraform apply is not guaranteed to fully configure the authorized endpoint.
* At least one subsequent Terraform operation must run after the CA certificate becomes available.
* A custom cluster without registered nodes may never populate `status.CACert`.
* API and network errors remain fatal.
* The endpoint FQDN must be included in the API server certificate SANs, typically through `tls-san`.


## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->

Added unit tests for the new functions. 

Validated the feature by using the binary built from the PR locally, including both node-driver and custom clusters. 

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? -->
<!--- If so, change the following line with an explanation. --->
Not a breaking change.
